### PR TITLE
PBM-595 fix: sharded backup with different rs name

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -157,7 +157,7 @@ func printPITR(cn *pbm.PBM, size int, full bool) {
 		log.Fatalf("Error: define cluster state: %v", err)
 	}
 
-	shards := []pbm.Shard{{ID: inf.SetName}}
+	shards := []pbm.Shard{{RS: inf.SetName}}
 	if inf.IsSharded() {
 		s, err := cn.GetShards()
 		if err != nil {
@@ -189,24 +189,24 @@ func printPITR(cn *pbm.PBM, size int, full bool) {
 	var rstlines [][]pbm.Timeline
 	for _, s := range shards {
 		if on {
-			err := pitrState(cn, s.ID, ts)
+			err := pitrState(cn, s.RS, ts)
 			if err == errPITRBackup && int64(epch.TS().T) <= time.Now().Add(-1*time.Minute).Unix() {
-				pitrErrors += fmt.Sprintf("  %s: PITR backup didn't started\n", s.ID)
+				pitrErrors += fmt.Sprintf("  %s: PITR backup didn't started\n", s.RS)
 			} else if err != nil {
-				log.Printf("Error: check PITR state for shard '%s': %v", s.ID, err)
+				log.Printf("Error: check PITR state for shard '%s': %v", s.RS, err)
 			}
-			lg, err := pitrLog(cn, s.ID, epch)
+			lg, err := pitrLog(cn, s.RS, epch)
 			if err != nil {
-				log.Printf("Error: get log for shard '%s': %v", s.ID, err)
+				log.Printf("Error: get log for shard '%s': %v", s.RS, err)
 			}
 			if lg != "" {
-				pitrErrors += fmt.Sprintf("  %s: %s\n", s.ID, lg)
+				pitrErrors += fmt.Sprintf("  %s: %s\n", s.RS, lg)
 			}
 		}
 
-		tlns, err := cn.PITRGetValidTimelines(s.ID, now)
+		tlns, err := cn.PITRGetValidTimelines(s.RS, now)
 		if err != nil {
-			log.Printf("Error: get PITR timelines for %s replset: %v", s.ID, err)
+			log.Printf("Error: get PITR timelines for %s replset: %v", s.RS, err)
 		}
 
 		if len(tlns) == 0 {
@@ -218,7 +218,7 @@ func printPITR(cn *pbm.PBM, size int, full bool) {
 		}
 
 		if full {
-			rsout := fmt.Sprintf("  %s:", s.ID)
+			rsout := fmt.Sprintf("  %s:", s.RS)
 			for _, tln := range tlns {
 				rsout += fmt.Sprintf(" %v,", tln)
 			}

--- a/e2e-tests/docker/scripts/sharded/mongos_init.js
+++ b/e2e-tests/docker/scripts/sharded/mongos_init.js
@@ -2,6 +2,6 @@ sh.addShard("rs1/rs101:27017")
 sh.addShard("rs1/rs102:27017")
 sh.addShard("rs1/rs103:27017")
 
-sh.addShard("rs2/rs201:27017")
-sh.addShard("rs2/rs202:27017")
-sh.addShard("rs2/rs203:27017")
+db.adminCommand({ addShard: "rs2/rs201:27017", name: "rsx" });
+db.adminCommand({ addShard: "rs2/rs202:27017", name: "rsx" });
+db.adminCommand({ addShard: "rs2/rs203:27017", name: "rsx" });

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -415,7 +415,7 @@ func Upload(ctx context.Context, src Source, dst storage.Storage, compression pb
 func (b *Backup) reconcileStatus(bcpName string, status pbm.Status, ninf *pbm.NodeInfo, timeout *time.Duration) error {
 	shards := []pbm.Shard{
 		{
-			ID:   ninf.SetName,
+			RS:   ninf.SetName,
 			Host: ninf.SetName + "/" + strings.Join(ninf.Hosts, ","),
 		},
 	}
@@ -494,7 +494,7 @@ func (b *Backup) converged(bcpName string, shards []pbm.Shard, status pbm.Status
 
 	for _, sh := range shards {
 		for _, shard := range bmeta.Replsets {
-			if shard.Name == sh.ID {
+			if shard.Name == sh.RS {
 				// check if node alive
 				lock, err := b.cn.GetLockData(&pbm.LockHeader{
 					Type:    pbm.CmdBackup,

--- a/pbm/bsontypes.go
+++ b/pbm/bsontypes.go
@@ -163,6 +163,7 @@ type ReplsetStatus struct {
 // Shard represent config.shard https://docs.mongodb.com/manual/reference/config-database/#config.shards
 type Shard struct {
 	ID   string `bson:"_id"`
+	RS   string `bson:"-"`
 	Host string `bson:"host"`
 }
 

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -697,6 +697,13 @@ func (p *PBM) GetShards() ([]Shard, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "message decode")
 		}
+		s.RS = s.ID
+		// _id may differ from the rs name, so extract rs name from the host (format like "rs2/localhost:27017")
+		// see https://jira.percona.com/browse/PBM-595
+		h := strings.Split(s.Host, "/")
+		if len(h) > 1 {
+			s.RS = h[0]
+		}
 		shards = append(shards, s)
 	}
 

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -625,7 +625,7 @@ func (r *Restore) restoreUsers(exclude *pbm.AuthInfo) error {
 func (r *Restore) reconcileStatus(status pbm.Status, timeout *time.Duration) error {
 	shards := []pbm.Shard{
 		{
-			ID:   r.nodeInfo.SetName,
+			RS:   r.nodeInfo.SetName,
 			Host: r.nodeInfo.SetName + "/" + strings.Join(r.nodeInfo.Hosts, ","),
 		},
 	}
@@ -704,7 +704,7 @@ func (r *Restore) converged(shards []pbm.Shard, status pbm.Status) (bool, error)
 
 	for _, sh := range shards {
 		for _, shard := range bmeta.Replsets {
-			if shard.Name == sh.ID {
+			if shard.Name == sh.RS {
 				// check if node alive
 				lock, err := r.cn.GetLockData(&pbm.LockHeader{
 					Type:    pbm.CmdRestore,


### PR DESCRIPTION
`_id` in `config.shards` collection may differ from rs name.
So the `pbm-agent` would register itself in the backup meta by the rs name.
While peers would search it by the `_id` field of `config.shards`.

This PR changes the rs name in shards info to be the rs name, not the shard id.