### PR TITLE
Add s3 storage config prefix

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -43,7 +43,9 @@ func backup(cn *pbm.PBM, bcpName, compression string) (string, error) {
 		storeString += stg.S3.EndpointURL + "/"
 	}
 	storeString += stg.S3.Bucket
-
+	if stg.S3.Prefix != "" {
+		storeString += "/" + stg.S3.Prefix
+	}
 	return storeString, nil
 }
 

--- a/pbm/backup/dst.go
+++ b/pbm/backup/dst.go
@@ -67,7 +67,7 @@ func Save(data io.Reader, stg pbm.Storage, name string) error {
 			u.Concurrency = 10
 		}).Upload(&s3manager.UploadInput{
 			Bucket: aws.String(stg.S3.Bucket),
-			Key:    aws.String(name),
+			Key:    aws.String(path.Join(stg.S3.Prefix, name)),
 			Body:   data,
 		})
 

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -34,6 +34,7 @@ type S3 struct {
 	Region      string      `bson:"region" json:"region" yaml:"region"`
 	EndpointURL string      `bson:"endpointUrl,omitempty" json:"endpointUrl" yaml:"endpointUrl,omitempty"`
 	Bucket      string      `bson:"bucket" json:"bucket" yaml:"bucket"`
+	Prefix      string      `bson:"prefix,omitempty" json:"prefix,omitempty" yaml:"prefix,omitempty"`
 	Credentials Credentials `bson:"credentials" json:"credentials,omitempty" yaml:"credentials"`
 }
 

--- a/pbm/restore/src.go
+++ b/pbm/restore/src.go
@@ -52,7 +52,7 @@ func Source(stg pbm.Storage, name string, compression pbm.CompressionType) (io.R
 
 		s3obj, err := s3.New(awsSession).GetObject(&s3.GetObjectInput{
 			Bucket: aws.String(stg.S3.Bucket),
-			Key:    aws.String(name),
+			Key:    aws.String(path.Join(stg.S3.Prefix, name)),
 		})
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "read '%s/%s' file from S3", stg.S3.Bucket, name)


### PR DESCRIPTION
Hi @dAdAbird,
 
This pull request replaces https://github.com/percona/percona-backup-mongodb/pull/289.
The new storage config file should look like this:
```yaml
storage:
  type: s3
  s3:
    region: <s3 region>
    bucket: <my s3 bucket name>
    prefix: <desired folder hierarchy inside bucket> # optional
    credentials:
      access-key-id: <my s3 access key id>
      secret-access-key: <my s3 secret access key>
```
If a prefix is defined, the user will receive the following feedback upon backup creation:
```bash
Starting backup '2019-11-17T16:20:19Z'...
Backup '2019-11-17T16:20:19Z' to remote store 's3://<bucket>/<prefix>' has started
```
I have tested backup, list and restore operations with and without prefix and everything works as expected. 