### PR TITLE
Fix user and roles collections restore

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -230,7 +230,13 @@ func (b *Backup) run(ctx context.Context, bcp pbm.BackupCmd, opid pbm.OPID, l *p
 		return errors.Wrap(err, "copy users and roles for the restore")
 	}
 
-	defer l.Debug("drop tmp users and roles: %v", errors.Wrap(b.node.DropTMPcoll(), "error"))
+	defer func() {
+		l.Info("dropping tmp collections")
+		err := b.node.DropTMPcoll()
+		if err != nil {
+			l.Warning("drop tmp users and roles: %v", err)
+		}
+	}()
 
 	sz, err := b.node.SizeDBs()
 	if err != nil {

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -226,7 +226,7 @@ func (n *Node) DropTMPcoll() error {
 	}
 	defer cn.Disconnect(n.ctx)
 
-	err = DropTMPcoll(n.ctx, n.cn)
+	err = DropTMPcoll(n.ctx, cn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Tmp users and roles collection didn't get into the backup since they were
dropped before due to `defer` evaluation. Hence users other than PBM's
one weren't restoring. The other thing is that DropTMPcoll wasn't dropping
anything (due to a connection bug) on topologies other than single-node
replica sets. So it wasn't an issue on replicasets and sharded clusters.