### PR TITLE
Make it possible to configure number of parallel collections to dump

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,8 +33,8 @@ func New(pbm *pbm.PBM) *Agent {
 	}
 }
 
-func (a *Agent) AddNode(ctx context.Context, curi string) (err error) {
-	a.node, err = pbm.NewNode(ctx, curi)
+func (a *Agent) AddNode(ctx context.Context, curi string, dumpConns int) (err error) {
+	a.node, err = pbm.NewNode(ctx, curi, dumpConns)
 	return err
 }
 

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -23,7 +23,7 @@ func main() {
 		pbmAgentCmd = pbmCmd.Command("run", "Run agent").Default().Hidden()
 
 		mURI = pbmAgentCmd.Flag("mongodb-uri", "MongoDB connection string").Envar("PBM_MONGODB_URI").Required().String()
-		dumpConns = pbmAgentCmd.Flag("parallel-collections", "Number of collections to dump in parallel").Envar("PBM_DUMP_PARALLEL_COLLECTIONS").Default(strconv.Itoa(runtime.NumCPU()/2)).Int()
+		dumpConns = pbmAgentCmd.Flag("dump-parallel-collections", "Number of collections to dump in parallel").Envar("PBM_DUMP_PARALLEL_COLLECTIONS").Default(strconv.Itoa(runtime.NumCPU()/2)).Int()
 
 		versionCmd    = pbmCmd.Command("version", "PBM version info")
 		versionShort  = versionCmd.Flag("short", "Only version info").Default("false").Bool()

--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -74,7 +74,7 @@ func compression(mURL string, compression pbm.CompressionType, sizeGb float64, c
 	var cn *mongo.Client
 
 	if collection != "" {
-		node, err := pbm.NewNode(ctx, mURL)
+		node, err := pbm.NewNode(ctx, mURL, 1)
 		if err != nil {
 			log.Fatalln("Error: connect to mongodb-node:", err)
 		}
@@ -100,7 +100,7 @@ func compression(mURL string, compression pbm.CompressionType, sizeGb float64, c
 func storage(mURL string, compression pbm.CompressionType, sizeGb float64, collection string) {
 	ctx := context.Background()
 
-	node, err := pbm.NewNode(ctx, mURL)
+	node, err := pbm.NewNode(ctx, mURL, 1)
 	if err != nil {
 		log.Fatalln("Error: connect to mongodb-node:", err)
 	}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"runtime"
 	"strings"
 	"time"
 
@@ -228,7 +227,7 @@ func (b *Backup) run(bcp pbm.BackupCmd) (err error) {
 		sz *= 4
 	}
 
-	dump := newDump(b.node.ConnURI(), runtime.NumCPU()/2)
+	dump := newDump(b.node.ConnURI(), b.node.DumpConns())
 	_, err = Upload(b.ctx, dump, stg, bcp.Compression, rsMeta.DumpName, sz)
 	if err != nil {
 		return errors.Wrap(err, "mongodump")

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Node struct {
-	rs   string
-	me   string
-	ctx  context.Context
-	cn   *mongo.Client
-	curi string
+	rs        string
+	me        string
+	ctx       context.Context
+	cn        *mongo.Client
+	curi      string
+	dumpConns int
 }
 
 // ReplRole is a replicaset role in sharded cluster
@@ -27,10 +28,11 @@ const (
 	ReplRoleConfigSrv = "configsrv"
 )
 
-func NewNode(ctx context.Context, curi string) (*Node, error) {
+func NewNode(ctx context.Context, curi string, dumpConns int) (*Node, error) {
 	n := &Node{
 		ctx:  ctx,
 		curi: curi,
+		dumpConns: dumpConns,
 	}
 	err := n.Connect()
 	if err != nil {
@@ -179,6 +181,10 @@ func (n *Node) ReplicationLag() (int, error) {
 
 func (n *Node) ConnURI() string {
 	return n.curi
+}
+
+func (n *Node) DumpConns() int {
+	return n.dumpConns
 }
 
 func (n *Node) Session() *mongo.Client {


### PR DESCRIPTION
PBM currently dumps a maximum of `runtime.NumCPU()/2` collections concurrently. In our tests, depending on the used compression algorithm, this leads to either saturating the uplink of the backup nodes or very high CPU loads. We have some use cases where applications read from secondaries and we'd prefer to sacrifice some backup speed in order not to compromise those use cases.

This PR introduces a new optional pbm-agent environment variable, `PBM_DUMP_PARALLEL_COLLECTIONS`, for controlling the parallelism. It's not perfect as it doesn't in any way guarantee fairness of resource/bandwidth use, but at least it allows leaving more CPU cores free for other tasks and has an effect on bandwidth usage.

I figured an environment variable would make sense as opposed to using `pbm config` as it's possible to have a cluster with heterogenous hardware, and therefore the configuration should be per-agent.

For the speed tests I hardcoded the value to 1 as they don't seem to use mongodump, and they seem to operate on just one collection anyway.

I don't mind updating the docs if the idea gets approved, but didn't want to do it before.

BTW, `agent/agent.go` has CRLF line terminators while others don't. My IDEA is very eager to fix it but I don't know about your style policies so I left it as it is in order to avoid a horrible diff :)