### PR TITLE
PBM-559: restore: decrease batching defaults & expose it to the config

### DIFF
--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -47,6 +47,13 @@ func main() {
 	tests.ApplyConfig(storage)
 
 	tests.DeleteBallast()
+	tests.GenerateBallastData(2e7)
+	printStart("Basic Backup & Restore AWS S3")
+	tests.BackupAndRestore()
+	printDone("Basic Backup & Restore AWS S3")
+	flushStore(storage)
+
+	tests.DeleteBallast()
 	tests.GenerateBallastData(1e5)
 
 	printStart("Basic Backup & Restore AWS S3")

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -22,6 +22,7 @@ import (
 type Config struct {
 	PITR    PITRConf    `bson:"pitr" json:"pitr" yaml:"pitr"`
 	Storage StorageConf `bson:"storage" json:"storage" yaml:"storage"`
+	Restore RestoreConf `bson:"restore" json:"restore,omitempty" yaml:"restore,omitempty"`
 }
 
 // PITRConf is a Point-In-Time Recovery options
@@ -45,6 +46,12 @@ type StorageConf struct {
 	Type       StorageType `bson:"type" json:"type" yaml:"type"`
 	S3         s3.Conf     `bson:"s3,omitempty" json:"s3,omitempty" yaml:"s3,omitempty"`
 	Filesystem fs.Conf     `bson:"filesystem,omitempty" json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
+}
+
+// RestoreConf is config options for the restore
+type RestoreConf struct {
+	BatchSize           int `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
+	NumInsertionWorkers int `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
 }
 
 // ConfKeys returns valid (existing) config keys (option names)


### PR DESCRIPTION
Added config options
```
restore:
  batchSize: 500
  numInsertionWorkers: 10
```

Tests on  Mac mini:
- 3.2 GHz 6-Core Intel Core i7
- 64 GB 2667 MHz DDR4

Made for 3Gb and 20Gb datasets.
Datasets consists of ~3e6 and ~2e7 ~1Mb documents.

On both datasets memory consumption was similar.

Restore time for 3Gb dataset:
```
opt/opt       mem         restore time
100/2        275Mb            13'
100/10       269Mb            3'30"
200/10       302Mb            2"
500/10       376Mb            1'40"
2000/20      1.2Gb            1'30"
```
*`opt/opt` - `batchSize/numInsertionWorkers`