### PR TITLE
PBM-662: PITR status, check if running, not just conf

### DIFF
--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -255,12 +255,17 @@ func clusterStatus(cn *pbm.PBM) (fmt.Stringer, error) {
 }
 
 type pitrStat struct {
-	Status string `json:"status"`
-	Err    string `json:"error,omitempty"`
+	InConf  bool   `json:"conf"`
+	Running bool   `json:"run"`
+	Err     string `json:"error,omitempty"`
 }
 
 func (p pitrStat) String() string {
-	s := fmt.Sprintf("Status [%s]", p.Status)
+	status := "OFF"
+	if p.InConf || p.Running {
+		status = "ON"
+	}
+	s := fmt.Sprintf("Status [%s]", status)
 	if p.Err != "" {
 		s += fmt.Sprintf("\n! ERROR while running PITR backup: %s", p.Err)
 	}
@@ -269,15 +274,16 @@ func (p pitrStat) String() string {
 
 func getPitrStatus(cn *pbm.PBM) (fmt.Stringer, error) {
 	var p pitrStat
-	on, err := cn.IsPITR()
+	var err error
+	p.InConf, err = cn.IsPITR()
 	if err != nil {
-		return p, errors.Wrap(err, "unable check PITR status")
+		return p, errors.Wrap(err, "unable check PITR config status")
 	}
-	if !on {
-		p.Status = "OFF"
-		return p, nil
+
+	p.Running, err = cn.PITRrun()
+	if err != nil {
+		return p, errors.Wrap(err, "unable check PITR running status")
 	}
-	p.Status = "ON"
 
 	p.Err, err = getPitrErr(cn)
 


### PR DESCRIPTION
PBM status reflecting PITR state should also check locks because there is a lag
between config option and agents' state.

Now `pbm status` in text output shows PITR "ON" if either
config.pitr.enabled=on or there is PITR lock(s). JSON output contains
both options so API users could decide on their own.
JSON:
```
	"PITR incremental backup": {
		"conf": true,
		"run": false,
		"error": "2021-04-09T22:32:35.000+0300 E [config/localhost:37028] [pitr] init: defining starting point for the backup: no backup found after the restored 2021-04-06T17:09:48Z, a new backup is required to resume PITR"
	}
```
*error is omitted if empty

https://jira.percona.com/browse/PBM-662