### PR TITLE
PBM-555 don't retry download after mongorestore errors

### DIFF
--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -459,6 +459,10 @@ func (s *S3) SourceReader(name string) (io.ReadCloser, error) {
 				if err == io.EOF {
 					return
 				}
+				if errors.Is(err, io.ErrClosedPipe) {
+					s.log.Warning("reader closed pipe, stopping download")
+					return
+				}
 
 				s.log.Warning("got %v, try to reconnect in %v", err, time.Second*time.Duration(i+1))
 				time.Sleep(time.Second * time.Duration(i+1))


### PR DESCRIPTION
Just a chore. If mongorestore had exited and closed pipe before the download is finished it means that some error happened on that side. So there is no reason in retrying download and spamming log with failed attempts.