### PR TITLE
PBM-490: sync backup start time

### DIFF
--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -437,6 +437,7 @@ type BackupMeta struct {
 	MongoVersion     string               `bson:"mongodb_version" json:"mongodb_version,omitempty"`
 	StartTS          int64                `bson:"start_ts" json:"start_ts"`
 	LastTransitionTS int64                `bson:"last_transition_ts" json:"last_transition_ts"`
+	FirstWriteTS     primitive.Timestamp  `bson:"first_write_ts" json:"first_write_ts"`
 	LastWriteTS      primitive.Timestamp  `bson:"last_write_ts" json:"last_write_ts"`
 	Hb               primitive.Timestamp  `bson:"hb" json:"hb"`
 	Status           Status               `bson:"status" json:"status"`
@@ -548,12 +549,13 @@ func (p *PBM) BackupHB(bcpName string) error {
 	return errors.Wrap(err, "write into db")
 }
 
-func (p *PBM) SetLastWrite(bcpName string, ts primitive.Timestamp) error {
+func (p *PBM) SetFirstLastWrite(bcpName string, first, last primitive.Timestamp) error {
 	_, err := p.Conn.Database(DB).Collection(BcpCollection).UpdateOne(
 		p.ctx,
 		bson.D{{"name", bcpName}},
 		bson.D{
-			{"$set", bson.M{"last_write_ts": ts}},
+			{"$set", bson.M{"first_write_ts": first}},
+			{"$set", bson.M{"last_write_ts": last}},
 		},
 	)
 


### PR DESCRIPTION
Although we do synchronise oplog last write across agents in the sharded
cluster, the first write captured oplog is differ across the cluster. Hence
the backup start isn't synchronised. There is no way to start snapshot
(mongodump) at the same cluster time across the nodes. But we can do
that for oplog capturing.

This commit makes oplog start time (cluster time) to be the same across
all nodes. So oplog coverage now is consistent across the cluster not
only for the last write but for the first write as well.

https://jira.percona.com/browse/PBM-490