### PR TITLE
PBM-408: Putting storage key as top-level field in config yaml examples

### DIFF
--- a/doc/source/.res/code-block/yaml/example-amazon-s3-storage.yaml
+++ b/doc/source/.res/code-block/yaml/example-amazon-s3-storage.yaml
@@ -1,9 +1,10 @@
 .. code-block:: yaml
 
-   type: s3
-   s3:
-      region: us-west-2
-      bucket: pbm-test-bucket
-      credentials:
+   storage:
+     type: s3
+     s3:
+       region: us-west-2
+       bucket: pbm-test-bucket
+       credentials:
          access-key-id: <your-access-key-id-here>
          secret-access-key: <your-secret-key-here>

--- a/doc/source/.res/code-block/yaml/example-local-file-system-store.yaml
+++ b/doc/source/.res/code-block/yaml/example-local-file-system-store.yaml
@@ -1,5 +1,6 @@
 .. code-block:: yaml
 
-   type: filesystem
-   filesystem:
-     path: /data/local_backups
+   storage:
+     type: filesystem
+     filesystem:
+       path: /data/local_backups

--- a/doc/source/.res/code-block/yaml/example-minio-s3-storage.yaml
+++ b/doc/source/.res/code-block/yaml/example-minio-s3-storage.yaml
@@ -1,10 +1,11 @@
 .. code-block:: yaml
 
-   type: s3
-   s3:
-      endpointUrl: "http://localhost:9000"
-      region: my-region
-      bucket: pbm-example
-      credentials:
+   storage:
+     type: s3
+     s3:
+       endpointUrl: "http://localhost:9000"
+       region: my-region
+       bucket: pbm-example
+       credentials:
          access-key-id: <your-access-key-id-here>
          secret-access-key: <your-secret-key-here>

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -32,18 +32,19 @@ servers as the first shard's mongod nodes (listen port 27018, replica set name
 node (e.g. "mongodb://username:password@localhost:27019/").
 
 It is best to use the packaged service scripts to run |pbm-agent|. After
-adding the database connection configuration for them (see pbm.installation.service_init_scripts_) 
-you can start the |pbm-agent| service as below:
+adding the database connection configuration for them (see
+:ref: pbm.installation.service_init_scripts) you can start the |pbm-agent|
+service as below:
 
 .. code-block:: bash
 
-   sudo systemctl start pbm-agent
-   sudo systemctl status pbm-agent
+   $ sudo systemctl start pbm-agent
+   $ sudo systemctl status pbm-agent
 
-For reference an example of how to do it manually is shown below. The output is
-redirected to a file and the process is backgrounded. You can run it on a shell
-terminal temporarily if you want to observe and/or debug the startup from the
-log messages.
+For reference an example of starting pbm-agent manually is shown below. The
+output is redirected to a file and the process is backgrounded. Alternatively
+you can run it on a shell terminal temporarily if you want to observe and/or
+debug the startup from the log messages.
 
 .. code-block:: bash
 

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -26,13 +26,21 @@ sure one instance of it is started for each mongod node.
 
 E.g. Imagine you put configsvr nodes (listen port 27019) colocated on the same
 servers as the first shard's mongod nodes (listen port 27018, replica set name
-"sh1rs") to save some hardware costs. In this server you would start two
+"sh1rs"). In this server there should be two 
 |pbm-agent| processes, one connected to the shard
 (e.g. "mongodb://username:password@localhost:27018/") and one to the configsvr
 node (e.g. "mongodb://username:password@localhost:27019/").
 
-It is best to use the packaged service scripts to run |pbm-agent|. But for
-reference an example of how to do it manually is shown below. The output is
+It is best to use the packaged service scripts to run |pbm-agent|. After
+adding the database connection configuration for them (see pbm.installation.service_init_scripts_) 
+you can start the |pbm-agent| service as below:
+
+.. code-block:: bash
+
+   sudo systemctl start pbm-agent
+   sudo systemctl status pbm-agent
+
+For reference an example of how to do it manually is shown below. The output is
 redirected to a file and the process is backgrounded. You can run it on a shell
 terminal temporarily if you want to observe and/or debug the startup from the
 log messages.

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -58,6 +58,26 @@ You can confirm the |pbm-agent| connected to its mongod and started OK by
 confirming *"pbm agent is listening for the commands"* is printed to the log
 file.
 
+How to see the pbm-agent log
+--------------------------------------------------------------------------------
+
+With the packaged systemd service the log output to stdout is captured by
+systemd's default redirection to systemd-journald. You can view it with the
+command below. See `man journalctl` for useful options such as '--lines',
+'--follow', etc.
+
+.. code-block:: bash
+
+   ~$ journalctl -u pbm-agent.service
+   -- Logs begin at Tue 2019-10-22 09:31:34 JST. --
+   Jan 22 15:59:14 akira-x1 systemd[1]: Started pbm-agent.
+   Jan 22 15:59:14 akira-x1 pbm-agent[3579]: pbm agent is listening for the commands
+   ...
+   ...
+
+If you started pbm-agent manually see the file you redirected stdout and stderr
+to.
+
 Running |pbm|
 ================================================================================
 


### PR DESCRIPTION
I mistakenly left "storage:" out of the config file examples when I wrote the v1.1 documentation.

This patch to the three include files fixes that.