### PR TITLE
PBM-281 Fix agent's connection to a secondary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-cluster: env
 	--force-recreate \
 	--always-recreate-deps \
 	--renew-anon-volumes \
-	init
+	init 
 	docker/test/init-cluster-wait.sh
 
 test-cluster-clean: env
@@ -169,7 +169,7 @@ release: vendor
 	docker rmi -f $(NAME)-release
 
 docker-build: pbmctl pbm-agent pbm-coordinator
-	docker build -t $(REPO):common -f docker/Dockerfile.common .
+	docker build -t $(REPO):latest -f docker/Dockerfile.common .
 
 clean:
 	rm -rf vendor 2>/dev/null || true

--- a/docker/test/entrypoint-mongod.sh
+++ b/docker/test/entrypoint-mongod.sh
@@ -6,7 +6,7 @@ cp /rootCA.crt /tmp/mongod-rootCA.crt
 chmod 400 /tmp/mongod.key /tmp/mongod.pem /tmp/mongod-rootCA.pem
 
 /usr/bin/mongod \
-	--bind_ip=127.0.0.1 \
+	--bind_ip=0.0.0.0 \
 	--dbpath=/data/db \
 	--keyFile=/tmp/mongod.key \
 	--oplogSize=50 \


### PR DESCRIPTION
Fixed: pbm-agent will connect to a secondary from a docker container.
New features:
--dump-config: option to dump the cli options and storage to help debugging
--generate-sample-storage: option to generate a sample storage config option to make it easier to define new storage config