### PR TITLE
PBM-551 fix: unify log timezones and date/time format

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,7 +57,7 @@ func (a *Agent) Start() error {
 	for {
 		select {
 		case cmd := <-c:
-			a.log.Printf("Got command %s", cmd)
+			a.log.Printf("got command %s", cmd)
 			switch cmd.Cmd {
 			case pbm.CmdBackup:
 				// backup runs in the go-routine so it can be canceled

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2,13 +2,13 @@ package agent
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/version"
 )
 
 type Agent struct {
@@ -44,17 +44,20 @@ func (a *Agent) InitLogger(cn *pbm.PBM) {
 
 // Start starts listening the commands stream.
 func (a *Agent) Start() error {
-	log.Printf("node: %s", a.node.ID())
+	a.log.Printf("pbm-agent:\n\t%s", version.DefaultInfo.All(""))
+	a.log.Printf("node: %s", a.node.ID())
 
 	c, cerr, err := a.pbm.ListenCmd()
 	if err != nil {
 		return err
 	}
 
+	a.log.Printf("listening for the commands")
+
 	for {
 		select {
 		case cmd := <-c:
-			log.Printf("Got command %s [%v]", cmd.Cmd, cmd)
+			a.log.Printf("Got command %s", cmd)
 			switch cmd.Cmd {
 			case pbm.CmdBackup:
 				// backup runs in the go-routine so it can be canceled
@@ -84,7 +87,7 @@ func (a *Agent) Start() error {
 	}
 }
 
-// ResyncBackupList uploads a backup list from the remote store
+// ResyncStorage uploads a backup list from the remote store
 func (a *Agent) ResyncStorage() {
 	nodeInfo, err := a.node.GetInfo()
 	if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -26,6 +26,12 @@ const (
 	intentBackup
 )
 
+func New(pbm *pbm.PBM) *Agent {
+	return &Agent{
+		pbm: pbm,
+	}
+}
+
 func (a *Agent) AddNode(ctx context.Context, curi string) (err error) {
 	a.node, err = pbm.NewNode(ctx, curi)
 	return err

--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -64,7 +64,10 @@ func (a *Agent) wakeupPitr() {
 
 const pitrCheckPeriod = time.Second * 15
 
+// PITR starts PITR prcessing routine
 func (a *Agent) PITR() {
+	a.log.Printf("starting PITR routine")
+
 	tk := time.NewTicker(pitrCheckPeriod)
 	defer tk.Stop()
 	for range tk.C {

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -17,12 +17,6 @@ type currentBackup struct {
 	cancel context.CancelFunc
 }
 
-func New(pbm *pbm.PBM) *Agent {
-	return &Agent{
-		pbm: pbm,
-	}
-}
-
 func (a *Agent) setBcp(b *currentBackup) (changed bool) {
 	a.mx.Lock()
 	defer a.mx.Unlock()

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -67,10 +67,7 @@ func runAgent(mongoURI string) error {
 	}
 	agnt.InitLogger(pbmClient)
 
-	log.Println("pbm-agent", version.DefaultInfo.All(""))
-	log.Println("starting pitr routine")
 	go agnt.PITR()
 
-	log.Println("listening for the commands")
 	return errors.Wrap(agnt.Start(), "listen the commands stream")
 }

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -11,9 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/version"
-
 	"github.com/mongodb/mongo-tools-common/db"
+	mlog "github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools-common/progress"
 	"github.com/mongodb/mongo-tools/mongodump"
@@ -24,7 +23,16 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/version"
 )
+
+func init() {
+	// set date format for mongo tools (mongodump/mongorestore) logger
+	//
+	// duplicated in backup/restore packages just
+	// in the sake of clarity
+	mlog.SetDateFormat(pbm.LogTimeFormat)
+}
 
 type Backup struct {
 	cn   *pbm.PBM

--- a/pbm/log.go
+++ b/pbm/log.go
@@ -31,7 +31,7 @@ type LogEntry struct {
 }
 
 // LogTimeFormat is a date-time format to be displayed in the log output
-const LogTimeFormat = "2006/01/02 15:04:05"
+const LogTimeFormat = "2006-01-02T15:04:05.000-0700"
 
 func (e *LogEntry) formatTS() string {
 	return time.Unix(e.TS, 0).Local().Format(LogTimeFormat)
@@ -95,6 +95,10 @@ func (l *Logger) output(typ EntryType, action Command, obj, msg string, args ...
 	if err != nil {
 		log.Printf("[ERROR] wrting log: %v, entry: %s", err, e)
 	}
+}
+
+func (l *Logger) Printf(msg string, args ...interface{}) {
+	l.output(TypeInfo, CmdUndefined, "", msg, args...)
 }
 
 func (l *Logger) Info(action Command, obj, msg string, args ...interface{}) {

--- a/pbm/log.go
+++ b/pbm/log.go
@@ -21,6 +21,7 @@ type Logger struct {
 
 type LogEntry struct {
 	TS      int64     `bson:"ts" json:"ts"`
+	TZone   int       `bson:"tz" json:"tz"`
 	RS      string    `bson:"rs" json:"rs"`
 	Node    string    `bson:"node" json:"node"`
 	Type    EntryType `bson:"type" json:"type"`
@@ -29,10 +30,11 @@ type LogEntry struct {
 	Msg     string    `bson:"msg" json:"msg"`
 }
 
-const logTimeFormat = "2006/01/02 15:04:05"
+// LogTimeFormat is a date-time format to be displayed in the log output
+const LogTimeFormat = "2006/01/02 15:04:05"
 
 func (e *LogEntry) formatTS() string {
-	return time.Unix(e.TS, 0).UTC().Format(logTimeFormat)
+	return time.Unix(e.TS, 0).Local().Format(LogTimeFormat)
 }
 
 func (e *LogEntry) String() (s string) {
@@ -77,8 +79,10 @@ func (l *Logger) output(typ EntryType, action Command, obj, msg string, args ...
 	if len(args) > 0 {
 		msg = fmt.Sprintf(msg, args...)
 	}
+	_, tz := time.Now().Local().Zone()
 	e := &LogEntry{
 		TS:      time.Now().UTC().Unix(),
+		TZone:   tz,
 		RS:      l.rs,
 		Node:    l.node,
 		Type:    typ,

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -1,8 +1,11 @@
 package pbm
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -69,9 +72,37 @@ type Cmd struct {
 	TS         int64         `bson:"ts"`
 }
 
+func (c Cmd) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(string(c.Cmd))
+	switch c.Cmd {
+	case CmdBackup:
+		buf.WriteString(" [")
+		buf.WriteString(c.Backup.String())
+		buf.WriteString("]")
+	case CmdRestore:
+		buf.WriteString(" [")
+		buf.WriteString(c.Restore.String())
+		buf.WriteString("]")
+	case CmdPITRestore:
+		buf.WriteString(" [")
+		buf.WriteString(c.PITRestore.String())
+		buf.WriteString("]")
+	}
+	buf.WriteString(" <ts: ")
+	buf.WriteString(strconv.FormatInt(c.TS, 10))
+	buf.WriteString(">")
+	return buf.String()
+}
+
 type BackupCmd struct {
 	Name        string          `bson:"name"`
 	Compression CompressionType `bson:"compression"`
+}
+
+func (b BackupCmd) String() string {
+	return fmt.Sprintf("name: %s, compression: %s", b.Name, b.Compression)
 }
 
 type RestoreCmd struct {
@@ -79,9 +110,17 @@ type RestoreCmd struct {
 	BackupName string `bson:"backupName"`
 }
 
+func (r RestoreCmd) String() string {
+	return fmt.Sprintf("name: %s, backup name: %s", r.Name, r.BackupName)
+}
+
 type PITRestoreCmd struct {
 	Name string `bson:"name"`
 	TS   int64  `bson:"ts"`
+}
+
+func (p PITRestoreCmd) String() string {
+	return fmt.Sprintf("name: %s, point-in-time ts: %d", p.Name, p.TS)
 }
 
 type CompressionType string

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongo-tools-common/db"
+	mlog "github.com/mongodb/mongo-tools-common/log"
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools/mongorestore"
 	"github.com/pkg/errors"
@@ -17,6 +18,14 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
+
+func init() {
+	// set date format for mongo tools (mongodump/mongorestore) logger
+	//
+	// duplicated in backup/restore packages just
+	// in the sake of clarity
+	mlog.SetDateFormat(pbm.LogTimeFormat)
+}
 
 var excludeFromRestore = []string{
 	pbm.DB + "." + pbm.CmdStreamCollection,

--- a/version/version.go
+++ b/version/version.go
@@ -27,11 +27,11 @@ type Info struct {
 }
 
 const plain = `Version:   %s
-Platform:  %s
-GitCommit: %s
-GitBranch: %s
-BuildTime: %s
-GoVersion: %s`
+	Platform:  %s
+	GitCommit: %s
+	GitBranch: %s
+	BuildTime: %s
+	GoVersion: %s`
 
 var DefaultInfo Info
 


### PR DESCRIPTION
Timezone across the log unified to the **_local format_** (not UTC) as there is no way to change that option for the mongo-tools (mongodump/mongorestre) logger.

Also, data/time format changed to be consistent across the logs.

For example

was
```
2020/09/18 15:12:55 [INFO] backup/2020-09-18T12:12:38Z: backup started
2020-09-18T15:12:58.0001+0300	writing admin.system.users to archive on stdout
2020-09-18T15:12:58.0001+0300	done dumping admin.system.users (2 documents)
2020-09-18T15:12:58.0001+0300	done dumping config.migrations (0 documents)
2020/09/18 15:12:58 [INFO] backup/2020-09-18T12:12:38Z: mongodump finished, waiting for the oplog
```

now
```
2020-09-23T17:13:11.000+0300 [INFO] backup/2020-09-23T14:12:54Z: backup started
2020-09-23T17:13:14.562+0300	writing admin.system.users to archive on stdout
2020-09-23T17:13:14.564+0300	done dumping admin.system.users (2 documents)
2020-09-23T17:13:19.195+0300	done dumping test.testt (1073901 documents)
2020-09-23T17:13:19.000+0300 [INFO] backup/2020-09-23T14:12:54Z: mongodump finished, waiting for the oplog
```