### PR TITLE
CLI --help/flags cleanup #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,4 +143,4 @@ docker-build: pbmctl pbm-agent pbm-coordinator
 	docker build -t $(REPO):pbmctl -f docker/pbmctl/Dockerfile .
 
 clean:
-	rm -rf pbm-agent pbmctl pbm-coordinator test-out vendor 2>/dev/null || true
+	rm -rf pbm-agent pbmctl pbm-coordinator test-out vendor *.upx *.000 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -143,4 +143,5 @@ docker-build: pbmctl pbm-agent pbm-coordinator
 	docker build -t $(REPO):pbmctl -f docker/pbmctl/Dockerfile .
 
 clean:
-	rm -rf pbm-agent pbmctl pbm-coordinator test-out vendor *.upx *.000 2>/dev/null || true
+	rm -rf vendor 2>/dev/null || true
+	rm -f pbm-agent pbmctl pbm-coordinator test-out *.upx *.000 2>/dev/null || true

--- a/cli/pbm-agent/main.go
+++ b/cli/pbm-agent/main.go
@@ -202,7 +202,7 @@ func processCliArgs() (*cliOptions, error) {
 	app.Flag("quiet", "Quiet mode. Log only errors").Short('q').BoolVar(&opts.Quiet)
 	//
 	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddress).Short('s').StringVar(&opts.ServerAddress)
-	app.Flag("server-compressor", "Backup coordintor gRPC compression algorithm (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
+	app.Flag("server-compressor", "Backup coordintor gRPC compression (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Use TLS for server connection").BoolVar(&opts.TLS)
 	app.Flag("tls-cert-file", "TLS certificate file").ExistingFileVar(&opts.TLSCertFile)
 	app.Flag("tls-key-file", "TLS key file").ExistingFileVar(&opts.TLSKeyFile)

--- a/cli/pbm-agent/main.go
+++ b/cli/pbm-agent/main.go
@@ -192,16 +192,16 @@ func processCliArgs() (*cliOptions, error) {
 	opts := &cliOptions{
 		app: app,
 	}
-	app.Flag("config-file", "Backup agent config file").Default("config.yml").StringVar(&opts.configFile)
+	app.Flag("config-file", "Backup agent config file").Default("config.yml").Short('c').StringVar(&opts.configFile)
 	app.Flag("generate-sample-config", "Generate sample config.yml file with the defaults").BoolVar(&opts.generateSampleConfig)
-	app.Flag("backup-dir", "Directory (or AWS S3 bucket) to store backups").Default("/tmp").StringVar(&opts.BackupDir)
+	app.Flag("backup-dir", "Directory (or AWS S3 bucket) to store backups").Default("/tmp").Short('d').StringVar(&opts.BackupDir)
 	app.Flag("pid-file", "Backup agent pid file").StringVar(&opts.PIDFile)
-	app.Flag("log-file", "Backup agent log file").StringVar(&opts.LogFile)
+	app.Flag("log-file", "Backup agent log file").Short('l').StringVar(&opts.LogFile)
+	app.Flag("debug", "Enable debug log level").Short('v').BoolVar(&opts.Debug)
 	app.Flag("use-syslog", "Use syslog instead of Stderr or file").BoolVar(&opts.UseSysLog)
-	app.Flag("debug", "Enable debug log level").BoolVar(&opts.Debug)
-	app.Flag("quiet", "Quiet mode. Log only errors").BoolVar(&opts.Quiet)
+	app.Flag("quiet", "Quiet mode. Log only errors").Short('q').BoolVar(&opts.Quiet)
 	//
-	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddress).StringVar(&opts.ServerAddress)
+	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddress).Short('s').StringVar(&opts.ServerAddress)
 	app.Flag("server-compressor", "Backup coordintor gRPC compression algorithm (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Use TLS for server connection").BoolVar(&opts.TLS)
 	app.Flag("tls-cert-file", "TLS certificate file").ExistingFileVar(&opts.TLSCertFile)
