### PR TITLE
PBM-438 Fix pbm list layout order

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -122,7 +122,8 @@ func printBackupList(cn *pbm.PBM, size int64) {
 		log.Fatalln("Error: unable to get backups list:", err)
 	}
 	fmt.Println("Backup history:")
-	for _, b := range bcps {
+	for i := len(bcps) - 1; i >= 0; i-- {
+		b := bcps[i]
 		var bcp string
 		switch b.Status {
 		case pbm.StatusDone:

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -61,7 +61,9 @@ func printRestoreList(cn *pbm.PBM, size int64, full bool) {
 		log.Fatalln("Error: unable to get restore list:", err)
 	}
 	fmt.Println("Restores history:")
-	for _, r := range rs {
+	for i := len(rs) - 1; i >= 0; i-- {
+		r := rs[i]
+
 		var rprint string
 
 		name := r.Backup

--- a/pbm/restore.go
+++ b/pbm/restore.go
@@ -125,7 +125,7 @@ func (p *PBM) RestoresList(limit int64) ([]RestoreMeta, error) {
 	cur, err := p.Conn.Database(DB).Collection(RestoresCollection).Find(
 		p.ctx,
 		bson.M{},
-		options.Find().SetLimit(limit).SetSort(bson.D{{"start_ts", 1}}),
+		options.Find().SetLimit(limit).SetSort(bson.D{{"start_ts", -1}}),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "query mongo")


### PR DESCRIPTION
Fix for PBM-438 changed the listing order so the most recent backups became at the top of the list. This commit restores the listing order returning backup the behaviour when the most recent backups are listed in the bottom.

was
```
$ pbm list
Backup history:
  2020-04-03T12:38:26Z
  2020-03-17T20:37:39Z
  2020-03-17T19:37:40Z
```

become:
```
$ pbm list
Backup history:
  2020-03-17T19:37:40Z
  2020-03-17T20:37:39Z
  2020-04-03T12:38:26Z
```

It also fixes the restore listing.