### PR TITLE
 Allow coordinator to bind to non-localhost

### DIFF
--- a/cli/pmb-coordinator/main.go
+++ b/cli/pmb-coordinator/main.go
@@ -54,7 +54,6 @@ type cliOptions struct {
 }
 
 const (
-	defaultBindIP          = "0.0.0.0"
 	defaultGrpcPort        = 10000
 	defaultAPIPort         = 10001
 	defaultShutdownTimeout = 5 // Seconds


### PR DESCRIPTION
I cannot make the coordinator listen on non-localhost.

1. Add flags to set bind IP of gRPC + API.
1. Default to 0.0.0.0 bind IP, because the coordinator is a remote service.