### PR TITLE
PBM-562 fit: PITR timeline merging

### DIFF
--- a/pbm/pitr_test.go
+++ b/pbm/pitr_test.go
@@ -1,6 +1,8 @@
 package pbm
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -61,79 +63,137 @@ func TestPITRTimelines(t *testing.T) {
 }
 
 func TestPITRMergeTimelines(t *testing.T) {
-	tlns := [][]Timeline{
+	var tests = []struct {
+		name   string
+		tl     [][]Timeline
+		expect []Timeline
+	}{
 		{
-			{
-				Start: 3,
-				End:   11,
+			name: "no match",
+			tl: [][]Timeline{
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
+				{
+					{Start: 1, End: 3},
+					{Start: 6, End: 14},
+					{Start: 50, End: 55},
+				},
+				{
+					{Start: 7, End: 10},
+					{Start: 12, End: 19},
+					{Start: 20, End: 26},
+					{Start: 26, End: 60},
+				},
 			},
-			{
-				Start: 14,
-				End:   19,
+			expect: []Timeline{},
+		},
+		{
+			name: "all match",
+			tl: [][]Timeline{
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
 			},
-			{
-				Start: 20,
-				End:   30,
-			},
-			{
-				Start: 42,
-				End:   100500,
+			expect: []Timeline{
+				{Start: 3, End: 6},
+				{Start: 14, End: 19},
+				{Start: 19, End: 42},
 			},
 		},
-
 		{
-			{
-				Start: 2,
-				End:   12,
+			name: "partly overlap",
+			tl: [][]Timeline{
+				{
+					{Start: 3, End: 8},
+					{Start: 14, End: 19},
+					{Start: 21, End: 42},
+				},
+				{
+					{Start: 1, End: 3},
+					{Start: 4, End: 7},
+					{Start: 19, End: 36},
+				},
+				{
+					{Start: 5, End: 8},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+				},
 			},
-			{
-				Start: 14,
-				End:   20,
-			},
-			{
-				Start: 20,
-				End:   30,
+			expect: []Timeline{
+				{Start: 5, End: 7},
+				{Start: 21, End: 36},
 			},
 		},
-
 		{
-			{
-				Start: 1,
-				End:   5,
+			name: "redundant chunks",
+			tl: [][]Timeline{
+				{
+					{Start: 3, End: 6},
+					{Start: 14, End: 19},
+					{Start: 19, End: 42},
+					{Start: 42, End: 100500},
+				},
+				{
+					{Start: 2, End: 7},
+					{Start: 7, End: 8},
+					{Start: 8, End: 10},
+					{Start: 14, End: 20},
+					{Start: 20, End: 30},
+				},
+				{
+					{Start: 1, End: 5},
+					{Start: 13, End: 19},
+					{Start: 20, End: 30},
+				},
 			},
-			{
-				Start: 13,
-				End:   19,
-			},
-			{
-				Start: 20,
-				End:   30,
+			expect: []Timeline{
+				{Start: 3, End: 5},
+				{Start: 14, End: 19},
+				{Start: 20, End: 30},
 			},
 		},
 	}
 
-	should := []Timeline{
-		{
-			Start: 3,
-			End:   5,
-		},
-		{
-			Start: 14,
-			End:   19,
-		},
-		{
-			Start: 20,
-			End:   30,
-		},
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MergeTimelines(test.tl...)
+			if len(test.expect) != len(got) {
+				t.Fatalf("wrong timelines, exepct <%d> %v, got <%d> %v", len(test.expect), printttl(test.expect...), len(got), printttl(got...))
+			}
+			for i, gl := range got {
+				if test.expect[i] != gl {
+					t.Errorf("wrong timeline %d, exepct %v, got %v", i, printttl(test.expect[i]), printttl(gl))
+				}
+			}
+		})
+	}
+}
+
+func printttl(tlns ...Timeline) string {
+	ret := []string{}
+	for _, t := range tlns {
+		ret = append(ret, fmt.Sprintf("[%v - %v]", t.Start, t.End))
 	}
 
-	got := MergeTimelines(tlns...)
-	if len(should) != len(got) {
-		t.Fatalf("wrong timelines, exepct [%d] %v, got [%d] %v", len(should), should, len(got), got)
-	}
-	for i, gl := range got {
-		if should[i] != gl {
-			t.Errorf("wrong timeline %d, exepct %v, got %v", i, should[i], gl)
-		}
-	}
+	return strings.Join(ret, ", ")
 }


### PR DESCRIPTION
Merging of the PITR timelines from replicates relies on the assumption that RSs are making progress and stops altogether. And if some node fails and then resumes it'll catchup. I.e. there is no gap in timelines possible. But that is the false assumption.
In fact, we can have a station when one more RS stopped slicing while another node(s) making progress. And then after the backup, all nodes resume slicing starting from the backup's end_time leaving the gap in timelines on the RS that had been failed.

This commit changes the algorithm from comparing only timelines with the same index to grinding thru all timelines on other replica sets searching for overlapping ones.