### PR TITLE
PBM-130: Add basic auth to API gRPC port

### DIFF
--- a/cli/pbm-coordinator/main.go
+++ b/cli/pbm-coordinator/main.go
@@ -46,6 +46,8 @@ type cliOptions struct {
 	GrpcPort             int    `yaml:"grpc_port"`
 	APIBindIP            string `yaml:"api_bindip"`
 	APIPort              int    `yaml:"api_port"`
+	APIUsername          string `yaml:"api_username"`
+	APIPassword          string `yaml:"api_password"`
 	ShutdownTimeout      int    `yaml:"shutdown_timeout"`
 	LogFile              string `yaml:"log_file"`
 	UseSysLog            bool   `yaml:"sys_log_url"`
@@ -123,7 +125,7 @@ func main() {
 	runAgentsGRPCServer(grpcServer, lis, opts.ShutdownTimeout, stopChan, wg)
 
 	apiGrpcServer := grpc.NewServer(grpcOpts...)
-	apiServer := api.NewApiServer(messagesServer)
+	apiServer := api.NewApiServer(messagesServer, opts.APIUsername, opts.APIPassword)
 	apipb.RegisterApiServer(apiGrpcServer, apiServer)
 
 	wg.Add(1)
@@ -188,6 +190,8 @@ func processCliParams() (*cliOptions, error) {
 	app.Flag("grpc-port", "Listening port for gRPC client connections").IntVar(&opts.GrpcPort)
 	app.Flag("api-bindip", "Bind IP for API client connections").StringVar(&opts.APIBindIP)
 	app.Flag("api-port", "Listening port for API client connections").IntVar(&opts.APIPort)
+	app.Flag("api-username", "Required username for API client connections").StringVar(&opts.APIUsername)
+	app.Flag("api-password", "Required password for API client connections").StringVar(&opts.APIPassword)
 	app.Flag("shutdown-timeout", "Server shutdown timeout").IntVar(&opts.ShutdownTimeout)
 	app.Flag("log-file", "Write logs to file").StringVar(&opts.LogFile)
 	app.Flag("use-syslog", "Also send the logs to the local syslog server").BoolVar(&opts.UseSysLog)
@@ -257,11 +261,23 @@ func mergeOptions(opts, yamlOpts *cliOptions) {
 	if opts.KeyFile != "" {
 		yamlOpts.KeyFile = opts.KeyFile
 	}
+	if opts.GrpcBindIP != "" {
+		yamlOpts.GrpcBindIP = opts.GrpcBindIP
+	}
 	if opts.GrpcPort != 0 {
 		yamlOpts.GrpcPort = opts.GrpcPort
 	}
+	if opts.APIBindIP != "" {
+		yamlOpts.APIBindIP = opts.APIBindIP
+	}
 	if opts.APIPort != 0 {
 		yamlOpts.APIPort = opts.APIPort
+	}
+	if opts.APIUsername != "" {
+		yamlOpts.APIUsername = opts.APIUsername
+	}
+	if opts.APIPassword != "" {
+		yamlOpts.APIPassword = opts.APIPassword
 	}
 	if opts.ShutdownTimeout != 0 {
 		yamlOpts.ShutdownTimeout = opts.ShutdownTimeout

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -68,6 +68,7 @@ var (
 type basicGrpcAuth struct {
 	username string
 	password string
+	tls      bool
 }
 
 // GetRequestMetadata is called by gRPC to construct request
@@ -83,7 +84,7 @@ func (a basicGrpcAuth) GetRequestMetadata(ctx context.Context, in ...string) (ma
 // RequireTransportSecurity sets the requirement for transport
 // security (SSL/TLS) when providing auth credentials
 func (a basicGrpcAuth) RequireTransportSecurity() bool {
-	return true
+	return a.tls
 }
 
 func main() {
@@ -113,6 +114,7 @@ func main() {
 		grpcOpts = append(grpcOpts, grpc.WithPerRPCCredentials(basicGrpcAuth{
 			username: opts.ServerUsername,
 			password: opts.ServerPassword,
+			tls:      opts.TLS,
 		}))
 	}
 

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -70,6 +70,8 @@ type basicGrpcAuth struct {
 	password string
 }
 
+// GetRequestMetadata is called by gRPC to construct request
+// metadata containing a basic auth token
 func (a basicGrpcAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
 	auth := a.username + ":" + a.password
 	enc := base64.StdEncoding.EncodeToString([]byte(auth))
@@ -78,9 +80,10 @@ func (a basicGrpcAuth) GetRequestMetadata(ctx context.Context, in ...string) (ma
 	}, nil
 }
 
+// RequireTransportSecurity sets the requirement for transport
+// security (SSL/TLS) when providing auth credentials
 func (a basicGrpcAuth) RequireTransportSecurity() bool {
-	return false
-	//	return true
+	return true
 }
 
 func main() {

--- a/grpc/api/api.go
+++ b/grpc/api/api.go
@@ -40,7 +40,8 @@ func init() {
 	logger.SetLevel(logrus.DebugLevel)
 }
 
-// parse auth header
+// parseBasicAuthHeader parses a basic authorization header into
+// a username and password string
 func parseBasicAuthHeader(auth string) (string, string, error) {
 	const prefix = "Basic "
 	if !strings.HasPrefix(auth, prefix) {
@@ -58,7 +59,8 @@ func parseBasicAuthHeader(auth string) (string, string, error) {
 	return cs[:s], cs[s+1:], nil
 }
 
-// authenticate checks if a context passes authentication
+// checkAuthenticated confirms if a request context passes authentication
+// requirements
 func (a *ApiServer) checkAuthenticated(ctx context.Context) error {
 	// return nil if auth is disabled
 	if a.username == "" || a.password == "" {

--- a/grpc/api/api.go
+++ b/grpc/api/api.go
@@ -80,8 +80,7 @@ func (a *ApiServer) checkAuthenticated(ctx context.Context) error {
 	}
 
 	// parse basic auth header
-	auth := md["authorization"][0]
-	username, password, err := parseBasicAuthHeader(auth)
+	username, password, err := parseBasicAuthHeader(md["authorization"][0])
 	if err != nil {
 		logger.Debugf("Cannot parse basic auth header: %v", err)
 		return errUnauthorized

--- a/grpc/api/api.go
+++ b/grpc/api/api.go
@@ -220,10 +220,9 @@ func (a *ApiServer) RunBackup(ctx context.Context, opts *pbapi.RunBackupParams) 
 }
 
 func (a *ApiServer) RunRestore(ctx context.Context, opts *pbapi.RunRestoreParams) (*pbapi.RunRestoreResponse, error) {
-	// TODO: return a proper protobuf error here?
 	err := a.checkAuthenticated(ctx)
 	if err != nil {
-		return nil, err
+		return &pbapi.RunRestoreResponse{Error: err.Error()}, err
 	}
 
 	err = a.messagesServer.RestoreBackupFromMetadataFile(opts.MetadataFile, opts.SkipUsersAndRoles)


### PR DESCRIPTION
**Incomplete PR, tests and functional testing needed! DO NOT MERGE!**

TODO:
- [X] Add functionality for username/password to pbm-coordinator
- [X] Add functionality for username/password to pbmctl
- [ ] Resolve no auth-error on 'list backups'
- [ ] Resolve no auth-error on 'list nodes'
- [ ] Unit tests
- [ ] Functional testing

# pbm-coordinator configuration:
```
$ ./pbm-coordinator --api-username=tim --api-password=123456 --debug
INFO[2018-12-16T20:30:58+01:00] Starting clients gRPC net listener at address: :10000 
INFO[2018-12-16T20:30:58+01:00] Starting clients API net listener at address: :10001 
INFO[2018-12-16T20:30:58+01:00] Starting agents gRPC server. Listening on [::]:10000 
INFO[2018-12-16T20:30:58+01:00] Starting API gRPC server. Listening on [::]:10001 
Starting grpc server on port [::]:10000
Starting grpc server on port [::]:10001
```

# pbmctl 'run backup' success:
```
$ ./pbmctl run backup --description=test --server-username=tim --server-password=123456
INFO[0000] Backup completed                             
```

# pbmctl 'run backup' with unauthorized error:
```
$ ./pbmctl run backup --description=test --server-username=tim --server-password=12345
FATA[0000] rpc error: code = Unknown desc = unauthorized
```