### PR TITLE
PBM-636: temporarily disable PreserveUUID

### DIFF
--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -378,7 +378,7 @@ func (r *Restore) prepareSnapshot() (err error) {
 }
 
 const (
-	preserveUUID = true
+	preserveUUID = false
 
 	batchSizeDefault           = 500
 	numInsertionWorkersDefault = 10


### PR DESCRIPTION
Since the newly discovered issue with restoring of system.users breaks operator testes