### PR TITLE
PBM-619: oprimize status resposnse time

### DIFF
--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -71,12 +71,12 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 
 	var pitr []interface{}
 	for _, f := range pitrf {
-		_, err := stg.FileStat(PITRfsPrefix + "/" + f)
+		_, err := stg.FileStat(PITRfsPrefix + "/" + f.Name)
 		if err != nil {
 			l.Warning("skip %s because of %v", f, err)
 			continue
 		}
-		chnk := PITRmetaFromFName(f)
+		chnk := PITRmetaFromFName(f.Name)
 		if chnk != nil {
 			pitr = append(pitr, chnk)
 		}

--- a/pbm/storage/blackhole/blackhole.go
+++ b/pbm/storage/blackhole/blackhole.go
@@ -19,7 +19,7 @@ func (*Blackhole) Save(_ string, data io.Reader, _ int) error {
 }
 
 func (*Blackhole) Files(_ string) ([][]byte, error)                    { return [][]byte{}, nil }
-func (*Blackhole) List(_ string) ([]string, error)                     { return []string{}, nil }
+func (*Blackhole) List(_ string) ([]storage.FileInfo, error)           { return []storage.FileInfo{}, nil }
 func (*Blackhole) Delete(_ string) error                               { return nil }
 func (*Blackhole) FileStat(_ string) (inf storage.FileInfo, err error) { return }
 

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -73,8 +73,8 @@ func (fs *FS) FileStat(name string) (inf storage.FileInfo, err error) {
 	return inf, nil
 }
 
-func (fs *FS) List(prefix string) ([]string, error) {
-	var files []string
+func (fs *FS) List(prefix string) ([]storage.FileInfo, error) {
+	var files []storage.FileInfo
 
 	prefix = path.Join(fs.opts.Path, prefix)
 
@@ -94,7 +94,7 @@ func (fs *FS) List(prefix string) ([]string, error) {
 			if f[0] == '/' {
 				f = f[1:]
 			}
-			files = append(files, f)
+			files = append(files, storage.FileInfo{Name: f, Size: info.Size()})
 		}
 
 		return nil

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -9,6 +9,7 @@ import (
 var ErrNotExist = errors.New("no such file")
 
 type FileInfo struct {
+	Name string // with path
 	Size int64
 }
 
@@ -17,7 +18,7 @@ type Storage interface {
 	SourceReader(name string) (io.ReadCloser, error)
 	// FileStat returns file info. It returns error if file is empty or not exists
 	FileStat(name string) (FileInfo, error)
-	List(prefix string) ([]string, error)
+	List(prefix string) ([]FileInfo, error)
 	Files(suffix string) ([][]byte, error)
 	// Delete deletes given file.
 	// It returns storage.ErrNotExist if a file isn't exists


### PR DESCRIPTION
`pbm status` used to check the size on the storage for each PITR chunk separately.  So every new chunk made status rendering slower and slower.
This commit introduces chunks cache which is made for each status command so there is one request to the storage instead of many.

https://jira.percona.com/browse/PBM-619