### PR TITLE
PBM-563: update tests to reflect latest changes

### DIFF
--- a/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
+++ b/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
@@ -26,7 +26,7 @@ func (c *Cluster) BackupCancellation(storage string) {
 		log.Fatalf("Error: cancel backup '%s'.\nOutput: %s\nStderr:%v", bcpName, o, err)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	checkNoBackupFiles(bcpName, storage)
 

--- a/pbm/lock.go
+++ b/pbm/lock.go
@@ -222,6 +222,10 @@ func (p *PBM) GetLockData(lh *LockHeader) (LockData, error) {
 	return p.getLockData(lh, p.Conn.Database(DB).Collection(LockCollection))
 }
 
+func (p *PBM) GetOpLockData(lh *LockHeader) (LockData, error) {
+	return p.getLockData(lh, p.Conn.Database(DB).Collection(LockOpCollection))
+}
+
 func (p *PBM) getLockData(lh *LockHeader, cl *mongo.Collection) (LockData, error) {
 	var l LockData
 	r := cl.FindOne(p.ctx, lh)
@@ -234,6 +238,10 @@ func (p *PBM) getLockData(lh *LockHeader, cl *mongo.Collection) (LockData, error
 
 func (p *PBM) GetLocks(lh *LockHeader) ([]LockData, error) {
 	return p.getLocks(lh, p.Conn.Database(DB).Collection(LockCollection))
+}
+
+func (p *PBM) GetOpLocks(lh *LockHeader) ([]LockData, error) {
+	return p.getLocks(lh, p.Conn.Database(DB).Collection(LockOpCollection))
 }
 
 func (p *PBM) getLocks(lh *LockHeader, cl *mongo.Collection) ([]LockData, error) {


### PR DESCRIPTION
Namely changes in the delete procedure because now it has a different locking flow.

https://jira.percona.com/browse/PBM-563