### PR TITLE
Show config after it was set from a file

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -94,6 +94,12 @@ func main() {
 				}
 				fmt.Printf("[%s=%s]\n", k, v)
 			}
+		case len(*configShowKey) > 0:
+			k, err := pbmClient.GetConfigVar(*configShowKey)
+			if err != nil {
+				log.Fatalln("Error: unable to get config key:", err)
+			}
+			fmt.Println(k)
 		case len(*configFileF) > 0:
 			buf, err := ioutil.ReadFile(*configFileF)
 			if err != nil {
@@ -103,13 +109,9 @@ func main() {
 			if err != nil {
 				log.Fatalln("Error: unable to set storage:", err)
 			}
-			fmt.Println("[Config set]")
-		case len(*configShowKey) > 0:
-			k, err := pbmClient.GetConfigVar(*configShowKey)
-			if err != nil {
-				log.Fatalln("Error: unable to get config key:", err)
-			}
-			fmt.Println(k)
+			fmt.Println("[Config set]\n------")
+			// show config after it was set
+			fallthrough
 		case *configListF:
 			fallthrough
 		default:


### PR DESCRIPTION
If the file was malformed (e.g. misformatted) and the improper config was set, there is quite a chance user will notice that in the output.