### PR TITLE
PBM-635: wait for leader's metadata

### DIFF
--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -13,14 +13,14 @@ import (
 
 func restore(cn *pbm.PBM, bcpName string) error {
 	bcp, err := cn.GetBackupMeta(bcpName)
+	if errors.Is(err, pbm.ErrNotFound) {
+		return errors.Errorf("backup '%s' not found", bcpName)
+	}
 	if err != nil {
 		return errors.Wrap(err, "get backup data")
 	}
-	if bcp.Name != bcpName {
-		return errors.Errorf("backup '%s' not found", bcpName)
-	}
 	if bcp.Status != pbm.StatusDone {
-		return errors.Errorf("backup '%s' isn't finished successfully", bcpName)
+		return errors.Errorf("backup '%s' didn't finish successfully", bcpName)
 	}
 
 	locks, err := cn.GetLocks(&pbm.LockHeader{})

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -46,13 +46,6 @@ func main() {
 	flushStore(storage)
 	tests.ApplyConfig(storage)
 
-	// tests.DeleteBallast()
-	// tests.GenerateBallastData(2e7)
-	// printStart("Basic Backup & Restore AWS S3")
-	// tests.BackupAndRestore()
-	// printDone("Basic Backup & Restore AWS S3")
-	// flushStore(storage)
-
 	tests.DeleteBallast()
 	tests.GenerateBallastData(1e5)
 
@@ -120,6 +113,10 @@ func main() {
 	printStart("Check Backup Cancellation")
 	tests.BackupCancellation(storage)
 	printDone("Check Backup Cancellation")
+
+	printStart("Leader lag during backup start")
+	tests.LeaderLag()
+	printDone("Leader lag during backup start")
 
 	printStart("Backup Data Bounds Check")
 	tests.BackupBoundsCheck()

--- a/e2e-tests/docker/pbm-agent/Dockerfile
+++ b/e2e-tests/docker/pbm-agent/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.14
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		libfaketime \
-		iproute2 \
+	libfaketime \
+	iproute2 \
+	libkrb5-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/pbm

--- a/e2e-tests/pkg/pbm/docker.go
+++ b/e2e-tests/pkg/pbm/docker.go
@@ -55,6 +55,56 @@ func (d *Docker) StopAgents(rsName string) error {
 	return nil
 }
 
+// PauseAgents pause agent containers of the given replicaset
+func (d *Docker) PauseAgents(rsName string) error {
+	fltr := filters.NewArgs()
+	fltr.Add("label", "com.percona.pbm.agent.rs="+rsName)
+	containers, err := d.cn.ContainerList(d.ctx, types.ContainerListOptions{
+		Filters: fltr,
+	})
+	if err != nil {
+		return errors.Wrap(err, "container list")
+	}
+	if len(containers) == 0 {
+		return errors.Errorf("no containers found for replset %s", rsName)
+	}
+
+	for _, c := range containers {
+		log.Println("stopping container", c.ID)
+		err = d.cn.ContainerPause(d.ctx, c.ID)
+		if err != nil {
+			return errors.Wrapf(err, "stop container %s", c.ID)
+		}
+	}
+
+	return nil
+}
+
+// UnpauseAgents unpause agent containers of the given replicaset
+func (d *Docker) UnpauseAgents(rsName string) error {
+	fltr := filters.NewArgs()
+	fltr.Add("label", "com.percona.pbm.agent.rs="+rsName)
+	containers, err := d.cn.ContainerList(d.ctx, types.ContainerListOptions{
+		Filters: fltr,
+	})
+	if err != nil {
+		return errors.Wrap(err, "container list")
+	}
+	if len(containers) == 0 {
+		return errors.Errorf("no containers found for replset %s", rsName)
+	}
+
+	for _, c := range containers {
+		log.Println("stopping container", c.ID)
+		err = d.cn.ContainerUnpause(d.ctx, c.ID)
+		if err != nil {
+			return errors.Wrapf(err, "stop container %s", c.ID)
+		}
+	}
+
+	return nil
+}
+
 // StartAgents starts stopped agent containers of the given replicaset
 func (d *Docker) StartAgents(rsName string) error {
 	fltr := filters.NewArgs()

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -28,6 +28,10 @@ func NewMongoPBM(ctx context.Context, connectionURI string) (*MongoPBM, error) {
 	}, nil
 }
 
+func (m *MongoPBM) SendCmd(cmd pbm.Cmd) error {
+	return m.p.SendCmd(cmd)
+}
+
 func (m *MongoPBM) BackupsList(limit int64) ([]pbm.BackupMeta, error) {
 	return m.p.BackupsList(limit)
 }

--- a/e2e-tests/pkg/tests/sharded/cluster.go
+++ b/e2e-tests/pkg/tests/sharded/cluster.go
@@ -207,7 +207,7 @@ func (c *Cluster) checkBackup(bcpName string, waitFor time.Duration) error {
 			return errors.Errorf("timeout reached. pbm status:\n%s", sts)
 		case <-tkr.C:
 			m, err := c.mongopbm.GetBackupMeta(bcpName)
-			if err != nil {
+			if err != nil && err != pbmt.ErrNotFound {
 				errors.Wrap(err, "get backup meta")
 			}
 			switch m.Status {

--- a/e2e-tests/pkg/tests/sharded/test_leader_lag.go
+++ b/e2e-tests/pkg/tests/sharded/test_leader_lag.go
@@ -1,0 +1,60 @@
+package sharded
+
+import (
+	"log"
+	"time"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+// LeaderLag checks if cluster deals with leader lag during backup start
+// https://jira.percona.com/browse/PBM-635
+func (c *Cluster) LeaderLag() {
+	checkData := c.DataChecker()
+
+	log.Println("Pausing agents on", c.confsrv)
+	err := c.docker.PauseAgents(c.confsrv)
+	if err != nil {
+		log.Fatalln("ERROR: pausing agents:", err)
+	}
+	log.Println("Agents on pause", c.confsrv)
+
+	bcpName := time.Now().UTC().Format(time.RFC3339)
+
+	log.Println("Starting backup", bcpName)
+	err = c.mongopbm.SendCmd(pbm.Cmd{
+		Cmd: pbm.CmdBackup,
+		Backup: pbm.BackupCmd{
+			Name:        bcpName,
+			Compression: pbm.CompressionTypeS2,
+		},
+	})
+	if err != nil {
+		log.Fatalln("ERROR: starting backup:", err)
+	}
+
+	waitfor := time.Second * 5
+	log.Println("Sleeping for", waitfor)
+	time.Sleep(waitfor)
+
+	log.Println("Unpausing agents on", c.confsrv)
+	err = c.docker.UnpauseAgents(c.confsrv)
+	if err != nil {
+		log.Fatalln("ERROR: unpause agents:", err)
+	}
+	log.Println("Agents resumed", c.confsrv)
+
+	c.BackupWaitDone(bcpName)
+	c.DeleteBallast()
+
+	// to be sure the backup didn't vanish after the resync
+	// i.e. resync finished correctly
+	log.Println("resync backup list")
+	err = c.mongopbm.StoreResync()
+	if err != nil {
+		log.Fatalln("Error: resync backup lists:", err)
+	}
+
+	c.Restore(bcpName)
+	checkData()
+}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -176,7 +176,7 @@ func (b *Backup) run(bcp pbm.BackupCmd, opid pbm.OPID, l *plog.Event) (err error
 
 	// Waiting for StatusStarting to move further.
 	// In case some preparations has to be done before backup.
-	err = b.waitForStatus(bcp.Name, pbm.StatusStarting)
+	err = b.waitForStatus(bcp.Name, pbm.StatusStarting, &pbm.WaitBackupStart)
 	if err != nil {
 		return errors.Wrap(err, "waiting for start")
 	}
@@ -206,9 +206,9 @@ func (b *Backup) run(bcp pbm.BackupCmd, opid pbm.OPID, l *plog.Event) (err error
 	}
 
 	// Waiting for cluster's StatusRunning to move further.
-	err = b.waitForStatus(bcp.Name, pbm.StatusRunning)
+	err = b.waitForStatus(bcp.Name, pbm.StatusRunning, nil)
 	if err != nil {
-		return errors.Wrap(err, "waiting for start")
+		return errors.Wrap(err, "waiting for running")
 	}
 
 	oplog := NewOplog(b.node)
@@ -267,14 +267,14 @@ func (b *Backup) run(bcp pbm.BackupCmd, opid pbm.OPID, l *plog.Event) (err error
 		}
 	}
 
-	err = b.waitForStatus(bcp.Name, pbm.StatusDumpDone)
+	err = b.waitForStatus(bcp.Name, pbm.StatusDumpDone, nil)
 	if err != nil {
 		return errors.Wrap(err, "waiting for dump done")
 	}
 
 	lwTS, err := b.waitForLastWrite(bcp.Name)
 	if err != nil {
-		return errors.Wrap(err, "waiting and reading cluster last write ts")
+		return errors.Wrap(err, "get cluster last write ts")
 	}
 
 	oplog.SetTailingSpan(oplogTS, lwTS)
@@ -301,7 +301,7 @@ func (b *Backup) run(bcp pbm.BackupCmd, opid pbm.OPID, l *plog.Event) (err error
 	}
 
 	// to be sure the locks released only after the "done" status had written
-	err = b.waitForStatus(bcp.Name, pbm.StatusDone)
+	err = b.waitForStatus(bcp.Name, pbm.StatusDone, nil)
 	return errors.Wrap(err, "waiting for done")
 }
 
@@ -526,13 +526,22 @@ func (b *Backup) converged(bcpName string, shards []pbm.Shard, status pbm.Status
 	return false, nil
 }
 
-func (b *Backup) waitForStatus(bcpName string, status pbm.Status) error {
+func (b *Backup) waitForStatus(bcpName string, status pbm.Status, waitFor *time.Duration) error {
+	var tout <-chan time.Time
+	if waitFor != nil {
+		tmr := time.NewTimer(*waitFor)
+		defer tmr.Stop()
+		tout = tmr.C
+	}
 	tk := time.NewTicker(time.Second * 1)
 	defer tk.Stop()
 	for {
 		select {
 		case <-tk.C:
 			bmeta, err := b.cn.GetBackupMeta(bcpName)
+			if errors.Is(err, pbm.ErrNotFound) {
+				continue
+			}
 			if err != nil {
 				return errors.Wrap(err, "get backup metadata")
 			}
@@ -554,6 +563,8 @@ func (b *Backup) waitForStatus(bcpName string, status pbm.Status) error {
 			case pbm.StatusError:
 				return errors.Errorf("cluster failed: %v", err)
 			}
+		case <-tout:
+			return errors.New("no backup meta, looks like a leader failed to start")
 		case <-b.cn.Context().Done():
 			return nil
 		}
@@ -570,6 +581,16 @@ func (b *Backup) waitForLastWrite(bcpName string) (primitive.Timestamp, error) {
 			if err != nil {
 				return primitive.Timestamp{}, errors.Wrap(err, "get backup metadata")
 			}
+
+			clusterTime, err := b.cn.ClusterTime()
+			if err != nil {
+				return primitive.Timestamp{}, errors.Wrap(err, "read cluster time")
+			}
+
+			if bmeta.Hb.T+pbm.StaleFrameSec < clusterTime.T {
+				return primitive.Timestamp{}, errors.Errorf("backup stuck, last beat ts: %d", bmeta.Hb.T)
+			}
+
 			if bmeta.LastWriteTS.T > 0 {
 				return bmeta.LastWriteTS, nil
 			}

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -164,7 +164,7 @@ func (n *Node) Status() (*NodeStatus, error) {
 		}
 	}
 
-	return nil, errors.New("not found")
+	return nil, ErrNotFound
 }
 
 // ReplicationLag returns node replication lag in seconds

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -60,6 +60,9 @@ const (
 	MetadataFileSuffix = ".pbm.json"
 )
 
+// ErrNotFound - object not found
+var ErrNotFound = errors.New("not found")
+
 // Command represents actions that could be done on behalf of the client by the agents
 type Command string
 
@@ -615,14 +618,15 @@ func (p *PBM) GetBackupByOPID(opid string) (*BackupMeta, error) {
 }
 
 func (p *PBM) getBackupMeta(clause bson.D) (*BackupMeta, error) {
-	b := new(BackupMeta)
 	res := p.Conn.Database(DB).Collection(BcpCollection).FindOne(p.ctx, clause)
 	if res.Err() != nil {
 		if res.Err() == mongo.ErrNoDocuments {
-			return b, nil
+			return nil, ErrNotFound
 		}
 		return nil, errors.Wrap(res.Err(), "get")
 	}
+
+	b := &BackupMeta{}
 	err := res.Decode(b)
 	return b, errors.Wrap(err, "decode")
 }

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -279,7 +279,7 @@ func (r *Restore) prepareChunks(from, to primitive.Timestamp) error {
 
 func (r *Restore) PrepareBackup(backupName string) (err error) {
 	r.bcp, err = r.cn.GetBackupMeta(backupName)
-	if errors.Cause(err) == mongo.ErrNoDocuments {
+	if errors.Is(err, pbm.ErrNotFound) {
 		r.bcp, err = r.getMetaFromStore(backupName)
 	}
 


### PR DESCRIPTION
If the leader started with some delay in a sharded cluster other agents
would check metadata during "status waiting" and get `0` heartbeat ts
since meta wasn't set yet. So we should wait for meta if it isn't set.

https://jira.percona.com/browse/PBM-635