### PR TITLE
Fix: release lock if 2nd phase failed

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -132,7 +132,7 @@ func (a *Agent) Delete(d pbm.DeleteBackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	if !got {
-		l.Info("scheduled to another node")
+		l.Debug("skip: lock not acquired")
 		return
 	}
 	defer func() {
@@ -199,7 +199,7 @@ func (a *Agent) ResyncStorage(opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	if !got {
-		l.Info("operation has been scheduled on another replset node")
+		l.Debug("lock not acquired")
 		return
 	}
 
@@ -237,7 +237,7 @@ func (a *Agent) aquireLock(l *pbm.Lock) (got bool, err error) {
 
 	switch err.(type) {
 	case pbm.ErrDuplicateOp, pbm.ErrConcurrentOp:
-		a.log.Info("", "", l.OPID, *l.Epoch, "get lock: %v", err)
+		a.log.Debug("", "", l.OPID, *l.Epoch, "get lock: %v", err)
 		return false, nil
 	case pbm.ErrWasStaleLock:
 		lk := err.(pbm.ErrWasStaleLock).Lock

--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -155,6 +155,7 @@ func (a *Agent) pitr() (err error) {
 		return errors.Wrap(err, "acquiring lock")
 	}
 	if !got {
+		l.Debug("skip: lock not acquired")
 		return nil
 	}
 
@@ -219,6 +220,7 @@ func (a *Agent) PITRestore(r pbm.PITRestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	if !got {
+		l.Debug("skip: lock not acquired")
 		l.Error("unbale to run the restore while another backup or restore process running")
 		return
 	}

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -120,7 +120,7 @@ func (a *Agent) Backup(bcp pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	if !got {
-		l.Info("backup has been scheduled on another replset node")
+		l.Debug("skip: lock not acquired")
 		return
 	}
 
@@ -191,6 +191,7 @@ func (a *Agent) Restore(r pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	if !got {
+		l.Debug("skip: lock not acquired")
 		l.Error("unbale to run the restore while another operation running")
 		return
 	}

--- a/pbm/lock.go
+++ b/pbm/lock.go
@@ -99,6 +99,10 @@ func (l *Lock) Acquire() (bool, error) {
 		// log the operation. duplicate means error
 		err := l.log()
 		if err != nil {
+			rerr := l.Release()
+			if rerr != nil {
+				err = errors.Errorf("%v. Also failed to release the lock: %v", err, rerr)
+			}
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
To progress further with any op agent has to not only acquire a lock but also
log the op by its unique ID. If the log phase has failed agent wasn't removing
lock acquired on the 1st phase.

This commit fixes that bug. Plus rearranges a bit lock-related logging.