### PR TITLE
PBM-348 Drop backup

### DIFF
--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/percona/percona-backup-mongodb/speedt"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/alecthomas/kingpin"
-
 	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/blackhole"
 	"github.com/percona/percona-backup-mongodb/version"
 )
 
@@ -83,9 +83,7 @@ func compression(mURL string, compression pbm.CompressionType, sizeGb float64, c
 		cn = node.Session()
 	}
 
-	stg := pbm.Storage{
-		Type: pbm.StorageBlackHole,
-	}
+	stg := blackhole.New()
 	done := make(chan struct{})
 	go printw(done)
 

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -6,9 +6,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
 )
 
 func backup(cn *pbm.PBM, bcpName, compression string) (string, error) {
@@ -30,7 +31,7 @@ func backup(cn *pbm.PBM, bcpName, compression string) (string, error) {
 		}
 	}
 
-	stg, err := cn.GetStorage()
+	cfg, err := cn.GetConfig()
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return "", errors.New("no store set. Set remote store with <pbm store set>")
@@ -57,18 +58,18 @@ func backup(cn *pbm.PBM, bcpName, compression string) (string, error) {
 	}
 
 	storeString := ""
-	switch stg.Type {
+	switch cfg.Storage.Type {
 	case pbm.StorageS3:
 		storeString = "s3://"
-		if stg.S3.EndpointURL != "" {
-			storeString += stg.S3.EndpointURL + "/"
+		if cfg.Storage.S3.EndpointURL != "" {
+			storeString += cfg.Storage.S3.EndpointURL + "/"
 		}
-		storeString += stg.S3.Bucket
-		if stg.S3.Prefix != "" {
-			storeString += "/" + stg.S3.Prefix
+		storeString += cfg.Storage.S3.Bucket
+		if cfg.Storage.S3.Prefix != "" {
+			storeString += "/" + cfg.Storage.S3.Prefix
 		}
 	case pbm.StorageFilesystem:
-		storeString = stg.Filesystem.Path
+		storeString = cfg.Storage.Filesystem.Path
 	}
 	return storeString, nil
 }

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -45,7 +45,7 @@ var (
 	listCmdSize        = listCmd.Flag("size", "Show last N backups").Default("0").Int64()
 
 	deleteBcpCmd    = pbmCmd.Command("delete-backup", "Delete a backup")
-	deleteBcpName   = deleteBcpCmd.Arg("name", "backup name").String()
+	deleteBcpName   = deleteBcpCmd.Arg("name", "Backup name").String()
 	deleteBcpCmdOtF = deleteBcpCmd.Flag("older-than", "Delete backups older than").String()
 	deleteBcpForceF = deleteBcpCmd.Flag("force", "Force. Don't ask confirmation").Short('f').Bool()
 
@@ -151,7 +151,7 @@ func main() {
 			printBackupList(pbmClient, *listCmdSize)
 		}
 	case deleteBcpCmd.FullCommand():
-		if !*deleteBcpForceF {
+		if !*deleteBcpForceF && isTTY() {
 			fmt.Print("Are you sure you want delete backup(s)? [y/N] ")
 			scanner := bufio.NewScanner(os.Stdin)
 			scanner.Scan()
@@ -176,6 +176,11 @@ func main() {
 		}
 		printBackupList(pbmClient, 0)
 	}
+}
+
+func isTTY() bool {
+	fi, err := os.Stdin.Stat()
+	return (fi.Mode()&os.ModeCharDevice) != 0 && err == nil
 }
 
 func rsync(pbmClient *pbm.PBM) {

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -47,6 +47,7 @@ var (
 	deleteBcpCmd    = pbmCmd.Command("delete-backup", "Delete a backup")
 	deleteBcpName   = deleteBcpCmd.Arg("name", "backup name").String()
 	deleteBcpCmdOtF = deleteBcpCmd.Flag("older-than", "Delete backups older than").String()
+	deleteBcpForceF = deleteBcpCmd.Flag("force", "Force. Don't ask confirmation").Short('f').Bool()
 
 	versionCmd    = pbmCmd.Command("version", "PBM version info")
 	versionShort  = versionCmd.Flag("short", "Only version info").Default("false").Bool()
@@ -150,13 +151,15 @@ func main() {
 			printBackupList(pbmClient, *listCmdSize)
 		}
 	case deleteBcpCmd.FullCommand():
-		fmt.Print("Are you shure you want delete backup(s)?\n [yes/NO] ")
-		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Scan()
-		switch strings.TrimSpace(scanner.Text()) {
-		case "yes", "Yes", "YES", "Y", "y":
-		default:
-			return
+		if !*deleteBcpForceF {
+			fmt.Print("Are you shure you want delete backup(s)? [y/N] ")
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			switch strings.TrimSpace(scanner.Text()) {
+			case "yes", "Yes", "YES", "Y", "y":
+			default:
+				return
+			}
 		}
 
 		var err error

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -152,7 +152,7 @@ func main() {
 		}
 	case deleteBcpCmd.FullCommand():
 		if !*deleteBcpForceF {
-			fmt.Print("Are you shure you want delete backup(s)? [y/N] ")
+			fmt.Print("Are you sure you want delete backup(s)? [y/N] ")
 			scanner := bufio.NewScanner(os.Stdin)
 			scanner.Scan()
 			switch strings.TrimSpace(scanner.Text()) {

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -97,6 +97,9 @@ func main() {
 	tests.NetworkCut()
 	printDone("Cut network during the backup")
 
+	tests.DeleteBallast()
+	tests.GenerateBallastData(1e5)
+
 	cVersion := version.Must(version.NewVersion(tests.ServerVersion()))
 	v42 := version.Must(version.NewVersion("4.2"))
 	if cVersion.GreaterThanOrEqual(v42) {

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -67,6 +67,21 @@ func main() {
 	tests.BackupAndRestore()
 	printDone("Basic Backup & Restore Minio")
 
+	tests.DeleteBallast()
+	tests.GenerateBallastData(1e3)
+	flushStore("/etc/pbm/minio.yaml")
+
+	printStart("Check Backups deletion")
+	tests.BackupDelete("/etc/pbm/minio.yaml")
+	printDone("Check Backups deletion")
+
+	tests.DeleteBallast()
+	tests.GenerateBallastData(1e5)
+
+	printStart("Check the Running Backup can't be deleted")
+	tests.BackupNotDeleteRunning()
+	printDone("Check the Running Backup can't be deleted")
+
 	printStart("Backup Data Bounds Check")
 	tests.BackupBoundsCheck()
 	printDone("Backup Data Bounds Check")

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -90,6 +90,9 @@ func main() {
 	tests.RestartAgents()
 	printDone("Restart agents during the backup")
 
+	tests.DeleteBallast()
+	tests.GenerateBallastData(1e6)
+
 	printStart("Cut network during the backup")
 	tests.NetworkCut()
 	printDone("Cut network during the backup")

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -284,6 +284,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
+      sleep 2
       /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234;
       /usr/bin/mc mb myminio/bcp;
       exit 0;

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -25,20 +25,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger  --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger  --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   cfg02:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: cfg02
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   cfg03:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: cfg03
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   agent-cfg01:
@@ -101,20 +101,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   rs102:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs102
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   rs103:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs103
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   agent-rs101:
@@ -179,20 +179,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   rs202:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs202
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   rs203:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs203
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./keyFile:/opt/keyFile
   agent-rs201:

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -284,7 +284,6 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
-      sleep 2
       /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234;
       /usr/bin/mc mb myminio/bcp;
       exit 0;

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -25,20 +25,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger  --wiredTigerCacheSizeGB 1
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger  --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   cfg02:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: cfg02
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   cfg03:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: cfg03
-    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
+    command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   agent-cfg01:
@@ -101,20 +101,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   rs102:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs102
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   rs103:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs103
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   agent-rs101:
@@ -179,20 +179,20 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./scripts/start.sh:/opt/start.sh
       - ./keyFile:/opt/keyFile
   rs202:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs202
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   rs203:
     image: percona/percona-server-mongodb:${MONGODB_VERSION:-3.6}
     hostname: rs203
-    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1 --setParameter "transactionLifetimeLimitSeconds=300"
     volumes:
       - ./keyFile:/opt/keyFile
   agent-rs201:

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -110,7 +110,6 @@ start_cluster() {
     docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d
     sleep 25
     docker-compose -f $COMPOSE_PATH ps
-    docker-compose -f $COMPOSE_PATH logs cfg101
     export COMPOSE_INTERACTIVE_NO_CLI=1
     docker-compose -f $COMPOSE_PATH exec -T cfg01 /opt/start.sh
     docker-compose -f $COMPOSE_PATH exec -T rs101 /opt/start.sh

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -108,8 +108,9 @@ start_cluster() {
 
     export MONGODB_VERSION=${mongo_version:-"3.6"}
     docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d
-    sleep 30
+    sleep 25
     docker-compose -f $COMPOSE_PATH ps
+    docker-compose -f $COMPOSE_PATH logs cfg101
     export COMPOSE_INTERACTIVE_NO_CLI=1
     docker-compose -f $COMPOSE_PATH exec -T cfg01 /opt/start.sh
     docker-compose -f $COMPOSE_PATH exec -T rs101 /opt/start.sh

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -108,7 +108,8 @@ start_cluster() {
 
     export MONGODB_VERSION=${mongo_version:-"3.6"}
     docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d
-    sleep 25
+    sleep 30
+    docker-compose -f $COMPOSE_PATH ps
     export COMPOSE_INTERACTIVE_NO_CLI=1
     docker-compose -f $COMPOSE_PATH exec -T cfg01 /opt/start.sh
     docker-compose -f $COMPOSE_PATH exec -T rs101 /opt/start.sh
@@ -120,7 +121,6 @@ start_cluster() {
             agent-cfg01 agent-cfg02 agent-cfg03  agent-rs101 agent-rs102 agent-rs103 agent-rs201 agent-rs202 agent-rs203
     docker-compose -f $COMPOSE_PATH start \
             agent-cfg01 agent-cfg02 agent-cfg03  agent-rs101 agent-rs102 agent-rs103 agent-rs201 agent-rs202 agent-rs203
-
 }
 
 destroy_cluster() {

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -26,6 +26,10 @@ func NewMongoPBM(ctx context.Context, connectionURI string) (*MongoPBM, error) {
 	}, nil
 }
 
+func (m *MongoPBM) BackupsList(limit int64) ([]pbm.BackupMeta, error) {
+	return m.p.BackupsList(limit)
+}
+
 func (m *MongoPBM) GetBackupMeta(bcpName string) (*pbm.BackupMeta, error) {
 	return m.p.GetBackupMeta(bcpName)
 }

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -38,6 +38,10 @@ func (m *MongoPBM) StoreResync() error {
 	return m.p.ResyncBackupList()
 }
 
+func (m *MongoPBM) Conn() *mongo.Client {
+	return m.p.Conn
+}
+
 // WaitOp waits up to waitFor duration until operations witch acquires a given lock are finished
 func (m *MongoPBM) WaitOp(lock *pbm.LockHeader, waitFor time.Duration) error {
 	// just to be sure the check hasn't started before the lock were created

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -46,7 +46,7 @@ func (c *Ctl) ApplyConfig(file string) error {
 }
 
 func (c *Ctl) Backup() (string, error) {
-	out, err := c.RunCmd("pbm", "backup")
+	out, err := c.RunCmd("pbm", "backup", "--compression", "s2")
 	if err != nil {
 		return "", err
 	}

--- a/e2e-tests/pkg/tests/sharded/test_basic.go
+++ b/e2e-tests/pkg/tests/sharded/test_basic.go
@@ -1,6 +1,8 @@
 package sharded
 
-import "log"
+import (
+	"log"
+)
 
 func (c *Cluster) BackupAndRestore() {
 	checkData := c.DataChecker()
@@ -14,7 +16,7 @@ func (c *Cluster) BackupAndRestore() {
 	log.Println("resync backup list")
 	err := c.mongopbm.StoreResync()
 	if err != nil {
-		log.Fatalln("resync backup lists:", err)
+		log.Fatalln("Error: resync backup lists:", err)
 	}
 
 	c.Restore(bcpName)

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -97,8 +97,8 @@ func checkNoFiles(exceptPrefix, conf string) {
 			continue
 		}
 
-		if !strings.HasPrefix(object.Key, exceptPrefix) {
-			log.Fatalln("Error: delete lefover", object.Key)
+		if !strings.Contains(object.Key, exceptPrefix) {
+			log.Fatalln("Error: failed to delete lefover", object.Key)
 		}
 	}
 }

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -22,7 +22,7 @@ func (c *Cluster) BackupDelete(storage string) {
 		log.Println("doing backup:", bcpName)
 		c.BackupWaitDone(bcpName)
 		backups[i] = bcpName
-		time.Sleep(1)
+		time.Sleep(1 * time.Second)
 	}
 
 	c.printBcpList()

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go"
 	"github.com/percona/percona-backup-mongodb/pbm"
@@ -21,6 +22,7 @@ func (c *Cluster) BackupDelete(storage string) {
 		log.Println("doing backup:", bcpName)
 		c.BackupWaitDone(bcpName)
 		backups[i] = bcpName
+		time.Sleep(1)
 	}
 
 	c.printBcpList()
@@ -107,7 +109,7 @@ func (c *Cluster) BackupNotDeleteRunning() {
 
 	log.Println("deleting backup", bcpName)
 	o, err := c.pbm.RunCmd("pbm", "delete-backup", "-f", bcpName)
-	if err == nil || !strings.Contains(err.Error(), "Error: Undable delete backup in running state") {
+	if err == nil || !strings.Contains(err.Error(), "Error: Unable to delete backup in running state") {
 		list, lerr := c.pbm.RunCmd("pbm", "list")
 		log.Fatalf("Error: running backup '%s' shouldn't be deleted.\nOutput: %s\nStderr:%s\nBackups list:\n%v\n%v", bcpName, o, err, list, lerr)
 	}

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -25,6 +25,7 @@ func (c *Cluster) BackupDelete(storage string) {
 	for i := 0; i < len(backups); i++ {
 		ts := time.Now()
 		time.Sleep(1 * time.Second)
+		c.printBcpList()
 		bcpName := c.Backup()
 		backups[i] = backupDelete{
 			name: bcpName,

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -32,14 +32,6 @@ func (c *Cluster) BackupDelete(storage string) {
 			ts:   ts,
 		}
 		c.BackupWaitDone(bcpName)
-
-		// locks being released NOT immediately after the backup succeed
-		// see https://github.com/percona/percona-backup-mongodb/blob/v1.1.3/agent/agent.go#L128-L143
-		needToWait := pbm.WaitActionStart + time.Second - time.Since(ts)
-		if needToWait > 0 {
-			log.Printf("wait for lock to be released for %s", needToWait)
-			time.Sleep(needToWait)
-		}
 	}
 
 	c.printBcpList()

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -1,0 +1,120 @@
+package sharded
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/minio/minio-go"
+	"github.com/percona/percona-backup-mongodb/pbm"
+	"gopkg.in/yaml.v2"
+)
+
+func (c *Cluster) BackupDelete(storage string) {
+	checkData := c.DataChecker()
+
+	backups := make([]string, 5)
+	for i := 0; i < len(backups); i++ {
+		bcpName := c.Backup()
+		log.Println("doing backup:", bcpName)
+		c.BackupWaitDone(bcpName)
+		backups[i] = bcpName
+	}
+
+	c.printBcpList()
+
+	log.Println("delete backup", backups[4])
+	_, err := c.pbm.RunCmd("pbm", "delete-backup", "-f", backups[4])
+	if err != nil {
+		log.Fatalf("Error: delete backup %s: %v", backups[4], err)
+	}
+
+	c.printBcpList()
+
+	log.Println("delete backups older than", backups[3])
+	_, err = c.pbm.RunCmd("pbm", "delete-backup", "-f", "--older-than", backups[3])
+	if err != nil {
+		log.Fatalf("Error: delete backups older than %s: %v", backups[3], err)
+	}
+
+	c.printBcpList()
+
+	log.Println("should be only backup", backups[3])
+	checkNoFiles(backups[3], storage)
+
+	blist, err := c.mongopbm.BackupsList(0)
+	if err != nil {
+		log.Fatalln("Error: get backups list", err)
+	}
+
+	if len(blist) != 1 || blist[0].Name != backups[3] {
+		log.Fatalf("Error: wrong backups list. Should has been left only backup %s. But have:\n%v", backups[3], blist)
+	}
+
+	log.Println("trying to restore from", backups[3])
+	c.DeleteBallast()
+	c.Restore(backups[3])
+	checkData()
+}
+
+const awsurl = "s3.amazonaws.com"
+
+func checkNoFiles(exceptPrefix, conf string) {
+	buf, err := ioutil.ReadFile(conf)
+	if err != nil {
+		log.Fatalln("Error: unable to read config file:", err)
+	}
+
+	var cfg pbm.Config
+	err = yaml.UnmarshalStrict(buf, &cfg)
+	if err != nil {
+		log.Fatalln("Error: unmarshal yaml:", err)
+	}
+
+	stg := cfg.Storage
+
+	endopintURL := awsurl
+	if stg.S3.EndpointURL != "" {
+		eu, err := url.Parse(stg.S3.EndpointURL)
+		if err != nil {
+			log.Fatalln("Error: parse EndpointURL:", err)
+		}
+		endopintURL = eu.Host
+	}
+
+	mc, err := minio.NewWithRegion(endopintURL, stg.S3.Credentials.AccessKeyID, stg.S3.Credentials.SecretAccessKey, false, stg.S3.Region)
+	if err != nil {
+		log.Fatalln("Error: NewWithRegion:", err)
+	}
+
+	for object := range mc.ListObjects(stg.S3.Bucket, stg.S3.Prefix, true, nil) {
+		if object.Err != nil {
+			fmt.Println("Error: ListObjects: ", object.Err)
+			continue
+		}
+
+		if !strings.HasPrefix(object.Key, exceptPrefix) {
+			log.Fatalln("Error: delete lefover", object.Key)
+		}
+	}
+}
+
+func (c *Cluster) BackupNotDeleteRunning() {
+	log.Println("starting backup")
+	bcpName := c.Backup()
+
+	log.Println("deleting backup", bcpName)
+	o, err := c.pbm.RunCmd("pbm", "delete-backup", "-f", bcpName)
+	if err == nil || !strings.Contains(err.Error(), "Error: Undable delete backup in running state") {
+		list, lerr := c.pbm.RunCmd("pbm", "list")
+		log.Fatalf("Error: running backup '%s' shouldn't be deleted.\nOutput: %s\nStderr:%s\nBackups list:\n%v\n%v", bcpName, o, err, list, lerr)
+	}
+	c.BackupWaitDone(bcpName)
+}
+
+func (c *Cluster) printBcpList() {
+	listo, _ := c.pbm.RunCmd("pbm", "list")
+	fmt.Printf("backup list:\n%s\n", listo)
+}

--- a/e2e-tests/pkg/tests/sharded/test_network_cut.go
+++ b/e2e-tests/pkg/tests/sharded/test_network_cut.go
@@ -19,7 +19,6 @@ func (c *Cluster) NetworkCut() {
 	}
 
 	bcpName := c.Backup()
-	time.Sleep(time.Second * 2)
 
 	log.Println("Cut network on agents", rs)
 	err := c.docker.RunOnReplSet(rs, time.Second*5,

--- a/e2e-tests/pkg/tests/sharded/test_trx.go
+++ b/e2e-tests/pkg/tests/sharded/test_trx.go
@@ -340,6 +340,7 @@ func (c *Cluster) checkTrxCollection(ctx context.Context, bcpName string) {
 	c.checkTrxDoc(ctx, 10, -1)
 	c.checkTrxDoc(ctx, 2000, -1)
 
+	log.Println("delete trx.test data:", c.deleteTrxData(ctx, time.Minute*1))
 }
 
 func (c *Cluster) zeroTrxDoc(ctx context.Context, id int) {

--- a/e2e-tests/pkg/tests/sharded/test_trx.go
+++ b/e2e-tests/pkg/tests/sharded/test_trx.go
@@ -138,14 +138,13 @@ func (c *Cluster) DistributedTransactions() {
 			log.Fatalln("ERROR: update in transaction trx180:", err)
 		}
 
+		c.printBalancerStatus(ctx)
+
 		log.Println("Waiting for the backup to done")
 		<-bcpDone
 		log.Println("Backup done")
 
 		c.printBalancerStatus(ctx)
-
-		// // to prevent StaleConfig after the balancer moved chunks
-		// c.flushRouterConfig(ctx)
 
 		log.Println("trx2 99")
 		err = c.updateTrxRetry(sc, bson.M{"idx": 99}, bson.D{{"$set", bson.M{"changed": 1}}})
@@ -339,8 +338,6 @@ func (c *Cluster) checkTrxCollection(ctx context.Context, bcpName string) {
 	// check data that wasn't touched by transactions
 	c.checkTrxDoc(ctx, 10, -1)
 	c.checkTrxDoc(ctx, 2000, -1)
-
-	log.Println("delete trx.test data:", c.deleteTrxData(ctx, time.Minute*1))
 }
 
 func (c *Cluster) zeroTrxDoc(ctx context.Context, id int) {

--- a/e2e-tests/pkg/tests/sharded/test_trx.go
+++ b/e2e-tests/pkg/tests/sharded/test_trx.go
@@ -74,7 +74,10 @@ func (c *Cluster) DistributedTransactions() {
 	}()
 
 	err = mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
-		var err error
+		err := sess.StartTransaction()
+		if err != nil {
+			log.Fatalln("ERROR: start transaction:", err)
+		}
 		defer func() {
 			if err != nil {
 				sess.AbortTransaction(sc)
@@ -95,12 +98,12 @@ func (c *Cluster) DistributedTransactions() {
 
 		_, err = conn.Database("trx").Collection("test").UpdateOne(sc, bson.M{"idx": 199}, bson.D{{"$set", bson.M{"changed": 1}}})
 		if err != nil {
-			log.Fatalln("ERROR: update in transaction trx:", err)
+			log.Fatalln("ERROR: update in transaction trx199:", err)
 		}
 
 		_, err = conn.Database("trx").Collection("test").UpdateOne(sc, bson.M{"idx": 2001}, bson.D{{"$set", bson.M{"changed": 1}}})
 		if err != nil {
-			log.Fatalln("ERROR: update in transaction trx:", err)
+			log.Fatalln("ERROR: update in transaction trx2001:", err)
 		}
 
 		log.Println("Commiting the transaction")

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -79,7 +79,7 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 
 	stg, err := b.cn.GetStorage()
 	if err != nil {
-		return errors.Wrap(err, "unable to get storage")
+		return errors.Wrap(err, "unable to get PBM storage configuration settings")
 	}
 
 	ver, err := b.node.GetMongoVersion()
@@ -89,7 +89,7 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 
 	cfg, err := b.cn.GetConfig()
 	if err != nil {
-		return errors.Wrap(err, "unable to get config")
+		return errors.Wrap(err, "unable to get PBM config settings")
 	}
 	if cfg.Storage.Type == pbm.StorageUndef {
 		return errors.New("store is doesn't set, you have to set store to make backup")

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -19,6 +19,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
 )
 
 type Backup struct {
@@ -75,21 +77,26 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 		}
 	}()
 
+	stg, err := b.cn.GetStorage()
+	if err != nil {
+		return errors.Wrap(err, "unable to get storage")
+	}
+
 	ver, err := b.node.GetMongoVersion()
 	if err == nil {
 		meta.MongoVersion = ver.VersionString
 	}
 
-	stg, err := b.cn.GetStorage()
+	cfg, err := b.cn.GetConfig()
 	if err != nil {
-		return errors.Wrap(err, "unable to get backup store")
+		return errors.Wrap(err, "unable to get config")
 	}
-	if stg.Type == pbm.StorageUndef {
+	if cfg.Storage.Type == pbm.StorageUndef {
 		return errors.New("store is doesn't set, you have to set store to make backup")
 	}
-	meta.Store = stg
+	meta.Store = cfg.Storage
 	// Erase credentials data
-	meta.Store.S3.Credentials = pbm.Credentials{}
+	meta.Store.S3.Credentials = s3.Credentials{}
 
 	if im.IsLeader() {
 		err = b.cn.SetBackupMeta(meta)
@@ -291,7 +298,7 @@ type Source interface {
 }
 
 // Upload writes data to dst from given src and returns an amount of written bytes
-func Upload(src Source, dst pbm.Storage, compression pbm.CompressionType, fname string) (int64, error) {
+func Upload(src Source, dst storage.Storage, compression pbm.CompressionType, fname string) (int64, error) {
 	r, pw := io.Pipe()
 	defer r.Close()
 
@@ -305,7 +312,7 @@ func Upload(src Source, dst pbm.Storage, compression pbm.CompressionType, fname 
 		pw.Close()
 	}()
 
-	err.write = Save(r, dst, fname)
+	err.write = dst.Save(fname, r)
 
 	if !err.nil() {
 		return 0, err
@@ -490,7 +497,7 @@ func (b *Backup) waitForLastWrite(bcpName string) (primitive.Timestamp, error) {
 	}
 }
 
-func (b *Backup) dumpClusterMeta(bcpName string, stg pbm.Storage) error {
+func (b *Backup) dumpClusterMeta(bcpName string, stg storage.Storage) error {
 	meta, err := b.cn.GetBackupMeta(bcpName)
 	if err != nil {
 		return errors.Wrap(err, "get backup metadata")
@@ -499,13 +506,13 @@ func (b *Backup) dumpClusterMeta(bcpName string, stg pbm.Storage) error {
 	return writeMeta(stg, meta)
 }
 
-func writeMeta(stg pbm.Storage, meta *pbm.BackupMeta) error {
+func writeMeta(stg storage.Storage, meta *pbm.BackupMeta) error {
 	b, err := json.MarshalIndent(meta, "", "\t")
 	if err != nil {
 		return errors.Wrap(err, "marshal data")
 	}
 
-	err = Save(bytes.NewReader(b), stg, meta.Name+".pbm.json")
+	err = stg.Save(meta.Name+".pbm.json", bytes.NewReader(b))
 	return errors.Wrap(err, "write to store")
 }
 

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -88,11 +88,10 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 	}
 
 	cfg, err := b.cn.GetConfig()
-	if err != nil {
+	if err == pbm.ErrStorageUndefined {
+		return errors.New("backups cannot be saved because PBM storage configuration hasn't been set yet")
+	} else if err != nil {
 		return errors.Wrap(err, "unable to get PBM config settings")
-	}
-	if cfg.Storage.Type == pbm.StorageUndef {
-		return errors.New("store is doesn't set, you have to set store to make backup")
 	}
 	meta.Store = cfg.Storage
 	// Erase credentials data

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -512,7 +512,7 @@ func writeMeta(stg storage.Storage, meta *pbm.BackupMeta) error {
 		return errors.Wrap(err, "marshal data")
 	}
 
-	err = stg.Save(meta.Name+".pbm.json", bytes.NewReader(b))
+	err = stg.Save(meta.Name+pbm.MetadataFileSuffix, bytes.NewReader(b))
 	return errors.Wrap(err, "write to store")
 }
 

--- a/pbm/backup/dst.go
+++ b/pbm/backup/dst.go
@@ -22,7 +22,7 @@ type NopCloser struct {
 // Close to satisfy io.WriteCloser interface
 func (NopCloser) Close() error { return nil }
 
-// Compress makes a compressed writer from given one
+// Compress makes a compressed writer from the given one
 func Compress(w io.Writer, compression pbm.CompressionType) io.WriteCloser {
 	switch compression {
 	case pbm.CompressionTypeGZIP:

--- a/pbm/backup/dst.go
+++ b/pbm/backup/dst.go
@@ -3,21 +3,12 @@ package backup
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
-	"os"
-	"path"
 	"runtime"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/golang/snappy"
 	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/pgzip"
-	"github.com/minio/minio-go"
 	"github.com/pierrec/lz4"
-	"github.com/pkg/errors"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
 )
@@ -31,7 +22,7 @@ type NopCloser struct {
 // Close to satisfy io.WriteCloser interface
 func (NopCloser) Close() error { return nil }
 
-// Compress makes a compressed the writer from given one
+// Compress makes a compressed writer from given one
 func Compress(w io.Writer, compression pbm.CompressionType) io.WriteCloser {
 	switch compression {
 	case pbm.CompressionTypeGZIP:
@@ -56,64 +47,5 @@ func Compress(w io.Writer, compression pbm.CompressionType) io.WriteCloser {
 		return s2.NewWriter(w, s2.WriterConcurrency(cc))
 	default:
 		return NopCloser{w}
-	}
-}
-
-// Save writes data to given store
-func Save(data io.Reader, stg pbm.Storage, name string) error {
-	switch stg.Type {
-	case pbm.StorageFilesystem:
-		filepath := path.Join(stg.Filesystem.Path, name)
-		fw, err := os.Create(filepath)
-		if err != nil {
-			return errors.Wrapf(err, "create destination file <%s>", filepath)
-		}
-		_, err = io.Copy(fw, data)
-		return errors.Wrap(err, "write to file")
-	case pbm.StorageS3:
-		switch stg.S3.Provider {
-		default:
-			awsSession, err := session.NewSession(&aws.Config{
-				Region:   aws.String(stg.S3.Region),
-				Endpoint: aws.String(stg.S3.EndpointURL),
-				Credentials: credentials.NewStaticCredentials(
-					stg.S3.Credentials.AccessKeyID,
-					stg.S3.Credentials.SecretAccessKey,
-					"",
-				),
-				S3ForcePathStyle: aws.Bool(true),
-			})
-			if err != nil {
-				return errors.Wrap(err, "create AWS session")
-			}
-			cc := runtime.NumCPU() / 2
-			if cc == 0 {
-				cc = 1
-			}
-			_, err = s3manager.NewUploader(awsSession, func(u *s3manager.Uploader) {
-				u.PartSize = 10 * 1024 * 1024 // 10MB part size
-				u.LeavePartsOnError = true    // Don't delete the parts if the upload fails.
-				u.Concurrency = cc
-			}).Upload(&s3manager.UploadInput{
-				Bucket: aws.String(stg.S3.Bucket),
-				Key:    aws.String(path.Join(stg.S3.Prefix, name)),
-				Body:   data,
-			})
-			return errors.Wrap(err, "upload to S3")
-		case pbm.S3ProviderGCS:
-			// using minio client with GCS because it
-			// allows to disable chuncks muiltipertition for upload
-			mc, err := minio.NewWithRegion(pbm.GCSEndpointURL, stg.S3.Credentials.AccessKeyID, stg.S3.Credentials.SecretAccessKey, true, stg.S3.Region)
-			if err != nil {
-				return errors.Wrap(err, "NewWithRegion")
-			}
-			_, err = mc.PutObject(stg.S3.Bucket, path.Join(stg.S3.Prefix, name), data, -1, minio.PutObjectOptions{})
-			return errors.Wrap(err, "upload to GCS")
-		}
-	case pbm.StorageBlackHole:
-		_, err := io.Copy(ioutil.Discard, data)
-		return errors.Wrap(err, "upload to blackhole")
-	default:
-		return errors.New("unknown storage type")
 	}
 }

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -162,6 +162,9 @@ func (p *PBM) GetConfig() (Config, error) {
 	return c, errors.Wrap(err, "decode")
 }
 
+// ErrStorageUndefined is an error for undefined storage
+var ErrStorageUndefined = errors.New("storage undefined")
+
 // GetStorage reads current storage config and creates and
 // returns respective storage.Storage object
 func (p *PBM) GetStorage() (storage.Storage, error) {
@@ -172,15 +175,13 @@ func (p *PBM) GetStorage() (storage.Storage, error) {
 
 	switch c.Storage.Type {
 	case StorageS3:
-		err := c.Storage.S3.Cast()
-		if err != nil {
-			return nil, errors.Wrap(err, "cast options")
-		}
-		return s3.New(c.Storage.S3), nil
+		return s3.New(c.Storage.S3)
 	case StorageFilesystem:
 		return fs.New(c.Storage.Filesystem), nil
 	case StorageBlackHole:
 		return blackhole.New(), nil
+	case StorageUndef:
+		return nil, ErrStorageUndefined
 	default:
 		return nil, errors.Errorf("unknown storage type %s", c.Storage.Type)
 	}

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -1,7 +1,6 @@
 package pbm
 
 import (
-	"net/url"
 	"reflect"
 	"strings"
 
@@ -10,11 +9,16 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"gopkg.in/yaml.v2"
+
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/blackhole"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
 )
 
 // Config is a pbm config
 type Config struct {
-	Storage Storage `bson:"storage" json:"storage" yaml:"storage"`
+	Storage StorageConf `bson:"storage" json:"storage" yaml:"storage"`
 }
 
 type StorageType string
@@ -26,41 +30,10 @@ const (
 	StorageBlackHole  StorageType = "blackhole"
 )
 
-type Storage struct {
+type StorageConf struct {
 	Type       StorageType `bson:"type" json:"type" yaml:"type"`
-	S3         S3          `bson:"s3,omitempty" json:"s3,omitempty" yaml:"s3,omitempty"`
-	Filesystem Filesystem  `bson:"filesystem,omitempty" json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
-}
-
-type S3Provider string
-
-const (
-	S3ProviderUndef S3Provider = ""
-	S3ProviderAWS   S3Provider = "aws"
-	S3ProviderGCS   S3Provider = "gcs"
-)
-
-type S3 struct {
-	Provider    S3Provider  `bson:"provider,omitempty" json:"provider,omitempty" yaml:"provider,omitempty"`
-	Region      string      `bson:"region" json:"region" yaml:"region"`
-	EndpointURL string      `bson:"endpointUrl,omitempty" json:"endpointUrl" yaml:"endpointUrl,omitempty"`
-	Bucket      string      `bson:"bucket" json:"bucket" yaml:"bucket"`
-	Prefix      string      `bson:"prefix,omitempty" json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Credentials Credentials `bson:"credentials" json:"credentials,omitempty" yaml:"credentials"`
-}
-
-type Filesystem struct {
-	Path string `bson:"path" json:"path" yaml:"path"`
-}
-
-type Credentials struct {
-	AccessKeyID     string `bson:"access-key-id" json:"access-key-id,omitempty" yaml:"access-key-id,omitempty"`
-	SecretAccessKey string `bson:"secret-access-key" json:"secret-access-key,omitempty" yaml:"secret-access-key,omitempty"`
-	Vault           struct {
-		Server string `bson:"server" json:"server,omitempty" yaml:"server"`
-		Secret string `bson:"secret" json:"secret,omitempty" yaml:"secret"`
-		Token  string `bson:"token" json:"token,omitempty" yaml:"token"`
-	} `bson:"vault" json:"vault" yaml:"vault,omitempty"`
+	S3         s3.Conf     `bson:"s3,omitempty" json:"s3,omitempty" yaml:"s3,omitempty"`
+	Filesystem fs.Conf     `bson:"filesystem,omitempty" json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
 }
 
 // ConfKeys returns valid config keys (option names)
@@ -93,12 +66,14 @@ func (p *PBM) SetConfigByte(buf []byte) error {
 }
 
 func (p *PBM) SetConfig(cfg Config) error {
-	err := cfg.Storage.Cast()
-	if err != nil {
-		return errors.Wrap(err, "cast storage")
+	if cfg.Storage.Type == StorageS3 {
+		err := cfg.Storage.S3.Cast()
+		if err != nil {
+			return errors.Wrap(err, "cast storage")
+		}
 	}
 
-	_, err = p.Conn.Database(DB).Collection(ConfigCollection).UpdateOne(
+	_, err := p.Conn.Database(DB).Collection(ConfigCollection).UpdateOne(
 		p.ctx,
 		bson.D{},
 		bson.M{"$set": cfg},
@@ -187,44 +162,26 @@ func (p *PBM) GetConfig() (Config, error) {
 	return c, errors.Wrap(err, "decode")
 }
 
-const (
-	defaultS3Region = "us-east-1"
-	GCSEndpointURL  = "storage.googleapis.com"
-)
-
-func (p *PBM) GetStorage() (Storage, error) {
+// GetStorage readrs current storage sonfig and creates and
+// returns a respective storage.Storage object
+func (p *PBM) GetStorage() (storage.Storage, error) {
 	c, err := p.GetConfig()
 	if err != nil {
-		return c.Storage, errors.Wrap(err, "get config")
+		return nil, errors.Wrap(err, "get config")
 	}
 
-	err = c.Storage.Cast()
-	if err != nil {
-		return c.Storage, errors.Wrap(err, "case storage")
-	}
-
-	return c.Storage, err
-}
-
-func (s *Storage) Cast() error {
-	switch s.Type {
+	switch c.Storage.Type {
 	case StorageS3:
-		if s.S3.Region == "" {
-			s.S3.Region = defaultS3Region
+		err := c.Storage.S3.Cast()
+		if err != nil {
+			return nil, errors.Wrap(err, "cast options")
 		}
-		if s.S3.Provider == S3ProviderUndef {
-			s.S3.Provider = S3ProviderAWS
-			if s.S3.EndpointURL != "" {
-				eu, err := url.Parse(s.S3.EndpointURL)
-				if err != nil {
-					return errors.Wrap(err, "parse EndpointURL")
-				}
-				if eu.Host == GCSEndpointURL {
-					s.S3.Provider = S3ProviderGCS
-				}
-			}
-		}
+		return s3.New(c.Storage.S3), nil
+	case StorageFilesystem:
+		return fs.New(c.Storage.Filesystem), nil
+	case StorageBlackHole:
+		return blackhole.New(), nil
+	default:
+		return nil, errors.Errorf("unknown storage type %s", c.Storage.Type)
 	}
-
-	return nil
 }

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -162,8 +162,8 @@ func (p *PBM) GetConfig() (Config, error) {
 	return c, errors.Wrap(err, "decode")
 }
 
-// GetStorage readrs current storage sonfig and creates and
-// returns a respective storage.Storage object
+// GetStorage reads current storage config and creates and
+// returns respective storage.Storage object
 func (p *PBM) GetStorage() (storage.Storage, error) {
 	c, err := p.GetConfig()
 	if err != nil {

--- a/pbm/delete.go
+++ b/pbm/delete.go
@@ -1,0 +1,92 @@
+package pbm
+
+import (
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// DeleteBackup deletes backup with given name from the current storage
+// and pbm database
+func (p *PBM) DeleteBackup(name string) error {
+	meta, err := p.GetBackupMeta(name)
+	if err != nil {
+		return errors.Wrap(err, "get backup meta")
+	}
+
+	stg, err := p.GetStorage()
+	if err != nil {
+		return errors.Wrap(err, "get storage")
+	}
+
+	return p.deleteBackup(meta, stg)
+}
+
+func (p *PBM) deleteBackup(meta *BackupMeta, stg storage.Storage) (err error) {
+	switch meta.Status {
+	case StatusDone, StatusError:
+	default:
+		return errors.Errorf("Undable delete backup in %s state", meta.Status)
+	}
+	for _, r := range meta.Replsets {
+		err = stg.Delete(r.OplogName)
+		if err != nil {
+			return errors.Wrapf(err, "delete oplog %s", r.OplogName)
+		}
+		err = stg.Delete(r.DumpName)
+		if err != nil {
+			return errors.Wrapf(err, "delete dump %s", r.OplogName)
+		}
+	}
+
+	err = stg.Delete(meta.Name + MetadataFileSuffix)
+	if err != nil {
+		return errors.Wrap(err, "delete metadata file from storage")
+	}
+
+	_, err = p.Conn.Database(DB).Collection(BcpCollection).DeleteOne(p.ctx, bson.M{"name": meta.Name})
+	if err != nil {
+		return errors.Wrap(err, "delete metadata from db")
+	}
+
+	return nil
+}
+
+// DeleteOlderThan deletes backups which older than backup
+// with given name from the current storage and pbm database
+func (p *PBM) DeleteOlderThan(name string) error {
+	meta, err := p.GetBackupMeta(name)
+	if err != nil {
+		return errors.Wrap(err, "get backup meta")
+	}
+
+	stg, err := p.GetStorage()
+	if err != nil {
+		return errors.Wrap(err, "get storage")
+	}
+
+	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(
+		p.ctx,
+		bson.M{
+			"start_ts": bson.M{"$lt": meta.StartTS},
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "get backups list")
+	}
+	defer cur.Close(p.ctx)
+	for cur.Next(p.ctx) {
+		m := new(BackupMeta)
+		err := cur.Decode(m)
+		if err != nil {
+			return errors.Wrap(err, "decode backup meta")
+		}
+
+		err = p.deleteBackup(m, stg)
+		if err != nil {
+			return errors.Wrap(err, "delete backup")
+		}
+	}
+
+	return errors.Wrap(cur.Err(), "cursor")
+}

--- a/pbm/delete.go
+++ b/pbm/delete.go
@@ -6,7 +6,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// DeleteBackup deletes backup with given name from the current storage
+// DeleteBackup deletes backup with the given name from the current storage
 // and pbm database
 func (p *PBM) DeleteBackup(name string) error {
 	meta, err := p.GetBackupMeta(name)
@@ -26,7 +26,7 @@ func (p *PBM) deleteBackup(meta *BackupMeta, stg storage.Storage) (err error) {
 	switch meta.Status {
 	case StatusDone, StatusError:
 	default:
-		return errors.Errorf("Undable delete backup in %s state", meta.Status)
+		return errors.Errorf("Unable to delete backup in %s state", meta.Status)
 	}
 	for _, r := range meta.Replsets {
 		err = stg.Delete(r.OplogName)
@@ -53,7 +53,7 @@ func (p *PBM) deleteBackup(meta *BackupMeta, stg storage.Storage) (err error) {
 }
 
 // DeleteOlderThan deletes backups which older than backup
-// with given name from the current storage and pbm database
+// with the given name from the current storage and pbm database
 func (p *PBM) DeleteOlderThan(name string) error {
 	meta, err := p.GetBackupMeta(name)
 	if err != nil {

--- a/pbm/delete.go
+++ b/pbm/delete.go
@@ -1,6 +1,8 @@
 package pbm
 
 import (
+	"time"
+
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -48,14 +50,8 @@ func (p *PBM) deleteBackup(meta *BackupMeta, stg storage.Storage) (err error) {
 	return errors.Wrap(err, "delete metadata from db")
 }
 
-// DeleteOlderThan deletes backups which older than backup
-// with the given name from the current storage and pbm database
-func (p *PBM) DeleteOlderThan(name string) error {
-	meta, err := p.GetBackupMeta(name)
-	if err != nil {
-		return errors.Wrap(err, "get backup meta")
-	}
-
+// DeleteOlderThan deletes backups which older than Time
+func (p *PBM) DeleteOlderThan(t time.Time) error {
 	stg, err := p.GetStorage()
 	if err != nil {
 		return errors.Wrap(err, "get storage")
@@ -64,7 +60,7 @@ func (p *PBM) DeleteOlderThan(name string) error {
 	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(
 		p.ctx,
 		bson.M{
-			"start_ts": bson.M{"$lt": meta.StartTS},
+			"start_ts": bson.M{"$lt": t.Unix()},
 		},
 	)
 	if err != nil {

--- a/pbm/delete.go
+++ b/pbm/delete.go
@@ -45,11 +45,7 @@ func (p *PBM) deleteBackup(meta *BackupMeta, stg storage.Storage) (err error) {
 	}
 
 	_, err = p.Conn.Database(DB).Collection(BcpCollection).DeleteOne(p.ctx, bson.M{"name": meta.Name})
-	if err != nil {
-		return errors.Wrap(err, "delete metadata from db")
-	}
-
-	return nil
+	return errors.Wrap(err, "delete metadata from db")
 }
 
 // DeleteOlderThan deletes backups which older than backup

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -212,7 +212,7 @@ type BackupMeta struct {
 	Name             string              `bson:"name" json:"name"`
 	Replsets         []BackupReplset     `bson:"replsets" json:"replsets"`
 	Compression      CompressionType     `bson:"compression" json:"compression"`
-	Store            Storage             `bson:"store" json:"store"`
+	Store            StorageConf         `bson:"store" json:"store"`
 	MongoVersion     string              `bson:"mongodb_version" json:"mongodb_version,omitempty"`
 	StartTS          int64               `bson:"start_ts" json:"start_ts"`
 	LastTransitionTS int64               `bson:"last_transition_ts" json:"last_transition_ts"`

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -38,7 +38,7 @@ const (
 	// NoReplset is the name of a virtual replica set of the standalone node
 	NoReplset = "pbmnoreplicaset"
 
-	// MetadataFileSuffix is a suffix for the metadata file on storage
+	// MetadataFileSuffix is a suffix for the metadata file on a storage
 	MetadataFileSuffix = ".pbm.json"
 )
 

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -34,11 +34,12 @@ const (
 	RestoresCollection = "pbmRestores"
 	// CmdStreamCollection is the name of the mongo collection that contains backup/restore commands stream
 	CmdStreamCollection = "pbmCmd"
-)
 
-const (
 	// NoReplset is the name of a virtual replica set of the standalone node
 	NoReplset = "pbmnoreplicaset"
+
+	// MetadataFileSuffix is a suffix for the metadata file on storage
+	MetadataFileSuffix = ".pbm.json"
 )
 
 type Command string

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -541,7 +541,7 @@ func (r *Restore) MarkFailed(name, rsName, msg string) error {
 }
 
 func getMetaFromStore(bcpName string, stg storage.Storage) (*pbm.BackupMeta, error) {
-	r, err := stg.SourceReader(bcpName + ".pbm.json")
+	r, err := stg.SourceReader(bcpName + pbm.MetadataFileSuffix)
 	if err != nil {
 		return nil, errors.Wrap(err, "get from store")
 	}

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -30,7 +30,7 @@ var excludeFromDumpRestore = []string{
 	"config.lockpings",
 	"config.locks",
 	"config.system.sessions",
-	"config.cache.collections",
+	"config.cache.*",
 }
 
 type Restore struct {

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 var excludeFromDumpRestore = []string{
@@ -53,7 +54,7 @@ const (
 func (r *Restore) Run(cmd pbm.RestoreCmd) (err error) {
 	stg, err := r.cn.GetStorage()
 	if err != nil {
-		return errors.Wrap(err, "get backup store")
+		return errors.Wrap(err, "get backup storage")
 	}
 
 	bcp, err := r.cn.GetBackupMeta(cmd.BackupName)
@@ -165,16 +166,17 @@ func (r *Restore) Run(cmd pbm.RestoreCmd) (err error) {
 		return errors.Wrap(err, "waiting for start")
 	}
 
-	dumpReader, dumpCloser, err := Source(stg, rsBackup.DumpName, bcp.Compression)
+	sr, err := stg.SourceReader(rsBackup.DumpName)
 	if err != nil {
-		return errors.Wrap(err, "create source object for the dump restore")
+		return errors.Wrapf(err, "get object %s for the storage", rsBackup.DumpName)
 	}
-	defer func() {
-		dumpReader.Close()
-		if dumpCloser != nil {
-			dumpCloser.Close()
-		}
-	}()
+	defer sr.Close()
+
+	dumpReader, err := Decompress(sr, bcp.Compression)
+	if err != nil {
+		return errors.Wrapf(err, "decompress object %s", rsBackup.DumpName)
+	}
+	defer dumpReader.Close()
 
 	ver, err := r.node.GetMongoVersion()
 	if err != nil || len(ver.Version) < 1 {
@@ -250,16 +252,17 @@ func (r *Restore) Run(cmd pbm.RestoreCmd) (err error) {
 
 	log.Println("starting the oplog replay")
 
-	oplogReader, oplogCloser, err := Source(stg, rsBackup.OplogName, bcp.Compression)
+	or, err := stg.SourceReader(rsBackup.OplogName)
 	if err != nil {
-		return errors.Wrap(err, "create source object for the oplog restore")
+		return errors.Wrapf(err, "get object %s for the storage", rsBackup.DumpName)
 	}
-	defer func() {
-		oplogReader.Close()
-		if oplogCloser != nil {
-			oplogCloser.Close()
-		}
-	}()
+	defer or.Close()
+
+	oplogReader, err := Decompress(or, bcp.Compression)
+	if err != nil {
+		return errors.Wrapf(err, "decompress object %s", rsBackup.DumpName)
+	}
+	defer oplogReader.Close()
 
 	err = NewOplog(r.node, ver, preserveUUID).Apply(oplogReader)
 	if err != nil {
@@ -537,14 +540,15 @@ func (r *Restore) MarkFailed(name, rsName, msg string) error {
 	return errors.Wrap(err, "set replset state")
 }
 
-func getMetaFromStore(bcpName string, stg pbm.Storage) (*pbm.BackupMeta, error) {
-	rr, _, err := Source(stg, bcpName+".pbm.json", pbm.CompressionTypeNone)
+func getMetaFromStore(bcpName string, stg storage.Storage) (*pbm.BackupMeta, error) {
+	r, err := stg.SourceReader(bcpName + ".pbm.json")
 	if err != nil {
 		return nil, errors.Wrap(err, "get from store")
 	}
+	defer r.Close()
 
 	b := &pbm.BackupMeta{}
-	err = json.NewDecoder(rr).Decode(b)
+	err = json.NewDecoder(r).Decode(b)
 
 	return b, errors.Wrap(err, "decode")
 }

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -13,7 +13,7 @@ func (p *PBM) ResyncBackupList() error {
 		return errors.Wrap(err, "unable to get backup store")
 	}
 
-	bcps, err := stg.FilesList(".pbm.json")
+	bcps, err := stg.FilesList(MetadataFileSuffix)
 	if err != nil {
 		return errors.Wrap(err, "get a backups list from the storage")
 	}

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -2,15 +2,7 @@ package pbm
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"path"
-	"strings"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -20,24 +12,13 @@ func (p *PBM) ResyncBackupList() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get backup store")
 	}
-	var bcps []BackupMeta
-	switch stg.Type {
-	default:
-		return errors.New("store is doesn't set, you have to set store to make backup")
-	case StorageS3:
-		bcps, err = getBackupListS3(stg.S3)
-		if err != nil {
-			return errors.Wrap(err, "get backups from S3")
-		}
-	case StorageFilesystem:
-		bcps, err = getBackupListFS(stg.Filesystem)
-		if err != nil {
-			return errors.Wrap(err, "get backups from FS")
-		}
-	case StorageBlackHole:
+
+	bcps, err := stg.FilesList(".pbm.json")
+	if err != nil {
+		return errors.Wrap(err, "get a backups list from the storage")
 	}
 
-	err = p.archiveBackupsMeta(bcps)
+	err = p.archiveBackupsMeta()
 	if err != nil {
 		return errors.Wrap(err, "copy current backups meta")
 	}
@@ -52,7 +33,12 @@ func (p *PBM) ResyncBackupList() error {
 	}
 
 	var ins []interface{}
-	for _, v := range bcps {
+	for _, b := range bcps {
+		v := BackupMeta{}
+		err = json.Unmarshal(b, &v)
+		if err != nil {
+			return errors.Wrap(err, "unmarshal backup meta")
+		}
 		ins = append(ins, v)
 	}
 	_, err = p.Conn.Database(DB).Collection(BcpCollection).InsertMany(p.ctx, ins)
@@ -63,120 +49,23 @@ func (p *PBM) ResyncBackupList() error {
 	return nil
 }
 
-func (p *PBM) archiveBackupsMeta(bm []BackupMeta) error {
-	if len(bm) == 0 {
-		return nil
-	}
-	_, err := p.Conn.Database(DB).Collection(BcpOldCollection).InsertOne(
-		p.ctx,
-		struct {
-			CopiedAt time.Time    `bson:"copied_at"`
-			Backups  []BackupMeta `bson:"backups"`
-		}{
-			CopiedAt: time.Now().UTC(),
-			Backups:  bm,
-		},
-	)
-
-	return err
-}
-
-func getBackupListFS(stg Filesystem) ([]BackupMeta, error) {
-	files, err := ioutil.ReadDir(stg.Path)
+func (p *PBM) archiveBackupsMeta() error {
+	err := p.Conn.Database(DB).Collection(BcpOldCollection).Drop(p.ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "read dir")
+		return errors.Wrap(err, "remove old archive")
 	}
 
-	var bcps []BackupMeta
-	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-
-		fpath := path.Join(stg.Path, f.Name())
-		data, err := ioutil.ReadFile(fpath)
+	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(p.ctx, bson.M{})
+	if err != nil {
+		return errors.Wrap(err, "get current meta")
+	}
+	for cur.Next(p.ctx) {
+		_, err = p.Conn.Database(DB).Collection(BcpOldCollection).InsertOne(p.ctx, cur.Current)
 		if err != nil {
-			return nil, errors.Wrapf(err, "read file '%s'", fpath)
+			return errors.Wrap(err, "insert")
 		}
 
-		m := BackupMeta{}
-		err = json.Unmarshal(data, &m)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal file '%s'", fpath)
-		}
-
-		if m.Name != "" {
-			bcps = append(bcps, m)
-		}
 	}
 
-	return bcps, nil
-}
-
-func getBackupListS3(stg S3) ([]BackupMeta, error) {
-	awsSession, err := session.NewSession(&aws.Config{
-		Region:   aws.String(stg.Region),
-		Endpoint: aws.String(stg.EndpointURL),
-		Credentials: credentials.NewStaticCredentials(
-			stg.Credentials.AccessKeyID,
-			stg.Credentials.SecretAccessKey,
-			"",
-		),
-		S3ForcePathStyle: aws.Bool(true),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "create AWS session")
-	}
-
-	lparams := &s3.ListObjectsInput{
-		Bucket:    aws.String(stg.Bucket),
-		Delimiter: aws.String("/"),
-	}
-	if stg.Prefix != "" {
-		lparams.Prefix = aws.String(stg.Prefix)
-		if stg.Prefix[len(stg.Prefix)-1] != '/' {
-			*lparams.Prefix += "/"
-		}
-	}
-
-	var bcps []BackupMeta
-	awscli := s3.New(awsSession)
-	var berr error
-	err = awscli.ListObjectsPages(lparams,
-		func(page *s3.ListObjectsOutput, lastPage bool) bool {
-			for _, o := range page.Contents {
-				name := aws.StringValue(o.Key)
-				if strings.HasSuffix(name, ".pbm.json") {
-					s3obj, err := awscli.GetObject(&s3.GetObjectInput{
-						Bucket: aws.String(stg.Bucket),
-						Key:    aws.String(name),
-					})
-					if err != nil {
-						berr = errors.Wrapf(err, "get object '%s'", name)
-						return false
-					}
-
-					m := BackupMeta{}
-					err = json.NewDecoder(s3obj.Body).Decode(&m)
-					if err != nil {
-						berr = errors.Wrapf(err, "decode object '%s'", name)
-						return false
-					}
-					if m.Name != "" {
-						bcps = append(bcps, m)
-					}
-				}
-			}
-			return true
-		})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "get backup list")
-	}
-
-	if berr != nil {
-		return nil, errors.Wrap(berr, "metadata")
-	}
-
-	return bcps, nil
+	return cur.Err()
 }

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -57,7 +57,7 @@ func (p *PBM) archiveBackupsMeta() error {
 
 	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(p.ctx, bson.M{})
 	if err != nil {
-		return errors.Wrap(err, "get current meta")
+		return errors.Wrap(err, "get current backups meta")
 	}
 	for cur.Next(p.ctx) {
 		_, err = p.Conn.Database(DB).Collection(BcpOldCollection).InsertOne(p.ctx, cur.Current)

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -52,7 +52,7 @@ func (p *PBM) ResyncBackupList() error {
 func (p *PBM) archiveBackupsMeta() error {
 	err := p.Conn.Database(DB).Collection(BcpOldCollection).Drop(p.ctx)
 	if err != nil {
-		return errors.Wrap(err, "remove old archive")
+		return errors.Wrap(err, "failed to remove old archive from backups metadata")
 	}
 
 	cur, err := p.Conn.Database(DB).Collection(BcpCollection).Find(p.ctx, bson.M{})

--- a/pbm/storage/blackhole/blackhole.go
+++ b/pbm/storage/blackhole/blackhole.go
@@ -1,0 +1,30 @@
+package blackhole
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+type Blackhole struct{}
+
+func New() *Blackhole {
+	return &Blackhole{}
+}
+
+func (b *Blackhole) Save(_ string, data io.Reader) error {
+	_, err := io.Copy(ioutil.Discard, data)
+	return err
+}
+
+func (b *Blackhole) FilesList(_ string) ([][]byte, error) { return [][]byte{}, nil }
+func (b *Blackhole) Delete(name string) error             { return nil }
+
+// NopReadCloser is a no operation ReadCloser
+type NopReadCloser struct{}
+
+func (NopReadCloser) Read(b []byte) (int, error) {
+	return len(b), nil
+}
+func (NopReadCloser) Close() error { return nil }
+
+func (b *Blackhole) SourceReader(name string) (io.ReadCloser, error) { return NopReadCloser{}, nil }

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -1,0 +1,69 @@
+package fs
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type Conf struct {
+	Path string `bson:"path" json:"path" yaml:"path"`
+}
+
+type FS struct {
+	opts Conf
+}
+
+func New(opts Conf) *FS {
+	return &FS{
+		opts: opts,
+	}
+}
+
+func (fs *FS) Save(name string, data io.Reader) error {
+	filepath := path.Join(fs.opts.Path, name)
+	fw, err := os.Create(filepath)
+	if err != nil {
+		return errors.Wrapf(err, "create destination file <%s>", filepath)
+	}
+	_, err = io.Copy(fw, data)
+	return errors.Wrap(err, "write to file")
+}
+
+func (fs *FS) SourceReader(name string) (io.ReadCloser, error) {
+	filepath := path.Join(fs.opts.Path, name)
+	fr, err := os.Open(filepath)
+	return fr, errors.Wrapf(err, "open file '%s'", filepath)
+}
+
+func (fs *FS) FilesList(suffix string) ([][]byte, error) {
+	files, err := ioutil.ReadDir(fs.opts.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "read dir")
+	}
+
+	var bcps [][]byte
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), suffix) {
+			continue
+		}
+
+		fpath := path.Join(fs.opts.Path, f.Name())
+		data, err := ioutil.ReadFile(fpath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "read file '%s'", fpath)
+		}
+
+		bcps = append(bcps, data)
+	}
+
+	return bcps, nil
+}
+
+func (fs *FS) Delete(name string) error {
+	return os.Remove(path.Join(fs.opts.Path, name))
+}

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -1,0 +1,237 @@
+package s3
+
+import (
+	"io"
+	"io/ioutil"
+	"net/url"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/minio/minio-go"
+	"github.com/pkg/errors"
+)
+
+const (
+	// GCSEndpointURL is the endpoint url for Google Clound Strage service
+	GCSEndpointURL = "storage.googleapis.com"
+
+	defaultS3Region = "us-east-1"
+)
+
+type Conf struct {
+	Provider    S3Provider  `bson:"provider,omitempty" json:"provider,omitempty" yaml:"provider,omitempty"`
+	Region      string      `bson:"region" json:"region" yaml:"region"`
+	EndpointURL string      `bson:"endpointUrl,omitempty" json:"endpointUrl" yaml:"endpointUrl,omitempty"`
+	Bucket      string      `bson:"bucket" json:"bucket" yaml:"bucket"`
+	Prefix      string      `bson:"prefix,omitempty" json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Credentials Credentials `bson:"credentials" json:"credentials,omitempty" yaml:"credentials"`
+}
+
+func (c *Conf) Cast() error {
+	if c.Region == "" {
+		c.Region = defaultS3Region
+	}
+	if c.Provider == S3ProviderUndef {
+		c.Provider = S3ProviderAWS
+		if c.EndpointURL != "" {
+			eu, err := url.Parse(c.EndpointURL)
+			if err != nil {
+				return errors.Wrap(err, "parse EndpointURL")
+			}
+			if eu.Host == GCSEndpointURL {
+				c.Provider = S3ProviderGCS
+			}
+		}
+	}
+
+	return nil
+}
+
+type Credentials struct {
+	AccessKeyID     string `bson:"access-key-id" json:"access-key-id,omitempty" yaml:"access-key-id,omitempty"`
+	SecretAccessKey string `bson:"secret-access-key" json:"secret-access-key,omitempty" yaml:"secret-access-key,omitempty"`
+	Vault           struct {
+		Server string `bson:"server" json:"server,omitempty" yaml:"server"`
+		Secret string `bson:"secret" json:"secret,omitempty" yaml:"secret"`
+		Token  string `bson:"token" json:"token,omitempty" yaml:"token"`
+	} `bson:"vault" json:"vault" yaml:"vault,omitempty"`
+}
+
+type S3Provider string
+
+const (
+	S3ProviderUndef S3Provider = ""
+	S3ProviderAWS   S3Provider = "aws"
+	S3ProviderGCS   S3Provider = "gcs"
+)
+
+type S3 struct {
+	opts Conf
+}
+
+func New(opts Conf) *S3 {
+	return &S3{
+		opts: opts,
+	}
+}
+
+func (s *S3) Save(name string, data io.Reader) error {
+	switch s.opts.Provider {
+	default:
+		awsSession, err := session.NewSession(&aws.Config{
+			Region:   aws.String(s.opts.Region),
+			Endpoint: aws.String(s.opts.EndpointURL),
+			Credentials: credentials.NewStaticCredentials(
+				s.opts.Credentials.AccessKeyID,
+				s.opts.Credentials.SecretAccessKey,
+				"",
+			),
+			S3ForcePathStyle: aws.Bool(true),
+		})
+		if err != nil {
+			return errors.Wrap(err, "create AWS session")
+		}
+		cc := runtime.NumCPU() / 2
+		if cc == 0 {
+			cc = 1
+		}
+		_, err = s3manager.NewUploader(awsSession, func(u *s3manager.Uploader) {
+			u.PartSize = 10 * 1024 * 1024 // 10MB part size
+			u.LeavePartsOnError = true    // Don't delete the parts if the upload fails.
+			u.Concurrency = cc
+		}).Upload(&s3manager.UploadInput{
+			Bucket: aws.String(s.opts.Bucket),
+			Key:    aws.String(path.Join(s.opts.Prefix, name)),
+			Body:   data,
+		})
+		return errors.Wrap(err, "upload to S3")
+	case S3ProviderGCS:
+		// using minio client with GCS because it
+		// allows to disable chuncks muiltipertition for upload
+		mc, err := minio.NewWithRegion(GCSEndpointURL, s.opts.Credentials.AccessKeyID, s.opts.Credentials.SecretAccessKey, true, s.opts.Region)
+		if err != nil {
+			return errors.Wrap(err, "NewWithRegion")
+		}
+		_, err = mc.PutObject(s.opts.Bucket, path.Join(s.opts.Prefix, name), data, -1, minio.PutObjectOptions{})
+		return errors.Wrap(err, "upload to GCS")
+	}
+}
+
+func (s *S3) FilesList(suffix string) ([][]byte, error) {
+	awsSession, err := session.NewSession(&aws.Config{
+		Region:   aws.String(s.opts.Region),
+		Endpoint: aws.String(s.opts.EndpointURL),
+		Credentials: credentials.NewStaticCredentials(
+			s.opts.Credentials.AccessKeyID,
+			s.opts.Credentials.SecretAccessKey,
+			"",
+		),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "create AWS session")
+	}
+
+	lparams := &s3.ListObjectsInput{
+		Bucket:    aws.String(s.opts.Bucket),
+		Delimiter: aws.String("/"),
+	}
+	if s.opts.Prefix != "" {
+		lparams.Prefix = aws.String(s.opts.Prefix)
+		if s.opts.Prefix[len(s.opts.Prefix)-1] != '/' {
+			*lparams.Prefix += "/"
+		}
+	}
+
+	var bcps [][]byte
+	var berr error
+	awscli := s3.New(awsSession)
+	err = awscli.ListObjectsPages(lparams,
+		func(page *s3.ListObjectsOutput, lastPage bool) bool {
+			for _, o := range page.Contents {
+				name := aws.StringValue(o.Key)
+				if strings.HasSuffix(name, suffix) {
+					s3obj, err := awscli.GetObject(&s3.GetObjectInput{
+						Bucket: aws.String(s.opts.Bucket),
+						Key:    aws.String(name),
+					})
+					if err != nil {
+						berr = errors.Wrapf(err, "get object '%s'", name)
+						return false
+					}
+
+					b, err := ioutil.ReadAll(s3obj.Body)
+					if err != nil {
+						berr = errors.Wrapf(err, "read object '%s'", name)
+						return false
+					}
+					bcps = append(bcps, b)
+				}
+			}
+			return true
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "get backup list")
+	}
+
+	if berr != nil {
+		return nil, errors.Wrap(berr, "metadata")
+	}
+
+	return bcps, nil
+}
+
+func (s *S3) SourceReader(name string) (io.ReadCloser, error) {
+	awsSession, err := session.NewSession(&aws.Config{
+		Region:   aws.String(s.opts.Region),
+		Endpoint: aws.String(s.opts.EndpointURL),
+		Credentials: credentials.NewStaticCredentials(
+			s.opts.Credentials.AccessKeyID,
+			s.opts.Credentials.SecretAccessKey,
+			"",
+		),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create AWS session")
+	}
+
+	s3obj, err := s3.New(awsSession).GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(s.opts.Bucket),
+		Key:    aws.String(path.Join(s.opts.Prefix, name)),
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "read '%s/%s' file from S3", s.opts.Bucket, name)
+	}
+	return ioutil.NopCloser(s3obj.Body), nil
+}
+
+func (s *S3) Delete(name string) error {
+	awsSession, err := session.NewSession(&aws.Config{
+		Region:   aws.String(s.opts.Region),
+		Endpoint: aws.String(s.opts.EndpointURL),
+		Credentials: credentials.NewStaticCredentials(
+			s.opts.Credentials.AccessKeyID,
+			s.opts.Credentials.SecretAccessKey,
+			"",
+		),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+	if err != nil {
+		return errors.Wrap(err, "cannot create AWS session")
+	}
+
+	_, err = s3.New(awsSession).DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(s.opts.Bucket),
+		Key:    aws.String(path.Join(s.opts.Prefix, name)),
+	})
+
+	return errors.Wrapf(err, "delete '%s/%s' file from S3", s.opts.Bucket, name)
+}

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -75,10 +75,15 @@ type S3 struct {
 	opts Conf
 }
 
-func New(opts Conf) *S3 {
+func New(opts Conf) (*S3, error) {
+	err := opts.Cast()
+	if err != nil {
+		return nil, errors.Wrap(err, "cast options")
+	}
+
 	return &S3{
 		opts: opts,
-	}
+	}, nil
 }
 
 func (s *S3) Save(name string, data io.Reader) error {

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"io"
+)
+
+type Storage interface {
+	Save(name string, data io.Reader) error
+	SourceReader(name string) (io.ReadCloser, error)
+	FilesList(suffix string) ([][]byte, error)
+	Delete(name string) error
+}

--- a/speedt/speedt.go
+++ b/speedt/speedt.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 func init() {
@@ -127,7 +128,7 @@ func genData(b []byte) {
 
 const fileName = "pbmSpeedTest"
 
-func Run(nodeCN *mongo.Client, stg pbm.Storage, compression pbm.CompressionType, sizeGb float64, collection string) (*Results, error) {
+func Run(nodeCN *mongo.Client, stg storage.Storage, compression pbm.CompressionType, sizeGb float64, collection string) (*Results, error) {
 	var src backup.Source
 	var err error
 	if collection != "" {


### PR DESCRIPTION
`pbm delete-backup 2020-04-20T13:38:55Z` deletes specified backup

`pbm delete-backup --older-than 2020-04-20T13:13:20Z` deletes all backups that was made before specified. The argument is a backup name from `pbm list`. Specified backup is NOT being deleted in that case, only preceding backups. E.g.:
```
$ pbm list
Backup history:
  2020-04-20T10:55:42Z
  2020-04-20T13:07:34Z
  2020-04-20T13:13:20Z
$ pbm delete-backup -f --older-than 2020-04-20T13:13:20Z
Backup history:
  2020-04-20T13:13:20Z
```

By default delete-backup asks confirmation:
```
$ pbm delete-backup 2020-04-20T13:45:59Z
Are you shure you want delete backup(s)? [y/N]
```

Confirmation can be disabled by adding the flag `--force` or `-f`

Also, backup can be deleted only if it is NOT running (i.e. state is "done" or "error").
```
$ pbm delete-backup 2020-04-20T13:45:59Z
Are you shure you want delete backup(s)? [y/N] y
Error: Unable to delete backup in running state
```
