### PR TITLE
PBM-621: properly handle incomple bcps in status

### DIFF
--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -538,8 +538,8 @@ func getStorageStat(cn *pbm.PBM) (fmt.Stringer, error) {
 			snpsht.StateTS = int64(bcp.LastWriteTS.T)
 			sz, err := getSnapshotSize(bcp.Replsets, stg)
 			if err != nil {
-				log.Println("ERROR: storage: get snapshot size:", err)
-				continue
+				snpsht.Err = err.Error()
+				snpsht.Status = pbm.StatusError
 			}
 			snpsht.Size = sz
 		case pbm.StatusError:


### PR DESCRIPTION
If the backup is incomplete (error reading bcp files) during the pbm status
command backup marked with "ERROR". It doesn't change any metadata neither
on storage nor at db. Anyway, such backup would be discarded on restore
attempt. As well as during the next storage resync.

Example of output:
```
...
Backups:
========
S3 MinIO http://127.0.0.1:9000/bkt/pbm
  Snapshots:
    2021-01-20T17:09:46Z 3.28GB [complete: 2021-01-20T17:10:33]
    2021-01-13T16:10:20Z 3.28GB [complete: 2021-01-13T16:13:00]
    2021-01-13T15:50:54Z 0.00B [ERROR: get file 2021-01-13T15:50:54Z_config.dump.s2: no such file] [2021-01-13T15:53:40]
```

https://jira.percona.com/browse/PBM-621