### PR TITLE
Ignore shard configuration from backup

### DIFF
--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -42,6 +42,7 @@ var excludeFromRestore = []string{
 	"config.locks",
 	"config.system.sessions",
 	"config.cache.*",
+	"config.shards",
 }
 
 type Restore struct {

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -43,6 +43,7 @@ var excludeFromRestore = []string{
 	"config.system.sessions",
 	"config.cache.*",
 	"config.shards",
+	"admin.system.version",
 }
 
 type Restore struct {


### PR DESCRIPTION
When restoring a backup to a cluster consisting of different nodes than the ones the backup was made from, the shard configuration is overwritten. I don't think it makes sense to restore the shard configuration in any conditions because in any case, before restoring a sharded cluster, you need to have a functional cluster set up to begin with.

I almost had a heart attack the first time I noticed that `sh.status()` on my test cluster claimed to be talking to production shards.