### PR TITLE
Late Dec, early Jan touch-up of v1.1 documentation

### DIFF
--- a/doc/source/.res/code-block/bash/pbm-list-mongodb-uri.txt
+++ b/doc/source/.res/code-block/bash/pbm-list-mongodb-uri.txt
@@ -1,3 +1,3 @@
 .. code-block:: bash
 
-   $ pbm list --mongodb-uri="mongodb://pbmuser:secretpwd@localhost:27018/"
+   $ pbm list --mongodb-uri="mongodb://pbmuser:secretpwd@mongocsvr1:27018,mongocsvr2:27018,mongocsvr3:27018/?replicaSet=configrs"

--- a/doc/source/.res/code-block/bash/systemd-unit-file.txt
+++ b/doc/source/.res/code-block/bash/systemd-unit-file.txt
@@ -1,0 +1,16 @@
+.. code-block:: ini
+   
+   [Unit]
+   Description=pbm-agent
+   After=time-sync.target network.target
+   
+   [Service]
+   EnvironmentFile=-/etc/default/pbm-agent
+   Type=simple
+   User=pbm
+   Group=pbm
+   PermissionsStartOnly=true
+   ExecStart=/usr/bin/pbm-agent --mongodb-uri=${PBM_MONGODB_URI}
+   
+   [Install]
+   WantedBy=multi-user.target

--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -11,10 +11,9 @@ channel. Administrators observe and control the backups or restores with a
 |mongodb| cluster.
 
 A single |pbm-agent| is only involved with one cluster (or non-sharded replica
-set). The |pbm.app| CLI command can connect to any cluster it has network access
+set). The |pbm.app| CLI tool can connect to any cluster it has network access
 to, so it is possible for one user to list and launch backups or restores on
-many clusters. Different clusters will require the |pbm.app| user to use a
-different MongoDB connection for each though.
+many clusters. 
 
 .. contents::
    :local:
@@ -29,9 +28,7 @@ different MongoDB connection for each though.
 and config server replicaset nodes in a cluster.
 
 There is no |pbm-agent| config file. Some configuration is required for the
-service script (e.g. ``systemd`` unit file) that will run it though: The MongoDB
-connection URI string (see :ref:`pbm.auth`) to the local mongod node; and a
-filepath to save log output to. See
+service script (e.g. ``systemd`` unit file) that will run it though. See
 :ref:`pbm.installation.service_init_scripts`.
 
 The |pbm-agent|'s backup and restore operations are triggered when it observes
@@ -45,9 +42,9 @@ or restore for that replica set.
 PBM Command Line Utility (|pbm.app|)
 ================================================================================
 
-|pbm.app| is the tool you will use hands on. It is a normal CLI for users and a
-command that can be executed periodically in scripts (for example, by
-``crond``). It manages your backups through a set of sub-commands:
+|pbm.app| is the command you will use manually in the shell, and it will also
+work as a command that can be executed in scripts (for example, by ``crond``).
+It manages your backups through a set of sub-commands:
 
 .. include:: .res/code-block/bash/pbm-help-output.txt
 
@@ -56,10 +53,10 @@ config values. Likewise it starts and monitors backup or restore operations by
 updating and reading other PBM control collections for operations, log, etc.
 
 |pbm.app| does not have its own config and/or cache files per se. Setting the
-|env-pbm-mongodb-uri| environment variable in your shell resource files or
-sourcing that value in the scripts is valuable shell configuration
-though. (Without |env-pbm-mongodb-uri| the |opt-mongodb-uri| command line
-argument will need to be specified each time.)
+|env-pbm-mongodb-uri| environment variable in your shell is a
+configuration-like step that should be done for practical ease though. (Without
+|env-pbm-mongodb-uri| the |opt-mongodb-uri| command line argument will need to
+be specified each time.)
 
 .. _pbm.architecture.pbm_control_collections:
 
@@ -68,13 +65,13 @@ PBM Control Collections
 
 The config and state (current and historical) for backups is stored in
 collections in the MongoDB cluster or non-sharded replica set itself. These are
