### PR TITLE
Use vendor to build binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ versionpath?=github.com/percona/percona-backup-mongodb/version
 LDFLAGS= -X $(versionpath).version=$(VERSION) -X $(versionpath).gitCommit=$(GITCOMMIT) -X $(versionpath).gitBranch=$(GITBRANCH) -X $(versionpath).buildTime=$(BUILDTIME) -X $(versionpath).version=$(VERSION)
 
 build-pbm:
-	GOOS=$(GOOS) go build -ldflags="$(LDFLAGS)" -o ./bin/pbm ./cmd/pbm
+	GOOS=$(GOOS) go build -ldflags="$(LDFLAGS)" -mod=vendor -o ./bin/pbm ./cmd/pbm
 build-agent:
-	GOOS=$(GOOS) go build -ldflags="$(LDFLAGS)" -o ./bin/pbm-agent ./cmd/pbm-agent
+	GOOS=$(GOOS) go build -ldflags="$(LDFLAGS)" -mod=vendor -o ./bin/pbm-agent ./cmd/pbm-agent
 build: build-pbm build-agent
 
 install-pbm:


### PR DESCRIPTION
The module github.com/mongodb/mongo-tools-common@v0.0.1-0.20190823135426-6379cde3ec10 seems to not exist anymore:

``` bash
[d@wks percona-backup-mongodb]$ go mod tidy
go: github.com/mongodb/mongo-tools-common@v0.0.1-0.20190823135426-6379cde3ec10: invalid version: unknown revision 6379cde3ec10
```
Recreating go.mod from scratch works, but I am not 100% confident that the new dependencies do not affect the code functionality (more tests would be needed).

Building the binaries using the dependencies' vendored version is an alternative solution that fixed the potential missing versions.
