### PR TITLE
Fix version info layout for CLI

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -44,7 +44,7 @@ func (a *Agent) InitLogger(cn *pbm.PBM) {
 
 // Start starts listening the commands stream.
 func (a *Agent) Start() error {
-	a.log.Printf("pbm-agent:\n\t%s", version.DefaultInfo.All(""))
+	a.log.Printf("pbm-agent:\n%s", version.DefaultInfo.All(""))
 	a.log.Printf("node: %s", a.node.ID())
 
 	c, cerr, err := a.pbm.ListenCmd()

--- a/version/version.go
+++ b/version/version.go
@@ -27,11 +27,11 @@ type Info struct {
 }
 
 const plain = `Version:   %s
-	Platform:  %s
-	GitCommit: %s
-	GitBranch: %s
-	BuildTime: %s
-	GoVersion: %s`
+Platform:  %s
+GitCommit: %s
+GitBranch: %s
+BuildTime: %s
+GoVersion: %s`
 
 var DefaultInfo Info
 


### PR DESCRIPTION
CLI:
```
 $ pbm version
Version:   1.3.2
Platform:  darwin/amd64
GitCommit: 184ef918a2535e90b612cfc325b7c29deedffeb5
GitBranch: main
BuildTime: 2020-10-12_17:01_UTC
GoVersion: go1.14.5
```

Logs
```
2020-10-12T20:03:16.000+0300 [INFO] pbm-agent:
Version:   1.3.2
Platform:  darwin/amd64
GitCommit: 184ef918a2535e90b612cfc325b7c29deedffeb5
GitBranch: main
BuildTime: 2020-10-12_17:01_UTC
GoVersion: go1.14.5
2020-10-12T20:03:16.000+0300 [INFO] starting PITR routine
2020-10-12T20:03:16.000+0300 [INFO] node: rs1/localhost:37019
...
```