### PR TITLE
PBM-558 fix: error message when PITR slicing moved to another node

### DIFF
--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -163,7 +163,12 @@ func (a *Agent) pitr() (err error) {
 
 		err := ibcp.Stream(ctx, w, stg, pbm.CompressionTypeS2)
 		if err != nil {
-			a.log.Error(pbm.CmdPITR, "", "streaming oplog: %v", err)
+			switch err.(type) {
+			case pitr.ErrOpMoved:
+				a.log.Info(pbm.CmdPITR, "", "streaming oplog: %v", err)
+			default:
+				a.log.Error(pbm.CmdPITR, "", "streaming oplog: %v", err)
+			}
 		}
 
 		a.unsetPitr()


### PR DESCRIPTION
After the backup finished and the PITR slicer is resuming its operations it may find out that operation being "stolen" by another node. That's ok. And it shouldn't write "error" in the log on that matter.

https://jira.percona.com/browse/PBM-558