### PR TITLE
PBM-618 fix: don't resync incomplete snapshots

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -217,6 +217,13 @@ func main() {
 		if *listCmdRestore {
 			printRestoreList(pbmClient, *listCmdSize, *listCmdFullF)
 		} else {
+			// show message ans skip when resync is running
+			lk, err := findLock(pbmClient, pbmClient.GetLocks)
+			if err == nil && lk != nil && lk.Type == pbm.CmdResyncBackupList {
+				fmt.Println("[Storage resync is running. Backups list will be available after sync finishes.]")
+				return
+			}
+
 			printBackupList(pbmClient, *listCmdSize)
 			printPITR(pbmClient, int(*listCmdSize), *listCmdFullF)
 		}

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -391,7 +391,7 @@ func getCurrOps(cn *pbm.PBM) (fmt.Stringer, error) {
 		OPID: lk.OPID,
 	}
 
-	// recheacing here means no conflict operation, hence all locks are the same,
+	// reaching here means no conflict operation, hence all locks are the same,
 	// hence any lock in `lk` contais info on the current op
 	switch r.Type {
 	case pbm.CmdBackup:


### PR DESCRIPTION
Now storage resync checks the availability of all files from snapshot metadata.
And skips the snapshot if something is missing.

Also `pbm list` won't show any list while resync is running. Showing message instead.

https://jira.percona.com/browse/PBM-618