### PR TITLE
PBM-615: check if backups match the cluster

### DIFF
--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -270,7 +270,11 @@ func (a *Agent) PITRestore(r pbm.PITRestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 	l.Info("recovery started")
 	err = restore.New(a.pbm, a.node).PITR(r, opid, l)
 	if err != nil {
-		l.Error("restore: %v", err)
+		if errors.Is(err, restore.ErrNoDatForShard) {
+			l.Info("no data for the shard in backup, skipping")
+		} else {
+			l.Error("restore: %v", err)
+		}
 		return
 	}
 	l.Info("recovery successfully finished")

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -207,7 +207,11 @@ func (a *Agent) Restore(r pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 	l.Info("restore started")
 	err = restore.New(a.pbm, a.node).Snapshot(r, opid, l)
 	if err != nil {
-		l.Error("restore: %v", err)
+		if errors.Is(err, restore.ErrNoDatForShard) {
+			l.Info("no data for the shard in backup, skipping")
+		} else {
+			l.Error("restore: %v", err)
+		}
 		return
 	}
 	l.Info("restore finished successfully")

--- a/cmd/pbm/backup_test.go
+++ b/cmd/pbm/backup_test.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+func TestBcpMatchCluster(t *testing.T) {
+	cases := []struct {
+		shards []pbm.Shard
+		bcps   []pbm.BackupMeta
+		expect []pbm.BackupMeta
+	}{
+		{
+			shards: []pbm.Shard{
+				{RS: "config"},
+				{RS: "rs1"},
+				{RS: "rs2"},
+			},
+			bcps: []pbm.BackupMeta{
+				{
+					Name: "bcp1",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+						{Name: "rs1"},
+						{Name: "rs3"},
+					},
+					Status: pbm.StatusDone,
+				},
+				{
+					Name: "bcp2",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+						{Name: "rs1"},
+					},
+					Status: pbm.StatusDone,
+				},
+				{
+					Name: "bcp3",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+						{Name: "rs1"},
+						{Name: "rs2"},
+					},
+					Status: pbm.StatusDone,
+				},
+			},
+			expect: []pbm.BackupMeta{
+				{
+					Name:   "bcp1",
+					Status: pbm.StatusError,
+				},
+				{
+					Name:   "bcp2",
+					Status: pbm.StatusError,
+				},
+				{
+					Name:   "bcp3",
+					Status: pbm.StatusDone,
+				},
+			},
+		},
+		{
+			shards: []pbm.Shard{
+				{RS: "rs1"},
+			},
+			bcps: []pbm.BackupMeta{
+				{
+					Name: "bcp1",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+						{Name: "rs1"},
+						{Name: "rs3"},
+					},
+					Status: pbm.StatusDone,
+				},
+				{
+					Name: "bcp2",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+					},
+					Status: pbm.StatusDone,
+				},
+				{
+					Name: "bcp3",
+					Replsets: []pbm.BackupReplset{
+						{Name: "config"},
+						{Name: "rs2"},
+						{Name: "rs3"},
+					},
+					Status: pbm.StatusDone,
+				},
+				{
+					Name: "bcp4",
+					Replsets: []pbm.BackupReplset{
+						{Name: "rs1"},
+					},
+					Status: pbm.StatusDone,
+				},
+			},
+			expect: []pbm.BackupMeta{
+				{
+					Name:   "bcp1",
+					Status: pbm.StatusDone,
+				},
+				{
+					Name:   "bcp2",
+					Status: pbm.StatusError,
+				},
+				{
+					Name:   "bcp3",
+					Status: pbm.StatusError,
+				},
+				{
+					Name:   "bcp4",
+					Status: pbm.StatusDone,
+				},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			bcpMatchCluster(c.bcps, c.shards)
+			for i := 0; i < len(c.expect); i++ {
+				if c.expect[i].Status != c.bcps[i].Status {
+					t.Errorf("wrong status for %s, expect %s, got %s", c.bcps[i].Name, c.expect[i].Status, c.bcps[i].Status)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBcpMatchCluster3x10(b *testing.B) {
+	shards := []pbm.Shard{
+		{RS: "config"},
+		{RS: "rs1"},
+		{RS: "rs2"},
+	}
+
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 10; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Name: "bcp",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs2"},
+			},
+			Status: pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster3x100(b *testing.B) {
+	shards := []pbm.Shard{
+		{RS: "config"},
+		{RS: "rs1"},
+		{RS: "rs2"},
+	}
+
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 100; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Name: "bcp",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs2"},
+			},
+			Status: pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster17x100(b *testing.B) {
+	shards := []pbm.Shard{
+		{RS: "config"},
+		{RS: "rs1"},
+		{RS: "rs12"},
+		{RS: "rs112"},
+		{RS: "rs1112"},
+		{RS: "rs11112"},
+		{RS: "rs111112"},
+		{RS: "rs1111112"},
+		{RS: "rs22"},
+		{RS: "rs2222"},
+		{RS: "rs222222"},
+		{RS: "rs222222222"},
+		{RS: "rs332"},
+		{RS: "rs32"},
+		{RS: "rs33332"},
+		{RS: "rs333333332"},
+		{RS: "rs333333333332"},
+	}
+
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 100; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Name: "bcp3",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs12"},
+				{Name: "rs112"},
+				{Name: "rs1112"},
+				{Name: "rs11112"},
+				{Name: "rs111112"},
+				{Name: "rs1111112"},
+				{Name: "rs22"},
+				{Name: "rs2222"},
+				{Name: "rs222222"},
+				{Name: "rs222222222"},
+				{Name: "rs332"},
+				{Name: "rs32"},
+				{Name: "rs33332"},
+				{Name: "rs333333332"},
+				{Name: "rs333333333332"},
+			},
+			Status: pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster3x1000(b *testing.B) {
+	shards := []pbm.Shard{
+		{RS: "config"},
+		{RS: "rs1"},
+		{RS: "rs2"},
+	}
+
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 1000; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Name: "bcp3",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs2"},
+			},
+			Status: pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster1000x1000(b *testing.B) {
+	shards := []pbm.Shard{}
+	rss := []pbm.BackupReplset{}
+
+	for i := 0; i < 1000; i++ {
+		shards = append(shards, pbm.Shard{RS: fmt.Sprint(i)})
+		rss = append(rss, pbm.BackupReplset{Name: fmt.Sprint(i)})
+	}
+
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 1000; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Replsets: rss,
+			Status:   pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster3x10Err(b *testing.B) {
+	shards := []pbm.Shard{
+		{RS: "config"},
+		{RS: "rs1"},
+		{RS: "rs2"},
+	}
+
+	bcps := []pbm.BackupMeta{
+		{
+			Name: "bcp1",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs3"},
+			},
+			Status: pbm.StatusDone,
+		},
+		{
+			Name: "bcp2",
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+			},
+			Status: pbm.StatusDone,
+		},
+	}
+	for i := 0; i < 8; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Replsets: []pbm.BackupReplset{
+				{Name: "config"},
+				{Name: "rs1"},
+				{Name: "rs3"},
+			},
+			Status: pbm.StatusDone,
+		})
+	}
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}
+
+func BenchmarkBcpMatchCluster1000x1000Err(b *testing.B) {
+	shards := []pbm.Shard{}
+	rss := []pbm.BackupReplset{}
+
+	for i := 0; i < 1000; i++ {
+		shards = append(shards, pbm.Shard{RS: fmt.Sprint(i)})
+		rss = append(rss, pbm.BackupReplset{Name: fmt.Sprint(i)})
+	}
+
+	shards = append(shards, pbm.Shard{RS: "newrs"})
+	bcps := []pbm.BackupMeta{}
+
+	for i := 0; i < 1000; i++ {
+		bcps = append(bcps, pbm.BackupMeta{
+			Replsets: rss,
+			Status:   pbm.StatusDone,
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bcpMatchCluster(bcps, shards)
+	}
+}

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -96,8 +96,8 @@ func main() {
 	}
 
 	if *mURL == "" {
-		log.Println("Error: no mongodb connection URI supplied\n")
-		log.Println("       Usual practice is the set it by the PBM_MONGODB_URI environment variable. It can also be set with commandline argument --mongodb-uri.\n")
+		log.Println("Error: no mongodb connection URI supplied")
+		log.Println("       Usual practice is the set it by the PBM_MONGODB_URI environment variable. It can also be set with commandline argument --mongodb-uri.")
 		pbmCmd.Usage(os.Args[1:])
 		os.Exit(1)
 	}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/mongodb/mongo-tools-common/db"
@@ -413,19 +412,9 @@ func Upload(ctx context.Context, src Source, dst storage.Storage, compression pb
 }
 
 func (b *Backup) reconcileStatus(bcpName string, status pbm.Status, ninf *pbm.NodeInfo, timeout *time.Duration) error {
-	shards := []pbm.Shard{
-		{
-			RS:   ninf.SetName,
-			Host: ninf.SetName + "/" + strings.Join(ninf.Hosts, ","),
-		},
-	}
-
-	if ninf.IsSharded() {
-		s, err := b.cn.GetShards()
-		if err != nil {
-			return errors.Wrap(err, "get shards list")
-		}
-		shards = append(shards, s...)
+	shards, err := b.cn.ClusterMembers(ninf)
+	if err != nil {
+		return errors.Wrap(err, "get cluster members")
 	}
 
 	if timeout != nil {

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -3,7 +3,6 @@ package restore
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/mongodb/mongo-tools-common/db"
@@ -623,19 +622,9 @@ func (r *Restore) restoreUsers(exclude *pbm.AuthInfo) error {
 }
 
 func (r *Restore) reconcileStatus(status pbm.Status, timeout *time.Duration) error {
-	shards := []pbm.Shard{
-		{
-			RS:   r.nodeInfo.SetName,
-			Host: r.nodeInfo.SetName + "/" + strings.Join(r.nodeInfo.Hosts, ","),
-		},
-	}
-
-	if r.nodeInfo.IsSharded() {
-		s, err := r.cn.GetShards()
-		if err != nil {
-			return errors.Wrap(err, "get shards list")
-		}
-		shards = append(shards, s...)
+	shards, err := r.cn.ClusterMembers(r.nodeInfo)
+	if err != nil {
+		return errors.Wrap(err, "get cluster members")
 	}
 
 	if timeout != nil {

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -3,6 +3,7 @@ package restore
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/mongodb/mongo-tools-common/db"
@@ -49,13 +50,19 @@ var excludeFromRestore = []string{
 }
 
 type Restore struct {
-	name       string
-	cn         *pbm.PBM
-	node       *pbm.Node
-	stopHB     chan struct{}
-	nodeInfo   *pbm.NodeInfo
-	stg        storage.Storage
-	bcp        *pbm.BackupMeta
+	name     string
+	cn       *pbm.PBM
+	node     *pbm.Node
+	stopHB   chan struct{}
+	nodeInfo *pbm.NodeInfo
+	stg      storage.Storage
+	bcp      *pbm.BackupMeta
+	// Shards to participate in restore. Num of shards in bcp could
+	// be less than in the cluster and this is ok.
+	//
+	// Only the restore leader would have this info.
+	shards []pbm.Shard
+
 	dumpFile   string
 	oplogFile  string
 	pitrChunks []pbm.PITRChunk
@@ -84,7 +91,7 @@ func (r *Restore) Close() {
 // Snapshot do the snapshot's (mongo dump) restore
 func (r *Restore) Snapshot(cmd pbm.RestoreCmd, opid pbm.OPID, l *log.Event) (err error) {
 	defer func() {
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrNoDatForShard) {
 			ferr := r.MarkFailed(err)
 			if ferr != nil {
 				l.Error("mark restore as failed `%v`: %v", err, ferr)
@@ -115,7 +122,7 @@ func (r *Restore) Snapshot(cmd pbm.RestoreCmd, opid pbm.OPID, l *log.Event) (err
 // PITR do Point-in-Time Recovery
 func (r *Restore) PITR(cmd pbm.PITRestoreCmd, opid pbm.OPID, l *log.Event) (err error) {
 	defer func() {
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrNoDatForShard) {
 			ferr := r.MarkFailed(err)
 			if ferr != nil {
 				l.Error("mark restore as failed `%v`: %v", err, ferr)
@@ -197,18 +204,6 @@ func (r *Restore) init(name string, opid pbm.OPID, l *log.Event) (err error) {
 	err = r.waitForStatus(pbm.StatusStarting)
 	if err != nil {
 		return errors.Wrap(err, "waiting for start")
-	}
-
-	rsMeta := pbm.RestoreReplset{
-		Name:       r.nodeInfo.SetName,
-		StartTS:    time.Now().UTC().Unix(),
-		Status:     pbm.StatusStarting,
-		Conditions: []pbm.Condition{},
-	}
-
-	err = r.cn.AddRestoreRSMeta(r.name, rsMeta)
-	if err != nil {
-		return errors.Wrap(err, "add shard's metadata")
 	}
 
 	r.stg, err = r.cn.GetStorage(r.log)
@@ -296,6 +291,8 @@ func (r *Restore) PrepareBackup(backupName string) (err error) {
 	return errors.Wrap(err, "prepare snapshot")
 }
 
+var ErrNoDatForShard = errors.New("no data for shard")
+
 func (r *Restore) prepareSnapshot() (err error) {
 	if r.bcp == nil {
 		return errors.New("snapshot name doesn't set")
@@ -310,6 +307,33 @@ func (r *Restore) prepareSnapshot() (err error) {
 		return errors.Errorf("backup wasn't successful: status: %s, error: %s", r.bcp.Status, r.bcp.Error)
 	}
 
+	if r.nodeInfo.IsLeader() {
+		s, err := r.cn.ClusterMembers(r.nodeInfo)
+		if err != nil {
+			return errors.Wrap(err, "get cluster members")
+		}
+
+		fl := make(map[string]pbm.Shard, len(s))
+		for _, rs := range s {
+			fl[rs.RS] = rs
+		}
+
+		var nors []string
+		for _, sh := range r.bcp.Replsets {
+			rs, ok := fl[sh.Name]
+			if !ok {
+				nors = append(nors, sh.Name)
+				continue
+			}
+
+			r.shards = append(r.shards, rs)
+		}
+
+		if len(nors) > 0 {
+			return errors.Errorf("extra/unknown replica set found in the backup: %s", strings.Join(nors, ","))
+		}
+	}
+
 	var ok bool
 	for _, v := range r.bcp.Replsets {
 		if v.Name == r.nodeInfo.SetName {
@@ -320,7 +344,7 @@ func (r *Restore) prepareSnapshot() (err error) {
 		}
 	}
 	if !ok {
-		return errors.Errorf("metadata for replset/shard %s is not found", r.nodeInfo.SetName)
+		return ErrNoDatForShard
 	}
 
 	_, err = r.stg.FileStat(r.dumpFile)
@@ -332,9 +356,16 @@ func (r *Restore) prepareSnapshot() (err error) {
 		return errors.Errorf("failed to ensure oplog file %s: %v", r.oplogFile, err)
 	}
 
-	err = r.cn.ChangeRestoreRSState(r.name, r.nodeInfo.SetName, pbm.StatusRunning, "")
+	rsMeta := pbm.RestoreReplset{
+		Name:       r.nodeInfo.SetName,
+		StartTS:    time.Now().UTC().Unix(),
+		Status:     pbm.StatusRunning,
+		Conditions: []pbm.Condition{},
+	}
+
+	err = r.cn.AddRestoreRSMeta(r.name, rsMeta)
 	if err != nil {
-		return errors.Wrap(err, "set shard's StatusDumpDone")
+		return errors.Wrap(err, "add shard's metadata")
 	}
 
 	return nil
@@ -622,25 +653,20 @@ func (r *Restore) restoreUsers(exclude *pbm.AuthInfo) error {
 }
 
 func (r *Restore) reconcileStatus(status pbm.Status, timeout *time.Duration) error {
-	shards, err := r.cn.ClusterMembers(r.nodeInfo)
-	if err != nil {
-		return errors.Wrap(err, "get cluster members")
-	}
-
 	if timeout != nil {
-		return errors.Wrap(r.convergeClusterWithTimeout(shards, status, *timeout), "convergeClusterWithTimeout")
+		return errors.Wrap(r.convergeClusterWithTimeout(status, *timeout), "convergeClusterWithTimeout")
 	}
-	return errors.Wrap(r.convergeCluster(shards, status), "convergeCluster")
+	return errors.Wrap(r.convergeCluster(status), "convergeCluster")
 }
 
-// convergeCluster waits until all given shards reached `status` and updates a cluster status
-func (r *Restore) convergeCluster(shards []pbm.Shard, status pbm.Status) error {
+// convergeCluster waits until all participating shards reached `status` and updates a cluster status
+func (r *Restore) convergeCluster(status pbm.Status) error {
 	tk := time.NewTicker(time.Second * 1)
 	defer tk.Stop()
 	for {
 		select {
 		case <-tk.C:
-			ok, err := r.converged(shards, status)
+			ok, err := r.converged(r.shards, status)
 			if err != nil {
 				return err
 			}
@@ -655,8 +681,9 @@ func (r *Restore) convergeCluster(shards []pbm.Shard, status pbm.Status) error {
 
 var errConvergeTimeOut = errors.New("reached converge timeout")
 
-// convergeClusterWithTimeout waits up to the geiven timeout until all given shards reached `status` and then updates the cluster status
-func (r *Restore) convergeClusterWithTimeout(shards []pbm.Shard, status pbm.Status, t time.Duration) error {
+// convergeClusterWithTimeout waits up to the geiven timeout until all participating shards reached
+// `status` and then updates the cluster status
+func (r *Restore) convergeClusterWithTimeout(status pbm.Status, t time.Duration) error {
 	tk := time.NewTicker(time.Second * 1)
 	defer tk.Stop()
 	tout := time.NewTicker(t)
@@ -664,7 +691,7 @@ func (r *Restore) convergeClusterWithTimeout(shards []pbm.Shard, status pbm.Stat
 	for {
 		select {
 		case <-tk.C:
-			ok, err := r.converged(shards, status)
+			ok, err := r.converged(r.shards, status)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This commit changes the restore behaviour regarding backup - target cluster match

Now match means that each replset in the backup has respective replset on the target cluster. It's ok if the
cluster has more shards than there are currently in backup.

Also during `pbm list` and `pbm status` we compare each backup with the
current cluster and if backup's data doesn't match cluster backup's meta
would be changed to pbm.StatusError with respective error text emitted. It doesn't change meta on
storage nor in DB (backup is ok, it just doesn't cluster), it is just "in-flight" changes
in given `bcps`.

https://jira.percona.com/browse/PBM-615