### PR TITLE
PBM-547 fix: move delete ops to agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -145,7 +145,8 @@ func (a *Agent) Delete(d pbm.DeleteBackupCmd) {
 		}
 		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "done")
 	default:
-		a.log.Error(pbm.CmdDeleteBackup, "", "malformed command: %v", d)
+		a.log.Error(pbm.CmdDeleteBackup, "", "malformed command received in Delete() of backup: %v", d)
+
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -128,18 +128,19 @@ func (a *Agent) Delete(d pbm.DeleteBackupCmd) {
 	case d.OlderThan > 0:
 		t := time.Unix(d.OlderThan, 0).UTC()
 		tstr := t.Format("2006-01-02T15:04:05Z")
-		a.log.Info(pbm.CmdDeleteBackup, tstr, "deleteing backups older than %v", t)
+		a.log.Info(pbm.CmdDeleteBackup, tstr, "deleting backups older than %v", t)
 		err := a.pbm.DeleteOlderThan(t)
 		if err != nil {
-			a.log.Error(pbm.CmdDeleteBackup, tstr, "deleteing: %v", err)
+			a.log.Error(pbm.CmdDeleteBackup, tstr, "deleting: %v", err)
 			return
 		}
 		a.log.Info(pbm.CmdDeleteBackup, tstr, "done")
 	case d.Backup != "":
-		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "deleteing backup")
+		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "deleting backup")
 		err := a.pbm.DeleteBackup(d.Backup)
 		if err != nil {
-			a.log.Error(pbm.CmdDeleteBackup, d.Backup, "deleteing: %v", err)
+			a.log.Error(pbm.CmdDeleteBackup, d.Backup, "deleting: %v", err)
+
 			return
 		}
 		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "done")

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -70,6 +70,8 @@ func (a *Agent) Start() error {
 				a.ResyncStorage()
 			case pbm.CmdPITRestore:
 				a.PITRestore(cmd.PITRestore)
+			case pbm.CmdDeleteBackup:
+				a.Delete(cmd.Delete)
 			}
 		case err := <-cerr:
 			switch err.(type) {
@@ -84,6 +86,54 @@ func (a *Agent) Start() error {
 				a.log.Error(pbm.CmdUndefined, "", "listening commands: %v", err)
 			}
 		}
+	}
+}
+
+// Delete deletes backup(s) from the store and cleans up its metadata
+func (a *Agent) Delete(d pbm.DeleteBackupCmd) {
+	lock := a.pbm.NewLock(pbm.LockHeader{
+		Replset: a.node.RS(),
+		Node:    a.node.Name(),
+		Type:    pbm.CmdDeleteBackup,
+	})
+
+	got, err := a.aquireLock(lock, nil)
+	if err != nil {
+		a.log.Error(pbm.CmdDeleteBackup, "", "acquire lock: %v", err)
+		return
+	}
+	if !got {
+		a.log.Info(pbm.CmdDeleteBackup, "", "scheduled to another node")
+		return
+	}
+	defer func() {
+		err := lock.Release()
+		if err != nil {
+			a.log.Error(pbm.CmdDeleteBackup, "", "release lock: %v", err)
+		}
+	}()
+
+	switch {
+	case d.OlderThan > 0:
+		t := time.Unix(d.OlderThan, 0).UTC()
+		tstr := t.Format("2006-01-02T15:04:05Z")
+		a.log.Info(pbm.CmdDeleteBackup, tstr, "deleteing backups older than %v", t)
+		err := a.pbm.DeleteOlderThan(t)
+		if err != nil {
+			a.log.Error(pbm.CmdDeleteBackup, tstr, "deleteing: %v", err)
+			return
+		}
+		a.log.Info(pbm.CmdDeleteBackup, tstr, "done")
+	case d.Backup != "":
+		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "deleteing backup")
+		err := a.pbm.DeleteBackup(d.Backup)
+		if err != nil {
+			a.log.Error(pbm.CmdDeleteBackup, d.Backup, "deleteing: %v", err)
+			return
+		}
+		a.log.Info(pbm.CmdDeleteBackup, d.Backup, "done")
+	default:
+		a.log.Error(pbm.CmdDeleteBackup, "", "malformed command: %v", d)
 	}
 }
 

