### PR TITLE
PBM-535 fix: PITR failed to properly define the starting point

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -273,7 +273,9 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 		}
 	}
 
-	return nil
+	// to be sure the locks released only after the "done" status had written
+	err = b.waitForStatus(bcp.Name, pbm.StatusDone)
+	return errors.Wrap(err, "waiting for done")
 }
 
 const maxReplicationLagTimeSec = 21


### PR DESCRIPTION
After the backups (snapshot) was sucessfully done on all agents the leader agent changes the status in metadata to done. The issue is that the rest of agents don't wait for the meta to be updated before they finish the job and release their locks. It wasn't an issue before.

But with PITR it may happen that
1. The node release the lock before the status in meta was updated.
2. PITR process on the same RS acquires the lock and start pitr.Catchup() process while the status for the recent backup still hadn't updated.
4. Catchup observes the recent backup as still yet not finished and defines the starting point as the last PITR chunk before the backup.

At least the leader's RS would define the last backup as the starting point (its lock gonna be released only after the meta was updated). Therefore replicasets would have unaligned PITR timelines connected to the latest backup. Hence PBM wouldn't be able to converge such timelines and will exclude them from PITR restore range.

As the fix, now all agents are waiting for the meta to be updated with "done" status by the leader before releasing their locks.