### PR TITLE
Fix reconnect logic in pbm-agent

### DIFF
--- a/cli/pbm-agent/main.go
+++ b/cli/pbm-agent/main.go
@@ -229,7 +229,7 @@ func processCliArgs(args []string) (*cliOptions, error) {
 	app.Flag("mongodb-password", "MongoDB password").Short('p').StringVar(&opts.MongodbConnOptions.Password)
 	app.Flag("mongodb-authdb", "MongoDB authentication database").StringVar(&opts.MongodbConnOptions.AuthDB)
 	app.Flag("mongodb-replicaset", "MongoDB Replicaset name").StringVar(&opts.MongodbConnOptions.ReplicasetName)
-	app.Flag("mongodb-reconnect-delay", "MongoDB reconnection delay in seconds").IntVar(&opts.MongodbConnOptions.ReconnectDelay)
+	app.Flag("mongodb-reconnect-delay", "MongoDB reconnection delay in seconds").Default("10").IntVar(&opts.MongodbConnOptions.ReconnectDelay)
 	app.Flag("mongodb-reconnect-count", "MongoDB max reconnection attempts (0: forever)").IntVar(&opts.MongodbConnOptions.ReconnectCount)
 
 	app.PreAction(func(c *kingpin.ParseContext) error {


### PR DESCRIPTION
Fix broken reconnect logic in pbm-agent. Currently it reconnects in a loop with no delay:

```
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
ERROR[2019-02-09T16:09:35+01:00] Cannot connect to MongoDB at 127.0.0.1:27017: no reachable servers 
```