### PR TITLE
PBM-636: restore config. preserveUUID

### DIFF
--- a/doc/source/configuration-options.rst
+++ b/doc/source/configuration-options.rst
@@ -166,6 +166,7 @@ Backup restore options
    restore:
      batchSize: <int>
      numInsertionWorkers: <int>
+     preserveUUID: <bool>
 
 .. option:: batchSize
    
@@ -179,6 +180,12 @@ Backup restore options
    :type: int
    :default: 10
 
-   The number of workers that add the documents to buffer.      
+   The number of workers that add the documents to buffer.
+
+.. option:: preserveUUID
+   :type: bool
+   :default: false
+
+   Preserve collection UUID from backup source.
        
 .. include:: .res/replace.txt      

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -109,6 +109,7 @@ restore.
    restore:
      batchSize: 500
      numInsertionWorkers: 10
+     preserveUUID: false
 
 The default values were adjusted to fit the setups with the memory allocation of 1GB and less for the agent.
 

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -52,8 +52,9 @@ type StorageConf struct {
 
 // RestoreConf is config options for the restore
 type RestoreConf struct {
-	BatchSize           int `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
-	NumInsertionWorkers int `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	BatchSize           int  `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"` // num of documents to buffer
+	NumInsertionWorkers int  `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
+	PreserveUUID        bool `bson:"preserveUUID" json:"preserveUUID,omitempty" yaml:"preserveUUID,omitempty"`
 }
 
 type confMap map[string]reflect.Kind

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -216,7 +216,12 @@ func (r *Restore) init(name string, opid pbm.OPID, l *log.Event) (err error) {
 		return errors.Wrap(err, "define mongo version")
 	}
 
-	r.oplog = NewOplog(r.node, mgoV, preserveUUID)
+	cfg, err := r.cn.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "unable to get PBM config settings")
+	}
+
+	r.oplog = NewOplog(r.node, mgoV, cfg.Restore.PreserveUUID)
 
 	return nil
 }
@@ -375,8 +380,6 @@ func (r *Restore) prepareSnapshot() (err error) {
 }
 
 const (
-	preserveUUID = false
-
 	batchSizeDefault           = 500
 	numInsertionWorkersDefault = 10
 )
@@ -462,7 +465,7 @@ func (r *Restore) RunSnapshot() (err error) {
 			Drop:                     true,
 			NumInsertionWorkers:      numInsertionWorkers,
 			NumParallelCollections:   1,
-			PreserveUUID:             preserveUUID,
+			PreserveUUID:             cfg.Restore.PreserveUUID,
 			StopOnError:              true,
 			TempRolesColl:            "temproles",
 			TempUsersColl:            "tempusers",


### PR DESCRIPTION
https://jira.percona.com/browse/PBM-636

This change will let to config preserveUUID variable.

Collection UUID in sharded env should be the same at each shard + config server collection info db.
But looks like in some cases we don't need to preserve it.

`preserveUUID=false` commit
https://github.com/percona/percona-backup-mongodb/commit/4844a20876719c0c01d5ead54458b76627475c66#diff-2c9604cc50e20be7992d9ec0a27f57a9bf91a2ea9b2aeb848e2cc1d8983532b2R183

[PBM-419](https://jira.percona.com/browse/PBM-419) `preserveUUID=false` feature branch merge
https://github.com/percona/percona-backup-mongodb/commit/99ae9f5c