### PR TITLE
PBM-537 feature: check oplog sufficient range

### DIFF
--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -124,6 +124,15 @@ func (a *Agent) Backup(bcp pbm.BackupCmd) {
 		a.log.Info(pbm.CmdBackup, bcp.Name, "backup finished")
 	}
 
+	// Update PITR "changed" option to "reset" observation by pbm list of
+	// any PITR related errors in the log since some of the errors might
+	// be fixed by the backup. If not (errors wasn't fixed by bcp) PITR will
+	// generate new errors so we won't miss anything
+	err = a.pbm.ConfigBumpPITRepoch()
+	if err != nil {
+		a.log.Warning(pbm.CmdBackup, bcp.Name, "update PITR obesrvation ts")
+	}
+
 	// In the case of fast backup (small db) we have to wait before releasing the lock.
 	// Otherwise, since the primary node waits for `WaitBackupStart*0.9` before trying to acquire the lock
 	// it might happen that the backup will be made twice:

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -185,18 +185,17 @@ func printPITR(cn *pbm.PBM, size int, full bool) {
 	for _, s := range shards {
 		if on {
 			err := pitrState(cn, s.ID, ts)
-			if err == errPITRBackup {
-				lg, err := pitrLog(cn, s.ID, cfg.PITR.Changed)
-				if err != nil {
-					log.Printf("Error: get log for shard '%s': %v", s.ID, err)
-				}
-				if lg != "" {
-					pitrErrors += fmt.Sprintf("  %s: %s\n", s.ID, lg)
-				} else if cfg.PITR.Changed <= time.Now().Add(time.Minute*-1).Unix() {
-					pitrErrors += fmt.Sprintf("  %s: PITR backup didn't started\n", s.ID)
-				}
+			if err == errPITRBackup && cfg.PITR.Changed <= time.Now().Add(time.Minute*-1).Unix() {
+				pitrErrors += fmt.Sprintf("  %s: PITR backup didn't started\n", s.ID)
 			} else if err != nil {
 				log.Printf("Error: check PITR state for shard '%s': %v", s.ID, err)
+			}
+			lg, err := pitrLog(cn, s.ID, cfg.PITR.Changed)
+			if err != nil {
+				log.Printf("Error: get log for shard '%s': %v", s.ID, err)
+			}
+			if lg != "" {
+				pitrErrors += fmt.Sprintf("  %s: %s\n", s.ID, lg)
 			}
 		}
 

--- a/pbm/backup/oplog.go
+++ b/pbm/backup/oplog.go
@@ -38,7 +38,7 @@ type ErrInsuffRange struct {
 }
 
 func (e ErrInsuffRange) Error() string {
-	return fmt.Sprintf("oplog has insufficient range, not enough data from starting point %v. Run `pbm backup` to create a valid starting point for the PITR", e.t)
+	return fmt.Sprintf("oplog has insufficient range, some records since the last saved ts %v are missing. Run `pbm backup` to create a valid starting point for the PITR", e.t)
 }
 
 // WriteTo writes an oplog slice between start and end timestamps into the given io.Writer

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -95,6 +95,16 @@ func (p *PBM) SetConfig(cfg Config) error {
 	return errors.Wrap(err, "mongo ConfigCollection UpdateOne")
 }
 
+func (p *PBM) ConfigBumpPITRepoch() error {
+	_, err := p.Conn.Database(DB).Collection(ConfigCollection).UpdateOne(
+		p.ctx,
+		bson.D{},
+		bson.M{"$set": bson.M{"pitr.changed": time.Now().Unix()}},
+	)
+
+	return errors.Wrap(err, "write to db")
+}
+
 func (p *PBM) SetConfigVar(key, val string) error {
 	if !ValidateConfigKey(key) {
 		return errors.New("invalid config key")


### PR DESCRIPTION
During the oplog slicing, before processing the first oplog record we check if oplog has sufficient range,
i.e. if there are no gaps between the ts of the last backup or slice and
the first record of the current slice. Whereas the request is >= last_saved_ts
and no monotonic increment for oplog records we can't tell
if the returned oldest record is the first since last_saved_ts or
there were other records that are now removed because of oplog collection capacity.
So after we retrieved the first record of the current slice we check if there is
at least one preceding record (basically if there is still record(s) from the previous set).
If so, we can be sure we have a contiguous history with respect to the last_saved_slice.
There's a chance of false-negative though.

We should do this check only after we retrieved the first record of the set. Otherwise,
there is a possibility some records would be erased in a time span between the check and first
recorded retrieval due to ongoing write traffic (i.e. oplog append). 

In case of error `pbm list` will display
```
...
!Failed to run PITR backup. Agent logs:
  rs2: 2020-09-29T20:07:23.000+0300 [ERROR] pitr: streaming oplog: unable to upload chunk 1601397333.1601399234: read data: oplog has insufficient range, some records since the last saved ts {1601397333 1} are missing. Run `pbm backup` to create a valid starting point for the PITR.
```

https://jira.percona.com/browse/PBM-537