### PR TITLE
Add support for GCP Cloud Storage S3

### DIFF
--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -127,7 +127,7 @@ func getBackupListS3(stg S3) ([]BackupMeta, error) {
 		return nil, errors.Wrap(err, "create AWS session")
 	}
 
-	lparams := &s3.ListObjectsV2Input{
+	lparams := &s3.ListObjectsInput{
 		Bucket:    aws.String(stg.Bucket),
 		Delimiter: aws.String("/"),
 	}
@@ -138,8 +138,8 @@ func getBackupListS3(stg S3) ([]BackupMeta, error) {
 	var bcps []BackupMeta
 	awscli := s3.New(awsSession)
 	var berr error
-	err = awscli.ListObjectsV2Pages(lparams,
-		func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+	err = awscli.ListObjectsPages(lparams,
+		func(page *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, o := range page.Contents {
 				name := aws.StringValue(o.Key)
 				if strings.HasSuffix(name, ".pbm.json") {


### PR DESCRIPTION
GCP Cloud Storage S3 supports most actions using Amazon S3 V2 API but
listing objects is only supported using the V1 API.

If you try to resync backups when using GCP Cloud Storage S3 you'll get
the error like the one below:

```
2020/02/19 08:46:43 Got command resyncBcpList
2020/02/19 08:46:43 [INFO] resync_list: started
2020/02/19 08:46:43 [ERROR] resync_list: get backups from S3: get backup list: NotImplemented: A header or query you provided requested a function that is not implemented.
        status code: 400, request id: , host id:
```

Using the V1 API will however correctly resync the backups:

```
2020/02/19 10:42:37 Got command resyncBcpList
2020/02/19 10:42:37 [INFO] resync_list: started
2020/02/19 10:42:38 [INFO] resync_list: succeed
```

It may be somewhat controversial to use an older API in a new tool but
since Amazon still supports it and you get full GCP Cloud Storage
support thrown in for free I believe it is worth doing it.

Example storage config for anyone wanting to try this out:
```
storage:
  type: s3
  s3:
    provider: gcs
    region: eu
    endpointUrl: https://storage.googleapis.com
    bucket: project-id_backup
    credentials:
      access-key-id: '***'
      secret-access-key: '***'
```

Remember to create your own HMAC credentials.

See:
- https://cloud.google.com/storage/docs/migrating
- https://cloud.google.com/storage/docs/authentication/managing-hmackeys