### PR TITLE
PBM-585 Make ConvertLegacyIndexes restore option configurable

### DIFF
--- a/pbm/config.go
+++ b/pbm/config.go
@@ -52,8 +52,9 @@ type StorageConf struct {
 
 // RestoreConf is config options for the restore
 type RestoreConf struct {
-	BatchSize           int `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
-	NumInsertionWorkers int `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	BatchSize            int  `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
+	NumInsertionWorkers  int  `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	ConvertLegacyIndexes bool `bson:"convertLegacyIndexes" json:"convertLegacyIndexes" yaml:"convertLegacyIndexes"`
 }
 
 type confMap map[string]reflect.Kind

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -434,6 +434,7 @@ func (r *Restore) RunSnapshot() (err error) {
 			TempRolesColl:            "temproles",
 			TempUsersColl:            "tempusers",
 			WriteConcern:             "majority",
+			ConvertLegacyIndexes:     cfg.Restore.ConvertLegacyIndexes,
 		},
 		NSOptions: &mongorestore.NSOptions{
 			NSExclude: excludeFromRestore,


### PR DESCRIPTION
Indices created with old Mongo versions can no longer be restored to modern versions when they contain legacy index options or values. Mongorestore has an option to make sure legacy indices are converted: https://docs.mongodb.com/database-tools/mongorestore/#cmdoption-mongorestore-convertlegacyindexes

https://jira.percona.com/browse/PBM-585