### PR TITLE
PBM-157: Refresh client state before backup (and every N x seconds) to fix stale agent states

### DIFF
--- a/cli/pbm-agent/run-agents.sh
+++ b/cli/pbm-agent/run-agents.sh
@@ -52,11 +52,11 @@ run_agents() {
         echo "    --backup-dir=${backupdir} \\"
         echo "    --pid-file=${pidfile} &> ${logfile} &"
 
-        ./pbm-agent --mongodb-user=${TEST_MONGODB_USERNAME} \
+        ./pbm-agent --mongodb-username=${TEST_MONGODB_USERNAME} \
             --mongodb-password=${TEST_MONGODB_PASSWORD} \
             --mongodb-host=${TEST_MONGODB_HOST} \
             --mongodb-port=${port} \
-            --replicaset=${replicaset} \
+            --mongodb-replicaset=${replicaset} \
             --backup-dir=${backupdir} \
             --pid-file=${pidfile} &> ${logfile} &
         pid=$!

--- a/grpc/server/clients.go
+++ b/grpc/server/clients.go
@@ -283,6 +283,8 @@ func (c *Client) ping() error {
 	c.ReplicasetUUID = pongMsg.GetReplicaSetUuid()
 	c.ReplicasetVersion = pongMsg.GetReplicaSetVersion()
 	c.isTailing = pongMsg.GetIsTailing()
+	c.isPrimary = pongMsg.GetIsPrimary()
+	c.isSecondary = pongMsg.GetIsSecondary()
 	c.lastTailedTimestamp = pongMsg.GetLastTailedTimestamp()
 	c.statusLock.Unlock()
 

--- a/grpc/server/clients.go
+++ b/grpc/server/clients.go
@@ -279,6 +279,7 @@ func (c *Client) ping() error {
 	}
 	pongMsg := msg.GetPongMsg()
 	c.statusLock.Lock()
+	c.LastSeen = time.Now()
 	c.NodeType = pongMsg.GetNodeType()
 	c.ReplicasetUUID = pongMsg.GetReplicaSetUuid()
 	c.ReplicasetVersion = pongMsg.GetReplicaSetVersion()

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -52,18 +52,18 @@ type restoreSource struct {
 	Port   string
 }
 
-func NewMessagesServer(workDir string, logger *logrus.Logger) *MessagesServer {
-	messagesServer := newMessagesServer(workDir, logger)
+func NewMessagesServer(workDir string, clientsRefreshSecs int, logger *logrus.Logger) *MessagesServer {
+	messagesServer := newMessagesServer(workDir, clientsRefreshSecs, logger)
 	return messagesServer
 }
 
-func NewMessagesServerWithClientLogging(workDir string, logger *logrus.Logger) *MessagesServer {
-	messagesServer := newMessagesServer(workDir, logger)
+func NewMessagesServerWithClientLogging(workDir string, clientsRefreshSecs int, logger *logrus.Logger) *MessagesServer {
+	messagesServer := newMessagesServer(workDir, clientsRefreshSecs, logger)
 	messagesServer.clientLoggingEnabled = true
 	return messagesServer
 }
 
-func newMessagesServer(workDir string, logger *logrus.Logger) *MessagesServer {
+func newMessagesServer(workDir string, clientsRefreshSecs int, logger *logrus.Logger) *MessagesServer {
 	if logger == nil {
 		logger = logrus.New()
 		logger.SetLevel(logrus.StandardLogger().Level)
@@ -81,7 +81,7 @@ func newMessagesServer(workDir string, logger *logrus.Logger) *MessagesServer {
 		lock:                   &sync.Mutex{},
 		clients:                make(map[string]*Client),
 		clientDisconnetedChan:  make(chan string),
-		clientsRefreshInterval: time.Minute,
+		clientsRefreshInterval: time.Duration(clientsRefreshSecs) * time.Second,
 		stopChan:               make(chan struct{}),
 		clientsLogChan:         make(chan *pb.LogEntry, logBufferSize),
 		dbBackupFinishChan:     bfc,

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -410,6 +410,10 @@ func (s *MessagesServer) StartBackup(opts *pb.StartBackup) error {
 
 	s.lastBackupMetadata = NewBackupMetadata(opts)
 
+	if err := s.RefreshClients(); err != nil {
+		return errors.Wrapf(err, "cannot refresh clients state for backup")
+	}
+
 	clients, err := s.BackupSourceByReplicaset()
 	if err != nil {
 		return errors.Wrapf(err, "Cannot start backup. Cannot find backup source for replicas")

--- a/internal/testutils/grpc/daemon.go
+++ b/internal/testutils/grpc/daemon.go
@@ -75,7 +75,7 @@ func NewGrpcDaemon(ctx context.Context, workDir string, t *testing.T, logger *lo
 	d.ctx, d.cancelFunc = context.WithCancel(ctx)
 	// This is the sever/agents gRPC server
 	d.grpcServer4Clients = grpc.NewServer(opts...)
-	d.MessagesServer = server.NewMessagesServer(workDir, logger)
+	d.MessagesServer = server.NewMessagesServer(workDir, 60, logger)
 	pb.RegisterMessagesServer(d.grpcServer4Clients, d.MessagesServer)
 
 	d.wg.Add(1)


### PR DESCRIPTION
Resolves error:
```
Cannot call DBBackupFinished RPC method: rpc error: code = Unknown desc = DBBackupFinished: cannot find a primary in the clients list for replicaset rs0
```

BUT oplogs still are not uploaded.