### PR TITLE
PBM-547 fix locking

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -274,7 +274,7 @@ func deleteBackup(pbmClient *pbm.PBM) {
 		log.Fatalln("Error: schedule delete:", err)
 	}
 
-	fmt.Print("Waiting delete to be done ")
+	fmt.Print("Waiting for delete to be done ")
 	err = waitOp(pbmClient,
 		&pbm.LockHeader{
 			Type: pbm.CmdDeleteBackup,
@@ -324,6 +324,7 @@ var errTout = errors.Errorf("timeout reached")
 func waitOp(pbmClient *pbm.PBM, lock *pbm.LockHeader, waitFor time.Duration) error {
 	// just to be sure the check hasn't started before the lock were created
 	time.Sleep(1 * time.Second)
+	fmt.Print(".")
 
 	tmr := time.NewTimer(waitFor)
 	defer tmr.Stop()


### PR DESCRIPTION
The delete op could be finished fast enough so the other node in the RS may acquire a lock for the same operation.
It may lead to errors in logs (and in CLI) "Error: deleting: unable to delete backup in ' ' state".
Meaning the tries to delete the backup that is already has been deleted.
To prevent this races the node that finished delete has to wait some time so the lock should be held at least for 5 sec. Hence other nodes could observe this lock and abort.