### PR TITLE
Query the oplog to find the ts we should tail from (instead of using "now")

### DIFF
--- a/internal/oplog/oplog_tail.go
+++ b/internal/oplog/oplog_tail.go
@@ -129,7 +129,7 @@ func (ot *OplogTail) tail() {
 
 func (ot *OplogTail) getOplogTailTimestamp(col *mgo.Collection) bson.MongoTimestamp {
 	oplog := &mdbstructs.Oplog{}
-	err := col.Find(nil).Limit(1).One(oplog)
+	err := col.Find(nil).Sort("$natural").Limit(1).One(oplog)
 	if err != nil {
 		return bson.MongoTimestamp(0)
 	}


### PR DESCRIPTION
When we do not have a known last timestamp in the oplog tailer we use the func .BsonTimestampNow() to find a place in the oplog. "now" isn't a very useful place to start tailing from, at least in this use case.

This PR moves to doing a .Find() query to find the "tail" timestamp of the oplog. When we do not have a known place to start tailing this will cause the code to start at the oldest/tail point in the oplog. This will guarantee we have all the data better than using "now".

If the .Find() query fails we fallback to bson.MongoTimestamp(0) which should equal the epoch (January 1970?), which will still work in the .Find() as a good fallback - the "ts" index will still do a $gt/$gte on this fine. 

@percona-csalguero: feel free to propose any style changes, thoughts, etc.