### PR TITLE
PBM-460: Prevent conflicting namespace during the restore

### DIFF
--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -97,7 +97,11 @@ func (a *Agent) pitr() (err error) {
 		return nil
 	}
 
-	q, err := backup.NodeSuits(a.node)
+	ninf, err := a.node.GetInfo()
+	if err != nil {
+		return errors.Wrap(err, "get node info")
+	}
+	q, err := backup.NodeSuits(a.node, ninf)
 	if err != nil {
 		return errors.Wrap(err, "node check")
 	}

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -3,6 +3,7 @@ package pbm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -26,12 +27,21 @@ const (
 	ReplRoleUnknown   = "unknown"
 	ReplRoleShard     = "shard"
 	ReplRoleConfigSrv = "configsrv"
+
+	// TmpUsersCollection and TmpRoles are tmp collections used to avoid
+	// user related issues while resoring on new cluster.
+	// See https://jira.percona.com/browse/PBM-425
+	//
+	// Backup should ensure abscense of this collection to avoid
+	// restore conflicts. See https://jira.percona.com/browse/PBM-460
+	TmpUsersCollection = `pbmRUsers`
+	TmpRolesCollection = `pbmRRoles`
 )
 
 func NewNode(ctx context.Context, curi string, dumpConns int) (*Node, error) {
 	n := &Node{
-		ctx:  ctx,
-		curi: curi,
+		ctx:       ctx,
+		curi:      curi,
 		dumpConns: dumpConns,
 	}
 	err := n.Connect()
@@ -199,4 +209,39 @@ func (n *Node) CurrentUser() (*AuthInfo, error) {
 	}
 
 	return &c.AuthInfo, nil
+}
+
+func (n *Node) DropTMPcoll() error {
+	err := n.cn.Database(DB).Collection(TmpRolesCollection).Drop(n.ctx)
+	if err != nil {
+		return errors.Wrapf(err, "drop tmp roles collection %s", TmpRolesCollection)
+	}
+
+	err = n.cn.Database(DB).Collection(TmpUsersCollection).Drop(n.ctx)
+	if err != nil {
+		return errors.Wrapf(err, "drop tmp users collection %s", TmpUsersCollection)
+	}
+
+	return nil
+}
+
+func (n *Node) EnsureNoTMPcoll() error {
+	cols, err := n.cn.Database(DB).ListCollectionNames(n.ctx, bson.D{})
+	if err != nil {
+		return errors.Wrapf(err, "list collections in %s", DB)
+	}
+
+	var ext []string
+	for _, n := range cols {
+		if n == TmpRolesCollection || n == TmpUsersCollection {
+			ext = append(ext, DB+"."+n)
+		}
+	}
+	if len(ext) > 0 {
+		return errors.Errorf(
+			"pbm tmp collections exists. It will lead to failed restore. Drop collections: %s",
+			strings.Join(ext, ", "),
+		)
+	}
+	return nil
 }

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -239,7 +239,7 @@ func (n *Node) EnsureNoTMPcoll() error {
 	}
 	if len(ext) > 0 {
 		return errors.Errorf(
-			"pbm tmp collections exists. It will lead to failed restore. Drop collections: %s",
+			"PBM temporary collections exist. It will lead to a failed restore. Please, drop next collections manually: %s",
 			strings.Join(ext, ", "),
 		)
 	}

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -132,7 +132,11 @@ func (i *IBackup) Stream(ctx context.Context, wakeupSig <-chan struct{}, to stor
 		nextChunkT := time.Now().Add(i.span)
 
 		// check if the node is still any good to make backups
-		q, err := backup.NodeSuits(i.node)
+		ninf, err := i.node.GetInfo()
+		if err != nil {
+			return errors.Wrap(err, "get node info")
+		}
+		q, err := backup.NodeSuits(i.node, ninf)
 		if err != nil {
 			return errors.Wrap(err, "node check")
 		}

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -344,9 +344,6 @@ func (r *Restore) prepareSnapshot() (err error) {
 }
 
 const (
-	tmpUsers = `pbmRUsers`
-	tmpRoles = `pbmRRoles`
-
 	preserveUUID = false
 
 	batchSizeDefault           = 500
@@ -415,6 +412,13 @@ func (r *Restore) RunSnapshot() (err error) {
 		numInsertionWorkers = cfg.Restore.NumInsertionWorkers
 	}
 
+	defer func() {
+		err := r.node.DropTMPcoll()
+		if err != nil {
+			r.log.Error("dropping tmp collections: %v", err)
+		}
+	}()
+
 	mr := mongorestore.MongoRestore{
 		SessionProvider: rsession,
 		ToolOptions:     &topts,
@@ -436,7 +440,7 @@ func (r *Restore) RunSnapshot() (err error) {
 		NSOptions: &mongorestore.NSOptions{
 			NSExclude: excludeFromRestore,
 			NSFrom:    []string{`admin.system.users`, `admin.system.roles`},
-			NSTo:      []string{pbm.DB + `.` + tmpUsers, pbm.DB + `.` + tmpRoles},
+			NSTo:      []string{pbm.DB + `.` + pbm.TmpUsersCollection, pbm.DB + `.` + pbm.TmpRolesCollection},
 		},
 		InputReader: dumpReader,
 	}
@@ -565,7 +569,7 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *pbm.AuthInfo) error {
 		eroles = append(eroles, r.DB+"."+r.Role)
 	}
 
-	curr, err := r.node.Session().Database(pbm.DB).Collection(tmpRoles).Find(ctx, bson.M{"_id": bson.M{"$nin": eroles}})
+	curr, err := r.node.Session().Database(pbm.DB).Collection(pbm.TmpRolesCollection).Find(ctx, bson.M{"_id": bson.M{"$nin": eroles}})
 	if err != nil {
 		return errors.Wrap(err, "create cursor for tmpRoles")
 	}
@@ -591,7 +595,7 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *pbm.AuthInfo) error {
 	if len(exclude.Users) > 0 {
 		user = exclude.Users[0].DB + "." + exclude.Users[0].User
 	}
-	cur, err := r.node.Session().Database(pbm.DB).Collection(tmpUsers).Find(ctx, bson.M{"_id": bson.M{"$ne": user}})
+	cur, err := r.node.Session().Database(pbm.DB).Collection(pbm.TmpUsersCollection).Find(ctx, bson.M{"_id": bson.M{"$ne": user}})
 	if err != nil {
 		return errors.Wrap(err, "create cursor for tmpUsers")
 	}
@@ -613,15 +617,6 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *pbm.AuthInfo) error {
 		if err != nil {
 			return errors.Wrap(err, "insert user")
 		}
-	}
-
-	err = r.node.Session().Database(pbm.DB).Collection(tmpRoles).Drop(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "drop tmp roles collection %s", tmpRoles)
-	}
-	err = r.node.Session().Database(pbm.DB).Collection(tmpUsers).Drop(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "drop tmp users collection %s", tmpUsers)
 	}
 
 	return nil


### PR DESCRIPTION
Restore should remove tmp user and role collections otherwise
it would be a conflicting namespaces error during restore

This commit addresses issue by
1. Ensuring that restore would try to drop tmp collections even on error.
Which didn't happened before. The drop was run only on success.

2. Backup would ensure there ate no tmp collections and try to drop it otherwise.

There is no way to exclude some collections on mongodump stage
while it accepts "exclude..." option only if sole db specified (¯\_(ツ)_/¯)
So we're trying to clean up on primary node when it gets bcp command
but because there is no guarantee
that primary node reaches that code before some of the secondaries starts backup
we have to double-check in backup.run() before mongodump and fail on the dirty state.

https://jira.percona.com/browse/PBM-460