### PR TITLE
PBM-602 fix: discard failed PITR chunks

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -403,11 +403,13 @@ func Upload(ctx context.Context, src Source, dst storage.Storage, compression pb
 	case <-saveDone:
 	}
 
+	r.Close()
+
 	if !err.nil() {
 		return 0, err
 	}
 
-	return n, r.Close()
+	return n, nil
 }
 
 func (b *Backup) reconcileStatus(bcpName string, status pbm.Status, ninf *pbm.NodeInfo, timeout *time.Duration) error {

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -58,6 +58,11 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 
 	var pitr []interface{}
 	for _, f := range pitrf {
+		err := stg.CheckFile(f)
+		if err != nil {
+			l.Warning("skip %s because of %v", f, err)
+			continue
+		}
 		chnk := PITRmetaFromFName(f)
 		if chnk != nil {
 			pitr = append(pitr, chnk)


### PR DESCRIPTION
Any upload on storage would create the target file first and then will
stream data into it (data could be lager than the available RAM). And if
something went wrong while reading data we may end up with an already created
empty or inconsistent file. PITR chunks have no metadata along with it to
indicate any failed state. Although the failed PITR range won't be saved in
internal db as the available for restore. It would get in there after the storage
resync. So on any upload errors during the PITR slicing, we have to ensure no
leftovers on storage. And also skip empty PITR chunks during resync.

https://jira.percona.com/browse/PBM-602