### PR TITLE
Fix storage check

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -336,8 +336,7 @@ func (a *Agent) storStatus(log *log.Event) (sts pbm.SubsysStatus) {
 			sts.Err = fmt.Sprintf("storage: no init file, attempt to create failed: %v", err)
 			return sts
 		}
-	}
-	if err != nil {
+	} else if err != nil {
 		sts.Err = fmt.Sprintf("storage check failed with: %v", err)
 		return sts
 	}


### PR DESCRIPTION
If `.pbm.init` didn't exists and PBM successfully creates it still falls
into the condition of the next error check. And returns
`storage check failed with: no such file`. On the next run, everything gonna be ok but still annoying error in logs...

This commit fixes it.