-put in the system ``admin`` db to keep them cleanly separated from user db
-namespaces. In a cluster only in the ``admin`` db on the ``configsvr``
-replicaset, not the shards.
+put in the system ``admin`` db of the config server replica set to keep them
+cleanly separated from user db namespaces. (In a non-sharded replicaset the
+``admin`` db of the replica set itself is used.)
 
 - *admin.pbmConfig*
 - *admin.pbmCmd* (Used to define and trigger operations)
-- *admin.pbmOp* (|pbm-agent| synchronization-lock structure)
+- *admin.pbmLock* (|pbm-agent| synchronization-lock structure)
 - *admin.pbmBackup* (Log / status of each backup)
 
 The |pbm.app| command line tool creates these collections as needed. You do not
@@ -93,7 +90,7 @@ storage. Using |pbm-list|, a user can scan this directory to find existing
 backups even if they never used |pbm.app| on their computer before.
 
 The files are prefixed with the (UTC) starting time of the backup. For each
-backup, there are a metadata file. For each replicaset:
+backup there is one metadata file. For each replicaset in the backup:
 
   - A mongodump-format compressed archive that is the dump of collections
   - A (compressed) BSON file dump of the oplog covering the timespan of the backup.

--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -21,10 +21,10 @@ To run |pbm| a user must be created in the ``admin`` db that has the role
 .. include:: .res/code-block/mongo/db-createuser.txt
 
 User name and password values and other options of the createUser command can be
-chosen as you like so long as the roles shown above are granted.
+set as you require so long as the roles shown above are granted.
 
-This user must created on every replicaset, i.e. it must be created on the shard
-replicasets as well as the config server replicaset.
+This user must be created on every replicaset, i.e. it must be created on the
+shard replicasets as well as the config server replicaset.
 
 .. note::
 
@@ -43,7 +43,7 @@ MongoDB connection strings - A Reminder (or Primer)
 <https://docs.mongodb.com/manual/reference/connection-string/>`_ strings to open
 MongoDB connections. Neither |pbm.app| or |pbm-agent| accept legacy-style
 command-line arguments for host, port, replicaset, user, password, etc. as, say,
-the ``mongo`` shell or ``mongodump`` does.
+the ``mongo`` shell or ``mongodump`` command does.
 
 .. include:: .res/code-block/bash/pbm-agent-mongodb-conn-string-examples.txt
 
@@ -53,8 +53,8 @@ The connection URI above is the format that MongoDB drivers accept universally
 since approximately the release time of MongoDB server v3.6. The ``mongo`` shell
 `accepts it too since v4.0
 <https://docs.mongodb.com/v4.0/mongo/#mongodb-instance-on-a-remote-host>`_. Using
-a v4.0+ mongo shell is a recommended way to debug from the command line if your
-connection URI is valid or not.
+a v4.0+ mongo shell is a recommended way to debug connection URI validity from
+the command line.
 
 The `MongoDB Connection URI
 <https://docs.mongodb.com/manual/reference/connection-string/>`_ specification
