### PR TITLE
PBM-485 fix: Upload 100gb+ db on aws

### DIFF
--- a/pbm/node.go
+++ b/pbm/node.go
@@ -106,26 +106,16 @@ func (n *Node) GetInfo() (*NodeInfo, error) {
 	return i, nil
 }
 
-// MaxDBSize returns the size of the largest database on replicaset.
-// It is the of files on disk in bytes
-func (n *Node) MaxDBSize() (int, error) {
+// SizeDBs returns the total size in bytes of all databases' files on disk on replicaset
+func (n *Node) SizeDBs() (int, error) {
 	i := &struct {
-		Databases []struct {
-			SizeOnDisk int `bson:"sizeOnDisk"`
-		} `bson:"databases"`
+		TotalSize int `bson:"totalSize"`
 	}{}
 	err := n.cn.Database(DB).RunCommand(n.ctx, bson.D{{"listDatabases", 1}}).Decode(i)
 	if err != nil {
 		return 0, errors.Wrap(err, "run mongo command listDatabases")
 	}
-
-	sized := 0
-	for _, db := range i.Databases {
-		if db.SizeOnDisk > sized {
-			sized = db.SizeOnDisk
-		}
-	}
-	return sized, nil
+	return i.TotalSize, nil
 }
 
 // IsSharded return true if node is part of the sharded cluster (in shard or configsrv replset).

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -175,7 +175,7 @@ func (i *IBackup) Stream(ctx context.Context, wakeupSig <-chan struct{}, to stor
 		oplog.SetTailingSpan(i.lastTS, sliceTo)
 		fname := i.chunkPath(i.lastTS, sliceTo, compression)
 		// if use parent ctx, upload will be canceled on the "done" signal
-		_, err = backup.Upload(context.Background(), oplog, to, compression, fname)
+		_, err = backup.Upload(context.Background(), oplog, to, compression, fname, -1)
 		if err != nil {
 			return errors.Wrapf(err, "unable to upload chunk %v.%v", i.lastTS.T, sliceTo.T)
 		}

--- a/pbm/storage/blackhole/blackhole.go
+++ b/pbm/storage/blackhole/blackhole.go
@@ -11,7 +11,7 @@ func New() *Blackhole {
 	return &Blackhole{}
 }
 
-func (*Blackhole) Save(_ string, data io.Reader) error {
+func (*Blackhole) Save(_ string, data io.Reader, _ int) error {
 	_, err := io.Copy(ioutil.Discard, data)
 	return err
 }

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -27,7 +27,7 @@ func New(opts Conf) *FS {
 	}
 }
 
-func (fs *FS) Save(name string, data io.Reader) error {
+func (fs *FS) Save(name string, data io.Reader, _ int) error {
 	filepath := path.Join(fs.opts.Path, name)
 
 	err := os.MkdirAll(path.Dir(filepath), os.ModeDir|0775)

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -9,7 +9,7 @@ import (
 var ErrNotExist = errors.New("no such file")
 
 type Storage interface {
-	Save(name string, data io.Reader) error
+	Save(name string, data io.Reader, size int) error
 	SourceReader(name string) (io.ReadCloser, error)
 	// CheckFile checks if file/object exists and isn't empty
 	CheckFile(name string) error

--- a/speedt/speedt.go
+++ b/speedt/speedt.go
@@ -142,7 +142,7 @@ func Run(nodeCN *mongo.Client, stg storage.Storage, compression pbm.CompressionT
 
 	r := &Results{}
 	ts := time.Now()
-	size, err := backup.Upload(context.Background(), src, stg, compression, fileName)
+	size, err := backup.Upload(context.Background(), src, stg, compression, fileName, -1)
 	r.Size = Byte(size)
 	if err != nil {
 		return nil, errors.Wrap(err, "upload")


### PR DESCRIPTION
MaxUploadParts is 1e4 so with PartSize 10Mb the max allowed file size would be ~ 97.6Gb. Hence if the file size is bigger we're enlarging PartSize so PartSize * MaxUploadParts could fit the file. If calculated PartSize is smaller than the default we leave the default.
If UploadPartSize option was set we use it instead of the default. Even with the UploadPartSize set the calculated PartSize woulbe used if it's bigger.

If backup won't be compressed we're assuming that the dump size could be up to 4x lagrer due to mongo's wieredtiger compression. Otherwise, we assume that it would 
be covered by our compression. But in any case, there is an extra 10% gap while calculating chunk size.