--- a/pbm/lock.go
+++ b/pbm/lock.go
@@ -41,12 +41,22 @@ type Lock struct {
 // NewLock creates a new Lock object from geven header. Returned lock has no state.
 // So Acquire() and Release() methods should be called.
 func (p *PBM) NewLock(h LockHeader) *Lock {
+	return p.newLock(h, LockCollection)
+}
+
+// NewLockCol creates a new Lock object from geven header in given collection.
+// Returned lock has no state. So Acquire() and Release() methods should be called.
+func (p *PBM) NewLockCol(h LockHeader, collection string) *Lock {
+	return p.newLock(h, collection)
+}
+
+func (p *PBM) newLock(h LockHeader, col string) *Lock {
 	return &Lock{
 		LockData: LockData{
 			LockHeader: h,
 		},
 		p:        p,
-		c:        p.Conn.Database(DB).Collection(LockCollection),
+		c:        p.Conn.Database(DB).Collection(col),
 		hbRate:   time.Second * 5,
 		staleSec: StaleFrameSec,
 	}

--- a/pbm/log.go
+++ b/pbm/log.go
@@ -139,9 +139,16 @@ func (l *Logger) Output(e *LogEntry) error {
 
 // LogGet returns last log entries
 func (p *PBM) LogGet(rs string, typ EntryType, action Command, limit int64) ([]LogEntry, error) {
+	// TODO: it should be reworked along with the status implementation
+	// TODO: add indexes, make logs retrieval more flexible
+	filter := bson.D{{"type", typ}, {"action", action}}
+	if rs != "" {
+		filter = append(filter, bson.E{"rs", rs})
+	}
+
 	cur, err := p.Conn.Database(DB).Collection(LogCollection).Find(
 		p.ctx,
-		bson.D{{"rs", rs}, {"type", typ}, {"action", action}},
+		filter,
 		options.Find().SetLimit(limit).SetSort(bson.D{{"ts", -1}}),
 	)
 	if err != nil {

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -62,14 +62,16 @@ const (
 	CmdResyncBackupList Command = "resyncBcpList"
 	CmdPITR             Command = "pitr"
 	CmdPITRestore       Command = "pitrestore"
+	CmdDeleteBackup     Command = "delete"
 )
 
 type Cmd struct {
-	Cmd        Command       `bson:"cmd"`
-	Backup     BackupCmd     `bson:"backup,omitempty"`
-	Restore    RestoreCmd    `bson:"restore,omitempty"`
-	PITRestore PITRestoreCmd `bson:"pitrestore,omitempty"`
-	TS         int64         `bson:"ts"`
+	Cmd        Command         `bson:"cmd"`
+	Backup     BackupCmd       `bson:"backup,omitempty"`
+	Restore    RestoreCmd      `bson:"restore,omitempty"`
+	PITRestore PITRestoreCmd   `bson:"pitrestore,omitempty"`
+	Delete     DeleteBackupCmd `bson:"delete,omitempty"`
+	TS         int64           `bson:"ts"`
 }
 
 func (c Cmd) String() string {
@@ -121,6 +123,15 @@ type PITRestoreCmd struct {
 
 func (p PITRestoreCmd) String() string {
 	return fmt.Sprintf("name: %s, point-in-time ts: %d", p.Name, p.TS)
+}
+
+type DeleteBackupCmd struct {
+	Backup    string `bson:"backup"`
+	OlderThan int64  `bson:"olderthan"`
+}
+
+func (d DeleteBackupCmd) String() string {
+	return fmt.Sprintf("backup: %s, older than: %d", d.Backup, d.OlderThan)
 }
 
 type CompressionType string


### PR DESCRIPTION
Running deletes by “pbm” CLI might lead to issues with file permissions (file ower/group) on FS. So delete-backup operations should be executed by agents.

1. Locking

In order to run delete operations agents have to acquire locks (to decide which one is going to do the job). This means that no deletes allowed during:
1. Restores. Which is good since the user won’t able to delete backup from which restore is performing. Now that’s possible.
2. Backups. Which gives nothing since delete op refuses to do anything until the backup is either in “done” or “error” state. So the user can’t shoot in their foot deleting running backup even without locks.
3. PITR. Which again brings no value since delete op has the protection against deleting latest snapshot and derived from it pirt slices if PITR is ON.
4. Resync. Which is kinda “who cares”. If backup already synced its ok to delete it even while the other is still syncing.

So locks on delete op protect only from really bonker actions during the restore. But it’s going to really nag if PITR is running whereas user needs faffing around turning PITR off to delete something and then turning it on. No good at all.
Adding extra magic complexity to sync delete with pitr (as we do with backups during pitr) doesn’t worth it in this case.

This PR introduces non-exclusive operations' locks. Meaning that whenever such operation is running there is shouldn't be any other operation of the same type running concurrently, but the other operation is allowed. E.g. there are shouldn't be running more than one delete-backup operation but delete-backup may run along with the PITR slicing.


2. Async CLI

Having delete ops running by “pbm” CLI we have synchronous feedback to the user. Moving it to agents and yet not having status command we lose that interaction, by meaning that user has to investigate agent logs to find out if any error happened or has operation finished yet. 
To preserve synchronous feedback “pbm” CLI will wait up to 60 sec for the operation to be finished by an agent. And notify the user if the delete was finished or any execution errors happened during this timeframe. If in 60 sec operation is still in progress, CLI notify the user and return control.