@@ -62,7 +62,7 @@ includes several non-default options you may need to use. For example the TLS
 certificates/keys needed to connect to a cluster or non-sharded replicaset with
 network encryption enabled are "tls=true" plus "tlsCAFile" and/or
 "tlsCertificateKeyFile" (see `tls options
-<https://docs.mongodb.com/manual/reference/connection-string/#tls-options>`_.
+<https://docs.mongodb.com/manual/reference/connection-string/#tls-options>`_).
 
 .. admonition:: Technical note
 

--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -30,9 +30,9 @@ shard replicasets as well as the config server replicaset.
 
    In a cluster run `db.getSiblingDB("config").shards.find({}, {"host": true,
    "_id": false})` to list all the host+port lists for the shard
-   replicasets. The replicaset name at the front of these strings will have to
-   placed as a "/?replicaSet=xxxx" argument at the end to be used in a normal
-   connection though (see below).
+   replicasets. The replicaset name at the *front* of these "host" strings will
+   have to be placed as a "/?replicaSet=xxxx" argument in the parameters part
+   of the connection URI (see below).
 
 .. _pbm.auth.mdb_conn_string:
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -54,8 +54,8 @@ This storage is expected to be a remote fileserver mounted to a local
 directory. PBM uses the directory as if it was any normal directory, however,
 and does not attempt to confirm it is mounted from a remote server. It is the
 obligation of the server administrators to ensure that all the mongod-hosting
-servers have a remote backup server's directory mounted at that same directory
-path.
+servers have the remote backup server's directory mounted at the same local
+directory path.
 
 .. include:: .res/code-block/yaml/example-local-file-system-store.yaml
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -15,8 +15,9 @@ If there is no existing report, submit a report following these steps:
 1. Sign in to `JIRA issue tracker`_. You will need to create an account if you
    do not have one.
 #. In the *Summary*, *Description*, *Steps To Reproduce*, *Affects Version* fields
-   describe the problem you have detected. If the bug corresponds to a crash,
-   attach the stack trace from the logs.
+   describe the problem you have detected. For PBM the important diagnostic
+   information is: log files from the pbm-agents; a dump of the
+   PBM control collections.
   
 As a general rule of thumb, try to create bug reports that are:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,7 +12,7 @@ and MongoDB Community v3.6 or higher with `MongoDB Replication
 <https://docs.mongodb.com/manual/replication/>`_ enabled.
 
 The |pbm| project inherited from and replaces `mongodb_consistent_backup`,
-which is no longer actively developed or supported.  older tool is not
+which is no longer actively developed or supported.
 
 .. _pbm.feature:
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -113,19 +113,17 @@ and |pbm-agent| programs on your system.
 Configuring service init scripts
 ================================================================================
 
-Some configuration is required for the service script (e.g. systemd unit file)
-that will run the |pbm-agent| processes.
+The MongoDB connection URI string to the local mongod node should be set in
+environment file that the `pbm-agent.service` systemd unit file includes.
 
-- The MongoDB connection URI string to the local mongod node. (See
-  :ref:`pbm.auth` for an explanation of standard MongoDB connection strings if
-  you need.)
-- A file path to save log output to. |pbm-agent|'s log output comes straight to
-  stdout and the service script just redirects it (and stderr) to this path.
+With the current systemd unit file (see below) this means setting the 
+"PBM_MONGODB_URI" environment variable in /etc/default/pbm-agent.
 
-.. This section is not available any longer
-.. seealso:
-..
-..   pbm stores
-..     :ref:`pbm.config.storage.setting-up`
+`.../systemd/system/pbm-agent.service`
+
+.. include:: .res/code-block/bash/systemd-unit-file.txt
+
+(See :ref:`pbm.auth` for an explanation of standard MongoDB connection strings
+if you need.)
 
 .. include:: .res/replace.txt

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -5,7 +5,7 @@
 
 .. rubric:: How to use |pbm|: going back in time (|pbm-restore|)
 
-Even in a highly-available architecture, such as with |mongodb| replication, backups are still required even though losing one server suddenly is not fatal. Whether for a complete or partial data disaster you can use PBM (Percona Backup for MongoDB) to go back in time to the best available backup snapshot.
+Even in a highly-available architecture, such as with |mongodb| replication, backups are still required even though losing one server is not fatal. Whether for a complete or partial data disaster you can use PBM (Percona Backup for MongoDB) to go back in time to the best available backup snapshot.
 
 For example, imagine your web application's update was released on Sunday, June 9th 23:00 EDT but, by 11:23 Monday, someone realizes that the update has a bug that is wiping the historical data of any user who logged in. Nobody likes to have downtime, but it's time to roll back: what's the best backup to use?
 

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -22,7 +22,7 @@ Initial Setup
 Start the |pbm-agent| processes
 --------------------------------------------------------------------------------
 After installing |pbm-agent| on the all the servers that have mongod nodes make
-sure it is started one for each mongod node.
+sure one instance of it is started for each mongod node.
 
 E.g. Imagine you put configsvr nodes (listen port 27019) colocated on the same
 servers as the first shard's mongod nodes (listen port 27018, replica set name
@@ -33,8 +33,8 @@ node (e.g. "mongodb://username:password@localhost:27019/").
 
 It is best to use the packaged service scripts to run |pbm-agent|. But for
 reference an example of how to do it manually is shown below. The output is
-redirected to a file and the process is backgrounded. You can run it an shell
-terminal temporarily if you want to observer and/or debug the startup from the
+redirected to a file and the process is backgrounded. You can run it on a shell
+terminal temporarily if you want to observe and/or debug the startup from the
 log messages.
 
 .. code-block:: bash
@@ -43,10 +43,8 @@ log messages.
 
 .. tip::
    
-   Running as the mongod user and saving the log file in the same parent
-   directory as the mongod node's data directory would be the most intuitive and
-   convenient way. But if you want it can be another user, and the log file can
-   be at location that files can be written to, or piped to logging service.
+   Running as the mongod user would be the most intuitive and convenient way.
+   But if you want it can be another user.
 
 You can confirm the |pbm-agent| connected to its mongod and started OK by
 confirming *"pbm agent is listening for the commands"* is printed to the log
@@ -63,12 +61,12 @@ Running |pbm.app| Commands
 Configuring a Remote Store for Backup and Restore Operations
 --------------------------------------------------------------------------------
 
-This must done once, at installation time, before backups can be listed, made,
-or restored. Please see :ref:`pbm.config`.
+This must done once, at installation or re-installaton time, before backups can
+be listed, made, or restored. Please see :ref:`pbm.config`.
 
 .. _pbm.running.backup.listing:
 
-Example: Listing all backups
+Listing all backups
 --------------------------------------------------------------------------------
 
 .. include:: .res/code-block/bash/pbm-list-mongodb-uri.txt
@@ -84,14 +82,27 @@ Example: Listing all backups
 
 .. _pbm.running.backup.starting: 
 
-Example: Starting a backup
+Starting a backup
 --------------------------------------------------------------------------------
 
 .. include:: .res/code-block/bash/pbm-backup-mongodb-uri.txt
 
 .. _pbm.running.backup.restoring: 
 
-Example: Restoring a Backup
+.. important::
+
+   For PBM v1.0 (only) before running |pbm-backup| on a cluster stop the
+   balancer.
+
+Checking an in-progress backup
+--------------------------------------------------------------------------------
+
+Run the |pbm-list| command and you will see the running backup listed with a
+'In progress' label. When that is absent the backup is complete.
+
+.. _pbm.running.backup.restoring: 
+
+Restoring a Backup
 --------------------------------------------------------------------------------
 
 To restore a backup that you have made using |pbm-backup| you should use the

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -124,7 +124,7 @@ restore.
 
 .. include:: .res/code-block/bash/pbm-restore-mongodb-uri.txt
 
-After a cluster's restore complete a cluster all mongos nodes will need to be
+After a cluster's restore is complete all mongos nodes will need to be
 restarted to reload the sharding metadata.
 
 Deleting backups

--- a/doc/source/uninstalling.rst
+++ b/doc/source/uninstalling.rst
@@ -10,13 +10,14 @@ To uninstall |pbm| perform the following steps:
    is, so you can delete backups made by |pbm|. If it is S3-compatible object
    storage you will need to use another tool such as Amazon AWS's "aws s3",
    Minio's ``mc``, the web AWS Management Console, etc. to do that once |pbm| is
-   uninstalled.
+   uninstalled. Don't forget to note the connection credentials before they
+   are deleted too.
 #. Uninstall the |pbm-agent| and |pbm.app| executables. If you installed using a
    package manager, see :ref:`pbm.installation` for relevant package names and
    commands for your OS distribution.
 #. Drop the :ref:`PBM control collections <pbm.architecture.pbm_control_collections>`.
-#. Drop the PBM user. If this is a cluster the dropUser command will need to be
-   run on each shard as well as in the config server replica set.
+#. Drop the PBM database user. If this is a cluster the dropUser command will
+   need to be run on each shard as well as in the config server replica set.
 #. (Optional) Delete the backups from the remote backup storage.
 
 .. include:: .res/replace.txt


### PR DESCRIPTION
Hi Borys. This PR has a few things in my own v1.1 doc rewrite that I want to fix.

One thing especially to note: I've added a new .res file doc/source/.res/code-block/bash/systemd-unit-file.txt that shows an ini-format file. I just optimistically set the code type to "ini" without knowing if that will render. I apologize in advance if it does not. I guess a plain-text format is the next best thing if there is no "ini" formatter.