### PR TITLE
PBM-438 Fix sort-by order in BackupList()

### DIFF
--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -363,7 +363,7 @@ func (p *PBM) BackupsList(limit int64) ([]BackupMeta, error) {
 	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(
 		p.ctx,
 		bson.M{},
-		options.Find().SetLimit(limit).SetSort(bson.D{{"start_ts", 1}}),
+		options.Find().SetLimit(limit).SetSort(bson.D{{"start_ts", -1}}),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "query mongo")


### PR DESCRIPTION
The sort on "start_ts" was 1 (ascending) rather than -1 (descending). This leads to incorrectly showing the oldest rather than the latest backups when using the --size parameter to "pbm list".