### PR TITLE
Add config for excluding restore namespaces

### DIFF
--- a/pbm/config.go
+++ b/pbm/config.go
@@ -52,8 +52,9 @@ type StorageConf struct {
 
 // RestoreConf is config options for the restore
 type RestoreConf struct {
-	BatchSize           int `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
-	NumInsertionWorkers int `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	BatchSize            int      `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
+	NumInsertionWorkers  int      `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	ExcludeNamespaces    string   `bson:"excludeNamespaces" json:"excludeNamespaces" yaml:"excludeNamespaces"`
 }
 
 type confMap map[string]reflect.Kind

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -410,6 +410,15 @@ func (r *Restore) RunSnapshot() (err error) {
 		numInsertionWorkers = cfg.Restore.NumInsertionWorkers
 	}
 
+	splitFunc := func(c rune) bool {
+		return c == ','
+	}
+	excludeNamespaces := strings.FieldsFunc(cfg.Restore.ExcludeNamespaces, splitFunc)
+	for i := range excludeNamespaces {
+		excludeNamespaces[i] = strings.TrimSpace(excludeNamespaces[i])
+	}
+	excludeNs := append(excludeFromRestore, excludeNamespaces...)
+
 	defer func() {
 		err := r.node.DropTMPcoll()
 		if err != nil {
@@ -436,7 +445,7 @@ func (r *Restore) RunSnapshot() (err error) {
 			WriteConcern:             "majority",
 		},
 		NSOptions: &mongorestore.NSOptions{
-			NSExclude: excludeFromRestore,
+			NSExclude: excludeNs,
 			NSFrom:    []string{`admin.system.users`, `admin.system.roles`},
 			NSTo:      []string{pbm.DB + `.` + pbm.TmpUsersCollection, pbm.DB + `.` + pbm.TmpRolesCollection},
 		},

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -417,7 +417,7 @@ func (r *Restore) RunSnapshot() (err error) {
 	for i := range excludeNamespaces {
 		excludeNamespaces[i] = strings.TrimSpace(excludeNamespaces[i])
 	}
-	excludeNs := append(excludeFromRestore, excludeNamespaces...)
+	excludeFromRestore = append(excludeFromRestore, excludeNamespaces...)
 
 	defer func() {
 		err := r.node.DropTMPcoll()
@@ -445,7 +445,7 @@ func (r *Restore) RunSnapshot() (err error) {
 			WriteConcern:             "majority",
 		},
 		NSOptions: &mongorestore.NSOptions{
-			NSExclude: excludeNs,
+			NSExclude: excludeFromRestore,
 			NSFrom:    []string{`admin.system.users`, `admin.system.roles`},
 			NSTo:      []string{pbm.DB + `.` + pbm.TmpUsersCollection, pbm.DB + `.` + pbm.TmpRolesCollection},
 		},


### PR DESCRIPTION
In addition to the hardcoded list of excluded namespaces, allow configuring more.

My golang-fu isn't strong enough to quickly set up support for generic slice configuration options that you could manipulate via the CLI, so I made this a comma separated string that's parsed where it's used.

The motivation for doing this is to work around https://jira.percona.com/browse/PBM-601 by excluding the problematic collection.