### PR TITLE
PBM-570 A config file options page

### DIFF
--- a/doc/source/.res/code-block/bash/#pbm-backup-mongodb-uri.txt#
+++ b/doc/source/.res/code-block/bash/#pbm-backup-mongodb-uri.txt#
@@ -1,3 +1,0 @@
-.. code-block:: bash
-
-   $ pbm backup --mongodb-uri="mongodb://pbmuser@secretpwd@localhost:27017/"

--- a/doc/source/.res/code-block/mongo/db-createuser.txt
+++ b/doc/source/.res/code-block/mongo/db-createuser.txt
@@ -1,5 +1,5 @@
 
-.. code-block:: guess
+.. code-block:: javascript
 
    db.getSiblingDB("admin").createRole({ "role": "pbmAnyAction",
          "privileges": [

--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -94,6 +94,6 @@ backup there is one metadata file. For each replicaset in the backup:
     
 The end time of the oplog slice(s) is the data-consistent point in time of a backup snapshot.
 
-For details about supported backup storages, see :ref:`storage.config`.
+For details about supported backup storage, see :ref:`storage.config`.
 
 .. include:: .res/replace.txt

--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -94,4 +94,6 @@ backup there is one metadata file. For each replicaset in the backup:
     
 The end time of the oplog slice(s) is the data-consistent point in time of a backup snapshot.
 
+For details about supported backup storages, see :ref:`storage.config`.
+
 .. include:: .res/replace.txt

--- a/doc/source/configuration-options.rst
+++ b/doc/source/configuration-options.rst
@@ -1,0 +1,178 @@
+.. _pbm.config.options:
+
+Configuration file options
+********************************************************************************
+
+This page describes configuration file options available in |PBM|. For how to use configuration file, see :ref:`pbm.config`.
+
+.. contents::
+   :local:
+
+.. _pbm.storage.config.options:
+
+Remote backup storage options
+============================================================================
+
+|PBM| supports two types of remote storages: S3-compatible storages and filesystem. |PBM| should work with other S3-compatible storages but was only tested with the following ones: 
+
+- `Amazon Simple Storage Service <https://docs.aws.amazon.com/s3/index.html>`_, 
+- `Google Cloud Storage <https://cloud.google.com/storage>`_, 
+- `MinIO <https://min.io/>`_.
+
+S3 type storage options
+-------------------------------------------------------------------------------
+
+.. code-block:: yaml
+
+   storage:
+     type: s3
+     s3:
+       region: <string>
+       bucket: <string>
+       prefix: <string>
+       credentials:
+         access-key-id: <your-access-key-id-here>
+         secret-access-key: <your-secret-key-here>
+       serverSideEncryption:
+         sseAlgorithm: aws:kms
+         kmsKeyID: <your-kms-key-here>
+
+.. option:: storage.s3.provider
+   
+   :type: string
+   :required: NO
+   
+   The storage provider's name. Supported values: aws, gcs
+   
+.. option:: storage.s3.bucket
+  
+   :type: string
+   :required: YES
+
+   The name of the storage :term:`bucket <Bucket>`. See the `AWS Bucket naming rules <https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules>`_ and `GCS bucket naming guidelines <https://cloud.google.com/storage/docs/naming-buckets#requirements>`_ for bucket name requirements
+
+.. option:: storage.s3.region
+
+   :type: string
+   :required: YES (for AWS and GCS)
+  
+   The location of the storage bucket. 
+   Use the `AWS region list <https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region>`_ and `GCS region list <https://cloud.google.com/storage/docs/locations>`_ to define the bucket region
+   
+.. option:: storage.s3.prefix
+
+   :type: string
+   :required: NO
+   
+   The path to the data directory on the bucket. If undefined, backups are stored in the bucket root directory
+
+.. option:: storage.s3.endpointUrl
+
+   :type: string
+   :required: YES (for MinIO and GCS)
+   
+
+   The URL to access the bucket. The default value for GCS is ``https://storage.googleapis.com``
+
+.. option:: storage.s3.credentials.access-key-id
+
+   :type: string
+   :required: YES
+   
+   Your access key to the storage bucket
+   
+.. option:: storage.s3.credentials.secret-access-key
+
+  :type: string
+  :required: YES
+  
+  The key to sign your programmatic requests to the storage bucket 
+
+.. option:: storage.s3.uploadPartSize
+    
+   :type: int
+   :required: NO
+  
+   The size of data chunks to be uploaded to the bucket. Default: 10MB.
+       
+   |PBM| automatically increases the ``uploadPartSize`` value if the size of the file to be uploaded exceeds the max allowed file size. (The max allowed file size is calculated with the default values of uploadPartSize * `maxUploadParts <https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#pkg-constants>`_ and is appr. 97,6 GB)
+
+   The ``uploadPartSize`` value is printed in the :ref:`pbm-agent log <pbm-agent.log>`.
+
+   By setting this option, you can manually adjust the size of data chunks if |PBM| failed to do it for some reason. The defined ``uploadPartSize`` value overrides the default value and is used for calculating the max allowed file size
+
+.. rubric:: Server-side encryption options
+
+.. option:: serverSideEncryption.sseAlgorythm
+   
+   :type: string
+  
+   The key management mode used for server-side encryption. 
+
+   Supported value: ``aws:kms``
+   
+.. option:: serverSideEncryption.kmsKeyID
+     
+   :type: string
+  
+   Your customer-managed key
+
+Filesystem storage options
+-------------------------------------------------------------------------------
+
+.. code-block:: yaml
+
+   storage:
+     type: filesystem
+     filesystem:
+       path: <string>
+
+.. option:: storage.filesystem.path
+
+   :type: string
+   :required: YES
+   
+   The path to the backup directory
+
+.. _pitr.config:
+
+Point-in-time recovery options
+=================================================================================
+
+.. code-block:: yaml
+
+   pitr:
+     enabled: <boolean> 
+
+.. option:: pitr.enabled
+  
+   :type: boolean
+   
+   Enables point-in-time recovery
+
+.. _restore.config:
+
+Backup restore options
+=================================================================================
+
+.. code-block:: yaml
+
+   restore:
+     batchSize: <int>
+     numInsertionWorkers: <int>
+
+.. option:: batchSize
+   
+   :type: int
+   :default: 500
+
+   The number of documents to buffer. 
+
+.. option:: numInsertionWorkers 
+
+   :type: int
+   :default: 10
+
+   The number of workers that add the documents to buffer.      
+       
+.. include:: .res/replace.txt      

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ and MongoDB Community v3.6 or higher with `MongoDB Replication
 
 .. note::
 
-   |PBM| doesn't work on standalone |mongodb| instances. This is because |PBM| requires an :term:`oplog` to guarantee backup consistency. Oplog is available in clusters and replica sets only.
+   |PBM| doesn't work on standalone |mongodb| instances. This is because |PBM| requires an :term:`oplog <Oplog>` to guarantee backup consistency. Oplog is available in clusters and replica sets only.
 
    For testing purposes, you can deploy |PBM| on a single-node replica set. ( Specify the ``replication.replSetName`` in the configuration file of the standalone server.)  
 
@@ -49,6 +49,13 @@ Introduction
    :maxdepth: 2
 
    intro
+
+Architecture
+***********************************************
+
+.. toctree::
+   :maxdepth: 2
+
    architecture
 
 Installation and Upgrade
@@ -60,7 +67,7 @@ Installation and Upgrade
    installation
    upgrading
 
-Getting Started
+Configuration
 ***********************************************  
 
 .. toctree::
@@ -68,6 +75,7 @@ Getting Started
 
    authentication
    config
+   storage-configuration
 
 Usage
 ***********************************************
@@ -101,6 +109,7 @@ Reference
    :maxdepth: 1
 
    release-notes
+   configuration-options
    contributing
    glossary
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ and MongoDB Community v3.6 or higher with `MongoDB Replication
 
 .. note::
 
-   |PBM| doesn't work on standalone |mongodb| instances. This is because |PBM| requires an :term:`oplog <Oplog>` to guarantee backup consistency. Oplog is available in clusters and replica sets only.
+   |PBM| doesn't work on standalone |mongodb| instances. This is because |PBM| requires an :term:`oplog <Oplog>` to guarantee backup consistency. Oplog is available on nodes with replication enabled.
 
    For testing purposes, you can deploy |PBM| on a single-node replica set. ( Specify the ``replication.replSetName`` in the configuration file of the standalone server.)  
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -150,7 +150,7 @@ To set the "PBM_MONGODB_URI" environment variable:
    See :ref:`pbm.auth.create_pbm_user`.
 #. Edit the environment file:  
 
-   .. code-block:: guess
+   .. code-block:: bash
    
       PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@localhost:27018"
 

--- a/doc/source/point-in-time-recovery.rst
+++ b/doc/source/point-in-time-recovery.rst
@@ -18,7 +18,7 @@ When |PITR| is enabled, |pbm-agent| periodically saves consecutive slices of the
 
 A slice covers a 10 minute span of oplog events. It can be shorter if |PITR| is disabled or interrupted by the start of a backup snapshot operation.
 
-The oplog slices are stored in the :file:`pbmPitr` subdirectory in the :ref:`remote storage defined in the config <pbm.config.initialize>`. A slice name reflects the start and end time this slice covers. 
+The oplog slices are stored in the :file:`pbmPitr` subdirectory in the :ref:`remote storage defined in the config <storage.config>`. A slice name reflects the start and end time this slice covers. 
 
 The |pbm-list| output includes both backup snapshots and valid time ranges for recovery. It also shows the |PITR| status.
 

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -87,7 +87,7 @@ Provide the MongoDB URI connection string for |pbm.app|. This allows you to call
 
 Use the following command:
 
-.. code-block:: guess
+.. code-block:: bash
  
    export PBM_MONGODB_URI="mongodb://pbmuser:secretpwd@localhost:27018/"
 
@@ -98,11 +98,14 @@ Running |pbm.app| Commands
 
 |pbm.app| is the command line utility to control the backup system.
 
-Configuring a Remote Store for Backup and Restore Operations
+.. contents::
+   :local:
+
+Configuring a Remote Storage for Backup and Restore Operations
 --------------------------------------------------------------------------------
 
 This must be done once, at installation or re-installation time, before backups can
-be listed, made, or restored. Please see :ref:`pbm.config`.
+be listed, made, or restored. To configure remote storage, see :ref:`pbm.config` and :ref:`storage.config`.
 
 .. _pbm.running.backup.listing:
 
@@ -189,25 +192,13 @@ restore.
 
 After a cluster's restore is complete, restart all ``mongos`` nodes to reload the sharding metadata.
 
-Starting from v1.3.2, the |pbm| config includes the restore options to adjust the memory consumption by the |pbm-agent| in environments with tight memory bounds. This allows preventing out of memory errors during the restore operation. 
+Starting from v1.3.2, the |pbm| config includes the :ref:`restore options <restore.config>` to adjust the memory consumption by the |pbm-agent| in environments with tight memory bounds. This allows preventing out of memory errors during the restore operation. 
 
 .. code-block:: yaml
 
    restore:
      batchSize: 500
      numInsertionWorkers: 10
-
-.. option:: batchSize
-   
-   :default: 500
-
-   The number of documents to buffer. 
-
-.. option:: numInsertionWorkers 
-
-   :default: 10
-
-   The number of workers that add the documents to buffer. 
 
 The default values were adjusted to fit the setups with the memory allocation of 1GB and less for the agent. 
 

--- a/doc/source/storage-configuration.rst
+++ b/doc/source/storage-configuration.rst
@@ -1,0 +1,79 @@
+.. _storage.config:
+
+Remote backup storage 
+*********************************************************************************
+
+.. contents::
+   :local:
+
+|PBM| supports the following types of remote backup storages:
+
+* S3-compatible storage
+* Filesystem type storage
+
+.. rubric:: S3 compatible storage
+
+|PBM| should work with other S3-compatible storages but was only tested with the following ones:
+
+- `Amazon Simple Storage Service <https://docs.aws.amazon.com/s3/index.html>`_ 
+- `Google Cloud Storage <https://cloud.google.com/storage>`_
+- `MinIO <https://min.io/>`_
+  
+Starting from v1.3.2, |PBM| supports :term:`server-side encryption <Server-side encryption>` for :term:`S3 buckets <Bucket>` with customer managed keys stored in |AWS KMS|.
+
+.. seealso::
+
+   `Protecting Data Using Server-Side Encryption with CMKs Stored in AWS Key Management Service (SSE-KMS) <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html>`_
+
+.. rubric:: Remote Filesystem Server Storage
+
+This storage must be a remote fileserver mounted to a local directory. It is the
+responsibility of the server administrators to guarantee that the same remote
+directory is mounted at exactly the same local path on all servers in the
+MongoDB cluster or non-sharded replica set.
+
+.. warning::
+   |PBM| uses the directory as if it were any normal directory, and does not
+   attempt to confirm it is mounted from a remote server.
+   If the path is accidentally a normal local directory, errors will eventually
+   occur, most likely during a restore attempt. This will happen because
+   |pbm-agent| processes of other nodes in the same replica set can't access
+   backup archive files in a normal local directory on another server.
+
+.. rubric:: Local Filesystem Storage
+
+This cannot be used except if you have a single-node replica set. (See the warning
+note above as to why). We recommend using any object store you might be already
+familiar with for testing. If you don't have an object store yet, we recommend
+using MinIO for testing as it has simple setup. If you plan to use a remote
+filesytem-type backup server, please see the "Remote Filesystem Server Storage"
+above.
+
+.. _pbm.config.example_yaml:
+
+Example config files
+================================================================================
+
+Providing remote storage information within a YAML config file is the easiest way to configure the storage for |PBM|. For how to insert the config file, see :ref:`pbm.config.initialize`. 
+
+.. rubric:: S3-compatible remote storage
+
+Amazon Simple Storage Service
+
+.. include:: .res/code-block/yaml/example-amazon-s3-storage.yaml
+
+GCS
+
+.. include:: .res/code-block/yaml/example-gcs-s3-storage.yaml
+
+MinIO
+
+.. include:: .res/code-block/yaml/example-minio-s3-storage.yaml
+
+.. rubric:: Remote filesystem server storage
+
+.. include:: .res/code-block/yaml/example-local-file-system-store.yaml
+
+For the description of available configuration options, see :ref:`pbm.config.options`.
+
+.. include:: .res/replace.txt     


### PR DESCRIPTION
Added a dedicated page with config file options
Added reference to this page from related pages in the docs: config, running
Left only config file management info in config page
Exposed remote storage configuration to a separate page
Fixed code-block language for create user command
Reworked TOC to clearly describe doc sections