### PR TITLE
Remove 'snappy' from ServerCompressors, add 'none' type 

### DIFF
--- a/cli/pbm-agent/main.go
+++ b/cli/pbm-agent/main.go
@@ -68,6 +68,7 @@ var (
 	program         = filepath.Base(os.Args[0])
 	grpcCompressors = []string{
 		gzip.Name,
+		"none",
 	}
 )
 
@@ -215,7 +216,7 @@ func processCliArgs(args []string) (*cliOptions, error) {
 	app.Flag("use-syslog", "Use syslog instead of Stderr or file").BoolVar(&opts.UseSysLog)
 	//
 	app.Flag("server-address", "Backup coordinator address (host:port)").Short('s').StringVar(&opts.ServerAddress)
-	app.Flag("server-compressor", "Backup coordintor gRPC compression (snappy, gzip or none)").Default().EnumVar(&opts.ServerCompressor, grpcCompressors...)
+	app.Flag("server-compressor", "Backup coordintor gRPC compression (gzip or none)").Default().EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Use TLS for server connection").BoolVar(&opts.TLS)
 	app.Flag("tls-cert-file", "TLS certificate file").ExistingFileVar(&opts.TLSCertFile)
 	app.Flag("tls-key-file", "TLS key file").ExistingFileVar(&opts.TLSKeyFile)

--- a/cli/pbm-coordinator/main.go
+++ b/cli/pbm-coordinator/main.go
@@ -30,6 +30,7 @@ var (
 	commit          = "none"
 	grpcCompressors = []string{
 		gzip.Name,
+		"none",
 	}
 )
 
@@ -200,7 +201,7 @@ func processCliParams(args []string) (*cliOptions, error) {
 	//
 	app.Flag("grpc-bindip", "Bind IP for gRPC client connections").StringVar(&opts.GrpcBindIP)
 	app.Flag("grpc-port", "Listening port for gRPC client connections").IntVar(&opts.GrpcPort)
-	app.Flag("server-compressor", "Backup coordintor gRPC compression (snappy, gzip or none)").Default().EnumVar(&opts.ServerCompressor, grpcCompressors...)
+	app.Flag("server-compressor", "Backup coordintor gRPC compression (gzip or none)").Default().EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("api-bindip", "Bind IP for API client connections").StringVar(&opts.APIBindIP)
 	app.Flag("api-port", "Listening port for API client connections").IntVar(&opts.APIPort)
 	app.Flag("clients-refresh-secs", "Frequency in seconds to refresh state of clients").IntVar(&opts.ClientsRefreshSecs)

--- a/cli/pbmctl/main.go
+++ b/cli/pbmctl/main.go
@@ -33,6 +33,7 @@ var (
 
 	grpcCompressors = []string{
 		gzip.Name,
+		"none",
 	}
 
 	backuptypes = []string{
@@ -372,7 +373,7 @@ func processCliArgs(args []string) (string, *cliOptions, error) {
 	restoreCmd.Flag("storage", "Storage Name").Required().StringVar(&opts.storageName)
 
 	app.Flag("server-address", "Backup coordinator address (host:port)").Default(defaultServerAddress).Short('s').StringVar(&opts.ServerAddress)
-	app.Flag("server-compressor", "Backup coordinator gRPC compression (snappy, gzip or none)").Default(defaultServerCompressor).EnumVar(&opts.ServerCompressor, grpcCompressors...)
+	app.Flag("server-compressor", "Backup coordinator gRPC compression (gzip or none)").Default(defaultServerCompressor).EnumVar(&opts.ServerCompressor, grpcCompressors...)
 	app.Flag("tls", "Connection uses TLS if true, else plain TCP").Default(fmt.Sprintf("%v", defaultTlsEnabled)).BoolVar(&opts.TLS)
 	app.Flag("tls-ca-file", "The file containing the CA root cert file").StringVar(&opts.TLSCAFile)
 	app.Terminate(nil) // Don't call os.Exit() on errors


### PR DESCRIPTION
1. Remove 'snappy' from ServerCompressor 'help' message.
1. Add 'none' to grpcCompressors slice so that compression can be disabled.