### PR TITLE
Exclude arbiter nodes when installing pbm-agent

### DIFF
--- a/doc/source/initial-setup.rst
+++ b/doc/source/initial-setup.rst
@@ -3,7 +3,7 @@
 Initial setup   
 ****************************************************************
 
-After you’ve installed |pbm-agent| on every server with the ``mongod`` node, perform initial setup to run |PBM|.
+After you’ve installed |pbm-agent| on every server with a ``mongod`` node that is not an arbiter node, perform initial setup to run |PBM|.
 
 The setup steps are the following:
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -29,8 +29,10 @@ pbm-agent        An agent for running backup/restore actions on a database host
 
 |
 
-Install |pbm-agent| on every server that has mongod nodes in the
-MongoDB cluster (or non-sharded replica set). You can install |pbm.app| CLI 
+Install |pbm-agent| on every server that has ``mongod`` nodes in the
+MongoDB cluster (or non-sharded replica set). You don't need to install |pbm-agent| on arbiter nodes as they don't have the data set.
+
+You can install |pbm.app| CLI 
 on any or all servers or desktop computers you wish to use it from, so long as
 those computers aren't network-blocked from accessing the MongoDB cluster.
 


### PR DESCRIPTION
Arbiter mongod nodes do not need a pbm-agent installed.