### PR TITLE
PBM-429 Log mongodump progress

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"log"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -589,8 +588,18 @@ func newDump(curi string, conns int) *mdump {
 	}
 }
 
+// "logger" for the mongodup's ProgressManager.
+// need it to be able to write new progress data in a new line
+type progressWriter struct{}
+
+func (*progressWriter) Write(m []byte) (int, error) {
+	log.Printf("%s", m)
+	return len(m), nil
+}
+
 // Write always return 0 as written bytes. Needed to satisfy interface
 func (d *mdump) WriteTo(w io.Writer) (int64, error) {
+	pm := progress.NewBarWriter(&progressWriter{}, time.Second*60, 24, false)
 	mdump := mongodump.MongoDump{
 		ToolOptions: d.opts,
 		OutputOptions: &mongodump.OutputOptions{
@@ -603,13 +612,16 @@ func (d *mdump) WriteTo(w io.Writer) (int64, error) {
 		InputOptions:    &mongodump.InputOptions{},
 		SessionProvider: &db.SessionProvider{},
 		OutputWriter:    w,
-		ProgressManager: progress.NewBarWriter(os.Stdout, time.Second*3, 24, false),
+		ProgressManager: pm,
 	}
 	err := mdump.Init()
 	if err != nil {
 		return 0, errors.Wrap(err, "init")
 	}
-	return 0, errors.Wrap(mdump.Dump(), "make dump")
+	pm.Start()
+	err = mdump.Dump()
+	pm.Stop()
+	return 0, errors.Wrap(err, "make dump")
 }
 
 func getDstName(typ string, bcp pbm.BackupCmd, rsName string) string {

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -619,8 +619,10 @@ func (d *mdump) WriteTo(w io.Writer) (int64, error) {
 		return 0, errors.Wrap(err, "init")
 	}
 	pm.Start()
+	defer pm.Stop()
+
 	err = mdump.Dump()
-	pm.Stop()
+
 	return 0, errors.Wrap(err, "make dump")
 }
 


### PR DESCRIPTION
It's going to look something like that
```
2020/05/06 21:31:12 Backup 2020-05-06T18:31:12Z started on node rs2/localhost:28018
2020-05-06T21:31:14.797+0300	writing admin.system.users to archive on stdout
2020-05-06T21:31:14.799+0300	done dumping admin.system.users (2 documents)
2020-05-06T21:31:14.800+0300	writing admin.system.roles to archive on stdout
2020-05-06T21:31:14.807+0300	done dumping admin.system.roles (1 document)
2020-05-06T21:31:14.807+0300	writing admin.system.version to archive on stdout
2020-05-06T21:31:14.815+0300	done dumping admin.system.version (3 documents)
2020-05-06T21:31:14.816+0300	writing test.testt to archive on stdout
2020-05-06T21:31:14.829+0300	writing test.testt2 to archive on stdout
2020-05-06T21:31:14.829+0300	writing config.cache.chunks.config.system.sessions to archive on stdout
2020-05-06T21:31:14.832+0300	done dumping config.cache.chunks.config.system.sessions (1 document)
2020-05-06T21:31:14.834+0300	writing config.cache.collections to archive on stdout
2020-05-06T21:31:14.835+0300	done dumping config.cache.collections (1 document)
2020/05/06 21:31:24 [##......................]   test.testt  130841/1073901  (12.2%)
2020/05/06 21:31:24 [##########..............]  test.testt2   131370/300000  (43.8%)
2020/05/06 21:31:24 
2020/05/06 21:31:34 [#####...................]   test.testt  249603/1073901  (23.2%)
2020/05/06 21:31:34 [###################.....]  test.testt2   249603/300000  (83.2%)
2020/05/06 21:31:34 
2020/05/06 21:31:37 [########################]  test.testt2  300000/300000  (100.0%)
2020-05-06T21:31:39.363+0300	done dumping test.testt2 (300000 documents)
2020/05/06 21:31:44 [#########...............]  test.testt  433521/1073901  (40.4%)
2020/05/06 21:31:54 [##############..........]  test.testt  656850/1073901  (61.2%)
2020/05/06 21:32:04 [###################.....]  test.testt  893316/1073901  (83.2%)
2020/05/06 21:32:12 [########################]  test.testt  1073901/1073901  (100.0%)
2020-05-06T21:32:12.981+0300	done dumping test.testt (1073901 documents)
2020/05/06 21:32:13 mongodump finished, waiting for the oplog
2020/05/06 21:32:15 Backup 2020-05-06T18:31:12Z finished
```