### PR TITLE
PBM-642 fix: show priority=0 & hidden nodes in status

### DIFF
--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -185,20 +185,30 @@ func (c cluster) String() (s string) {
 }
 
 func clusterStatus(cn *pbm.PBM) (fmt.Stringer, error) {
-	inf, err := cn.GetNodeInfo()
+	cstat, err := cn.GetReplsetStatus()
 	if err != nil {
-		return nil, errors.Wrap(err, "get cluster info")
+		return nil, errors.Wrap(err, "get replSetGetStatus info")
+	}
+	var rshosts []string
+	for _, n := range cstat.Members {
+		rshosts = append(rshosts, n.Name)
 	}
 
 	type clstr struct {
 		rs    string
 		nodes []string
 	}
+
 	topology := []clstr{
 		{
-			rs:    inf.SetName,
-			nodes: inf.Hosts,
+			rs:    cstat.Set,
+			nodes: rshosts,
 		},
+	}
+
+	inf, err := cn.GetNodeInfo()
+	if err != nil {
+		return nil, errors.Wrap(err, "get cluster info")
 	}
 
 	if inf.IsSharded() {

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -951,3 +951,14 @@ func (p *PBM) AgentStatusGC() error {
 
 	return errors.Wrap(err, "delete")
 }
+
+// GetReplsetStatus returns `replSetGetStatus` for the replset
+// or config server in case of sharded cluster
+func (p *PBM) GetReplsetStatus() (*ReplsetStatus, error) {
+	status := &ReplsetStatus{}
+	err := p.Conn.Database("admin").RunCommand(p.ctx, bson.D{{"replSetGetStatus", 1}}).Decode(status)
+	if err != nil {
+		return nil, errors.Wrap(err, "run mongo command replSetGetStatus")
+	}
+	return status, err
+}


### PR DESCRIPTION
For the single replica set of config server in the sharded cluster, we should retrieve replSetGetStatus in order to get a node list with priority=0 and hidden nodes.

https://jira.percona.com/browse/PBM-642