### PR TITLE
PBM-520 fix: backup's meta should be unique

### DIFF
--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -5,10 +5,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/restore"
-	"github.com/pkg/errors"
 )
 
 type currentBackup struct {


### PR DESCRIPTION
If some node is lagging after it received backup command it may "wake up" after the backup, in fact, was already done. But the node will try to make a new one. Which in turn will create a mess.

1. Backup's meta collection now has a unique index by backup name. So trying to create "a new" meta will result in an error and this redundant attempt will fail. But this prevents only the leader node from starting the backup

2. We also should prevent lagging nodes from spoiling a valid backup meta with the errors of a failed attempt. For that, some extra checks have been added to the change meta status procedure.

Fix https://jira.percona.com/browse/PBM-520