@@ -209,10 +209,10 @@ func processCliArgs() (*cliOptions, error) {
 	app.Flag("tls-ca-file", "TLS CA file").ExistingFileVar(&opts.TLSCAFile)
 	//
 	app.Flag("mongodb-dsn", "MongoDB connection string").StringVar(&opts.DSN)
-	app.Flag("mongodb-host", "MongoDB hostname").Default(defaultMongoDBHost).StringVar(&opts.MongodbConnOptions.Host)
-	app.Flag("mongodb-port", "MongoDB port").Default(defaultMongoDBPort).StringVar(&opts.MongodbConnOptions.Port)
-	app.Flag("mongodb-username", "MongoDB username").StringVar(&opts.MongodbConnOptions.User)
-	app.Flag("mongodb-password", "MongoDB password").StringVar(&opts.MongodbConnOptions.Password)
+	app.Flag("mongodb-host", "MongoDB hostname").Default(defaultMongoDBHost).Short('H').StringVar(&opts.MongodbConnOptions.Host)
+	app.Flag("mongodb-port", "MongoDB port").Default(defaultMongoDBPort).Short('P').StringVar(&opts.MongodbConnOptions.Port)
+	app.Flag("mongodb-username", "MongoDB username").Short('u').StringVar(&opts.MongodbConnOptions.User)
+	app.Flag("mongodb-password", "MongoDB password").Short('p').StringVar(&opts.MongodbConnOptions.Password)
 	app.Flag("mongodb-authdb", "MongoDB authentication database").Default("admin").StringVar(&opts.MongodbConnOptions.AuthDB)
 	app.Flag("mongodb-replicaset", "MongoDB Replicaset name").StringVar(&opts.MongodbConnOptions.ReplicasetName)
 	app.Flag("mongodb-reconnect-delay", "MongoDB reconnection delay in seconds").Default("30").IntVar(&opts.MongodbConnOptions.ReconnectDelay)

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -339,7 +339,7 @@ func processCliArgs(args []string) (string, *cliOptions, error) {
 	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddr).Short('s').StringVar(&opts.ServerAddr)
 	app.Flag("server-compressor", "Backup coordinator gRPC compression algorithm (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Connection uses TLS if true, else plain TCP").Default("false").BoolVar(&opts.TLS)
-	app.Flag("tls-ca-file", "The file containning the CA root cert file").ExistingFileVar(&opts.TLSCAFile)
+	app.Flag("tls-ca-file", "The file containing the CA root cert file").ExistingFileVar(&opts.TLSCAFile)
 
 	yamlOpts := &cliOptions{
 		ServerAddr: defaultServerAddr,

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -316,7 +316,7 @@ func processCliArgs(args []string) (string, *cliOptions, error) {
 	restoreCmd := runCmd.Command("restore", "Restore a backup given a metadata file name")
 
 	opts := &cliOptions{
-		configFile: app.Flag("config", "Config file name").Default(defaultConfigFile).String(),
+		configFile: app.Flag("config", "Config file name").Default(defaultConfigFile).Short('c').String(),
 
 		list:             listCmd,
 		listBackups:      listBackupsCmd,
@@ -336,7 +336,7 @@ func processCliArgs(args []string) (string, *cliOptions, error) {
 		restoreSkipUsersAndRoles: restoreCmd.Flag("skip-users-and-roles", "Do not restore users and roles").Default("true").Bool(),
 	}
 
-	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddr).StringVar(&opts.ServerAddr)
+	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddr).Short('s').StringVar(&opts.ServerAddr)
 	app.Flag("server-compressor", "Backup coordinator gRPC compression algorithm (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Connection uses TLS if true, else plain TCP").Default("false").BoolVar(&opts.TLS)
 	app.Flag("tls-ca-file", "The file containning the CA root cert file").ExistingFileVar(&opts.TLSCAFile)

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -337,7 +337,7 @@ func processCliArgs(args []string) (string, *cliOptions, error) {
 	}
 
 	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddr).Short('s').StringVar(&opts.ServerAddr)
-	app.Flag("server-compressor", "Backup coordinator gRPC compression algorithm (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
+	app.Flag("server-compressor", "Backup coordinator gRPC compression (snappy, gzip or none)").Default(snappy.Name).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Connection uses TLS if true, else plain TCP").Default("false").BoolVar(&opts.TLS)
 	app.Flag("tls-ca-file", "The file containing the CA root cert file").ExistingFileVar(&opts.TLSCAFile)
 


### PR DESCRIPTION
1. Add kingpin .Short() flags to common/required flags. Try to match mongodb-tools' short flags so the tool feels natural.
1. Re-order/group coordinator kingpin flags to clean --help output to match changes in agent+pbmctl in #151.
1. Add 'tls_' suffix to TLS-related options to match changes in agent+pbmctl in #151.
1. Update Makefile to cleanup UPX temp files (*.000 and *.upx).
1. Fixed typo in help field.

## pbm-agent --help
```
$ ./pbm-agent --help
usage: pbm-agent [<flags>]

Percona Backup for MongoDB agent

Flags:
      --help                     Show context-sensitive help (also try --help-long and --help-man).
      --version                  Show application version.
  -c, --config-file="config.yml"  
                                 Backup agent config file
      --generate-sample-config   Generate sample config.yml file with the defaults
  -d, --backup-dir="/tmp"        Directory (or AWS S3 bucket) to store backups
      --pid-file=PID-FILE        Backup agent pid file
  -l, --log-file=LOG-FILE        Backup agent log file
  -v, --debug                    Enable debug log level
      --use-syslog               Use syslog instead of Stderr or file
  -q, --quiet                    Quiet mode. Log only errors
  -s, --server-address="127.0.0.1:10000"  
                                 Backup coordinator address (host:port)
      --server-compressor=snappy  
                                 Backup coordintor gRPC compression (snappy, gzip or none)
      --tls                      Use TLS for server connection
      --tls-cert-file=TLS-CERT-FILE  
                                 TLS certificate file
      --tls-key-file=TLS-KEY-FILE  
                                 TLS key file
      --tls-ca-file=TLS-CA-FILE  TLS CA file
      --mongodb-dsn=MONGODB-DSN  MongoDB connection string
  -H, --mongodb-host="127.0.0.1"  
                                 MongoDB hostname
  -P, --mongodb-port="27017"     MongoDB port
  -u, --mongodb-username=MONGODB-USERNAME  
                                 MongoDB username
  -p, --mongodb-password=MONGODB-PASSWORD  
                                 MongoDB password
      --mongodb-authdb="admin"   MongoDB authentication database
      --mongodb-replicaset=MONGODB-REPLICASET  
                                 MongoDB Replicaset name
      --mongodb-reconnect-delay=30  
                                 MongoDB reconnection delay in seconds
      --mongodb-reconnect-count=MONGODB-RECONNECT-COUNT  
                                 MongoDB max reconnection attempts (0: forever)
```

## pbm-coordinator --help
```
$ ./pbm-coordinator --help
usage: pbm-coordinator [<flags>]

Percona Backup for MongoDB coordinator

Flags:
      --help                     Show context-sensitive help (also try --help-long and --help-man).
      --version                  Show application version.
  -c, --config-file="config.yml"  
                                 Config file
  -d, --work-dir=WORK-DIR        Working directory for backup metadata
  -l, --log-file=LOG-FILE        Write logs to file
  -v, --debug                    Enable debug log level
      --use-syslog               Also send the logs to the local syslog server
      --grpc-bindip=GRPC-BINDIP  Bind IP for gRPC client connections
      --grpc-port=GRPC-PORT      Listening port for gRPC client connections
      --api-bindip=API-BINDIP    Bind IP for API client connections
      --api-port=API-PORT        Listening port for API client connections
      --enable-clients-logging   Enable showing logs comming from agents on the server side
      --shutdown-timeout=SHUTDOWN-TIMEOUT  
                                 Server shutdown timeout
      --tls                      Enable TLS
      --tls-cert-file=TLS-CERT-FILE  
                                 Cert file for gRPC client connections
      --tls-key-file=TLS-KEY-FILE  
                                 Key file for gRPC client connections
```

## pbmctl --help
```
$ ./pbmctl --help
usage: pbmctl [<flags>] <command> [<args> ...]

Percona Backup for MongoDB CLI

Flags:
      --help                     Show context-sensitive help (also try --help-long and --help-man).
      --version                  Show application version.
  -c, --config="~/.pbmctl.yml"   Config file name
  -s, --server-address="127.0.0.1:10001"  
                                 Backup coordinator address (host:port)
      --server-compressor=snappy  
                                 Backup coordinator gRPC compression (snappy, gzip or none)
      --tls                      Connection uses TLS if true, else plain TCP
      --tls-ca-file=TLS-CA-FILE  The file containing the CA root cert file

Commands:
  help [<command>...]
    Show help.

  run backup --description=DESCRIPTION [<flags>]
    Start a backup

  run restore [<flags>] <metadata-file>
    Restore a backup given a metadata file name

  list backups
    List backups

  list nodes [<flags>]
    List objects (connected nodes, backups, etc)
```