### PR TITLE
Add query comment to oplog tailer for troubleshooting/profiling/QAN

### DIFF
--- a/internal/oplog/oplog_tail.go
+++ b/internal/oplog/oplog_tail.go
@@ -127,7 +127,8 @@ func (ot *OplogTail) setRunning(state bool) {
 
 func (ot *OplogTail) tail() {
 	col := ot.session.DB(oplogDB).C(ot.oplogCollection)
-	iter := col.Find(ot.tailQuery()).LogReplay().Batch(mgoIterBatch).Prefetch(mgoIterPrefetch).Iter()
+	comment := "github.com/percona/mongodb-backup/internal/oplog.(*OplogTail).tail()"
+	iter := col.Find(ot.tailQuery()).LogReplay().Comment(comment).Batch(mgoIterBatch).Prefetch(mgoIterPrefetch).Iter()
 	for {
 		select {
 		case <-ot.stopChan:
@@ -156,7 +157,7 @@ func (ot *OplogTail) tail() {
 		if iter.Err() != nil {
 			iter.Close()
 		}
-		iter = col.Find(ot.tailQuery()).LogReplay().Batch(mgoIterBatch).Prefetch(mgoIterPrefetch).Iter()
+		iter = col.Find(ot.tailQuery()).LogReplay().Comment(comment).Batch(mgoIterBatch).Prefetch(mgoIterPrefetch).Iter()
 	}
 }
 


### PR DESCRIPTION
Add query comment to oplog tailer for troubleshooting:
```
rs:PRIMARY> db.system.profile.find({}, {command:1}).limit(1).pretty()
{
	"command" : {
		"find" : "oplog.rs",
		"filter" : {
			"op" : {
				"$ne" : "n"
			},
			"ts" : {
				"$gte" : Timestamp(1531909597, 0)
			}
		},
		"skip" : 0,
		"batchSize" : 100,
		"comment" : "github.com/percona/mongodb-backup/internal/oplog.(*OplogTail).tail()",
		"oplogReplay" : true,
		"$db" : "local"
	}
}
```