### PR TITLE
PBM-586 feature: add a request timeout to the restore S3 downloader

### DIFF
--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -335,6 +335,7 @@ func (s *S3) newPartReader(fname string) *partReader {
 }
 
 func (pr *partReader) setSession(s *s3.S3) {
+	s.Client.Config.HTTPClient.Timeout = time.Second * 30
 	pr.sess = s
 }
 


### PR DESCRIPTION
It allows not to depend on system keepalive settings and retry earlier if connection stalls.

https://jira.percona.com/browse/PBM-586