### PR TITLE
PBM-478 fix: don't restore incomplete backups

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -563,7 +563,7 @@ func (b *Backup) waitForStatus(bcpName string, status pbm.Status) error {
 			case pbm.StatusCancelled:
 				return ErrCancelled
 			case pbm.StatusError:
-				return errors.Wrap(err, "backup failed")
+				return errors.Errorf("cluster failed: %v", err)
 			}
 		case <-b.cn.Context().Done():
 			return nil

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -163,14 +163,14 @@ func (r *Restore) init(name string, opid pbm.OPID, l *log.Event) (err error) {
 	r.name = name
 
 	r.opid = opid.String()
-	meta := &pbm.RestoreMeta{
-		OPID:     r.opid,
-		Name:     r.name,
-		StartTS:  time.Now().Unix(),
-		Status:   pbm.StatusStarting,
-		Replsets: []pbm.RestoreReplset{},
-	}
 	if r.nodeInfo.IsLeader() {
+		meta := &pbm.RestoreMeta{
+			OPID:     r.opid,
+			Name:     r.name,
+			StartTS:  time.Now().Unix(),
+			Status:   pbm.StatusStarting,
+			Replsets: []pbm.RestoreReplset{},
+		}
 		err = r.cn.SetRestoreMeta(meta)
 		if err != nil {
 			return errors.Wrap(err, "write backup meta to db")
@@ -771,7 +771,7 @@ func (r *Restore) waitForStatus(status pbm.Status) error {
 			case status:
 				return nil
 			case pbm.StatusError:
-				return errors.Wrap(err, "restore failed")
+				return errors.Errorf("cluster failed: %s", meta.Error)
 			}
 		case <-r.cn.Context().Done():
 			return nil


### PR DESCRIPTION
The bug was with the statuses confirmation by secondary agents.
When cluster error  emitted it was returning `nil` instead of generating error.

The same bug was in backups.

https://jira.percona.com/browse/PBM-478