### PR TITLE
Use direct connection for MongoDump

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -588,6 +588,7 @@ func newDump(curi string, conns int) *mdump {
 			Auth:       &options.Auth{},
 			Namespace:  &options.Namespace{},
 			Connection: &options.Connection{},
+			Direct:     true,
 		},
 		conns: conns,
 	}


### PR DESCRIPTION
Currently PBM correctly chooses a secondary to perform a backup on, but instead of dumping from that secondary, pbm-agent connects to the primary and dumps from there. See more details about the setup I'm working with here: https://forums.percona.com/discussion/56353/pbm-agent-on-secondary-dumps-from-primary/p1?new=1

I'm not familiar enough with the code base to say if this might have some unwanted effects, but I did verify that it works correctly with one of our replica sets.