### PR TITLE
No need to wait and hold a lock for fast ops

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -142,7 +142,6 @@ func (a *Agent) Delete(d pbm.DeleteBackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		}
 	}()
 
-	tsstart := time.Now()
 	switch {
 	case d.OlderThan > 0:
 		t := time.Unix(d.OlderThan, 0).UTC()
@@ -165,12 +164,6 @@ func (a *Agent) Delete(d pbm.DeleteBackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 	default:
 		l.Error("malformed command received in Delete() of backup: %v", d)
 		return
-	}
-
-	// TODO: timers logic should be replaced with the opID
-	needToWait := waitAtLeast - time.Since(tsstart)
-	if needToWait > 0 {
-		time.Sleep(needToWait)
 	}
 
 	l.Info("done")
@@ -210,7 +203,6 @@ func (a *Agent) ResyncStorage(opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 
-	tstart := time.Now()
 	l.Info("started")
 	err = a.pbm.ResyncStorage(l)
 	if err != nil {
@@ -229,10 +221,6 @@ func (a *Agent) ResyncStorage(opid pbm.OPID, ep pbm.Epoch) {
 		}
 	}
 
-	needToWait := time.Second*1 - time.Since(tstart)
-	if needToWait > 0 {
-		time.Sleep(needToWait)
-	}
 	err = lock.Release()
 	if err != nil {
 		l.Error("reslase lock %v: %v", lock, err)
@@ -248,8 +236,8 @@ func (a *Agent) aquireLock(l *pbm.Lock) (got bool, err error) {
 	}
 
 	switch err.(type) {
-	case pbm.ErrConcurrentOp:
-		a.log.Printf("acquiring lock: %v", err)
+	case pbm.ErrDuplicateOp, pbm.ErrConcurrentOp:
+		a.log.Info("", "", l.OPID, *l.Epoch, "get lock: %v", err)
 		return false, nil
 	case pbm.ErrWasStaleLock:
 		lk := err.(pbm.ErrWasStaleLock).Lock

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -130,7 +130,6 @@ func (a *Agent) Backup(bcp pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		cancel: cancel,
 	})
 	l.Info("backup started")
-	tstart := time.Now()
 	err = backup.New(ctx, a.pbm, a.node).Run(bcp, opid, l)
 	a.unsetBcp()
 	if err != nil {
@@ -156,21 +155,7 @@ func (a *Agent) Backup(bcp pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		}
 	}
 
-	// In the case of fast backup (small db) we have to wait before releasing the lock.
-	// Otherwise, since the primary node waits for `WaitBackupStart*0.9` before trying to acquire the lock
-	// it might happen that the backup will be made twice:
-	//
-	// secondary1 >---------*!lock(fail - acuired by s1)---------------------------
-	// secondary2 >------*lock====backup====*unlock--------------------------------
-	// primary    >--------*wait--------------------*lock====backup====*unlock-----
-	//
-	// Secondaries also may start trying to acquire a lock with quite an interval (e.g. due to network issues)
-	// TODO: we cannot rely on the nodes wall clock.
-	// TODO: ? pbmBackups should have unique index by name ?
-	needToWait := pbm.WaitBackupStart - time.Since(tstart)
-	if needToWait > 0 {
-		time.Sleep(needToWait)
-	}
+	l.Debug("releasing lock")
 	err = lock.Release()
 	if err != nil {
 		l.Error("unable to release backup lock %v: %v", lock, err)
@@ -211,6 +196,7 @@ func (a *Agent) Restore(r pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 	}
 
 	defer func() {
+		l.Debug("releasing lock")
 		err := lock.Release()
 		if err != nil {
 			l.Error("release lock: %v", err)

--- a/pbm/lock.go
+++ b/pbm/lock.go
@@ -167,10 +167,11 @@ func (p *PBM) MarkBcpStale(opid string) error {
 	}
 
 	// not to rewrite an error emitted by the agent
-	if bcp.Status == StatusError {
+	if bcp.Status == StatusError || bcp.Status == StatusDone {
 		return nil
 	}
 
+	p.log.Debug(string(CmdBackup), "", opid, primitive.Timestamp{}, "mark stale meta")
 	return p.ChangeBackupStateOPID(opid, StatusError, "some of pbm-agents were lost during the backup")
 }
 
@@ -181,10 +182,11 @@ func (p *PBM) MarkRestoreStale(opid string) error {
 	}
 
 	// not to rewrite an error emitted by the agent
-	if r.Status == StatusError {
+	if r.Status == StatusError || r.Status == StatusDone {
 		return nil
 	}
 
+	p.log.Debug(string(CmdRestore), "", opid, primitive.Timestamp{}, "mark stale meta")
 	return p.ChangeRestoreStateOPID(opid, StatusError, "some of pbm-agents were lost during the restore")
 }
 


### PR DESCRIPTION
OPID would protect from running the same op twice by different nodes.

Moreover, waiting may trigger bug in k8s operator.  If the database is relatively small -  backups went really fast. Let’s say in 10sec backup being marked as successfully done. But because of timeouts needed for some internal sync pbm-agent would hold the lock for at least 34sec. So we have a situation when operator observes “backup done” and send the next backup command to the PBM. But since some agents still are holding locks this operation either being discarded by PBM straight ahead (because of timing some of the replset may actually start a backup and then “fail” it because “couldn’t get a response from all shards”).
Anyway, the issue is that for small and fast backup operator might think that backup is done (and it is really done) but the new operation can’t be scheduled while lock(s) is still being held. It is not an issue with the pbm cli since it checks for locks beforehand.