### PR TITLE
PBM-555 Retry and reconnect on errors while downloading from S3

### DIFF
--- a/cmd/pbm/logs.go
+++ b/cmd/pbm/logs.go
@@ -48,8 +48,6 @@ func logs(cn *pbm.PBM) {
 		f = plog.FormatJSON
 	}
 
-	// TODO: need to decouple "logger" and "logs printer"
-	cn.InitLogger("", "")
 	err := cn.Logger().PrintLogs(os.Stdout, f, r, *logsTailF, r.Node == "")
 
 	if err != nil {

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -105,6 +105,8 @@ func main() {
 	if err != nil {
 		log.Fatalln("Error: connect to mongodb:", err)
 	}
+	// TODO: need to decouple "logger" and "logs printer"
+	pbmClient.InitLogger("", "")
 
 	switch cmd {
 	case configCmd.FullCommand():

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -26,6 +26,9 @@ func init() {
 	// duplicated in backup/restore packages just
 	// in the sake of clarity
 	mlog.SetDateFormat(log.LogTimeFormat)
+	mlog.SetVerbosity(&options.Verbosity{
+		VLevel: mlog.DebugLow,
+	})
 }
 
 var excludeFromRestore = []string{


### PR DESCRIPTION
Currently when PBM downloads and parses the backup file during restore it has to abort if reading or connection error happens. Since file (object) being downloaded and parsed as a whole, retrying won't help much if an error happened after lest's say 500Gb already had been parsed. "Retrying" in such case would mean do it again from the beginning.

This PR addresses issue by downloading S3 objects in chunks using HTTP Range header https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.  That makes retries possible if an error happened.
Along with the retries, PBM would recreate session with the S3 should conniption being dropped.

https://jira.percona.com/browse/PBM-555