### PR TITLE
PBM-597 fix: Properly handle mongo fail while PITR slicing

### DIFF
--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -774,7 +774,11 @@ func (p *PBM) ClusterTime() (primitive.Timestamp, error) {
 }
 
 func (p *PBM) LogGet(r *log.LogRequest, limit int64) ([]log.LogEntry, error) {
-	return p.log.Get(r, limit)
+	return p.log.Get(r, limit, false)
+}
+
+func (p *PBM) LogGetExactSeverity(r *log.LogRequest, limit int64) ([]log.LogEntry, error) {
+	return p.log.Get(r, limit, true)
 }
 
 type Epoch primitive.Timestamp

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -94,12 +94,16 @@ func (e ErrOpMoved) Error() string {
 	return fmt.Sprintf("pitr slicing resumed on node %s", e.to)
 }
 
+// LogStartMsg message to log on successful streaming start
+const LogStartMsg = "star_ok"
+
 // Stream streaming (saving) chunks of the oplog to the given storage
 func (i *IBackup) Stream(ctx context.Context, ep pbm.Epoch, wakeupSig <-chan struct{}, to storage.Storage, compression pbm.CompressionType) error {
 	if i.lastTS.T == 0 {
 		return errors.New("no starting point defined")
 	}
 	l := i.pbm.Logger().NewEvent(string(pbm.CmdPITR), "", "", ep.TS())
+	l.Debug(LogStartMsg)
 	l.Info("streaming started from %v / %v", time.Unix(int64(i.lastTS.T), 0).UTC(), i.lastTS.T)
 
 	tk := time.NewTicker(i.span)

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -95,7 +95,7 @@ func (e ErrOpMoved) Error() string {
 }
 
 // LogStartMsg message to log on successful streaming start
-const LogStartMsg = "star_ok"
+const LogStartMsg = "start_ok"
 
 // Stream streaming (saving) chunks of the oplog to the given storage
 func (i *IBackup) Stream(ctx context.Context, ep pbm.Epoch, wakeupSig <-chan struct{}, to storage.Storage, compression pbm.CompressionType) error {


### PR DESCRIPTION
Added an extra wait penalty to the next agent's loop iteration
should slicer return with an error.

Also, fixed PITR error messaging in pbm status.
If one agent failed with error the other will catch up. Epoch won't
change but and despite successful slicing by another node pbm status
would display error of failed node. So have to check for no
subsequent success before firing an error.

And remove pitr errors from `pbm list` output