### PR TITLE
 PBM-636: fix waiting time for tmp users

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -238,6 +238,7 @@ func (b *Backup) run(ctx context.Context, bcp pbm.BackupCmd, opid pbm.OPID, l *p
 	// before proceeding any further we have to be sure that tmp users and roles
 	// have replicated to the node we're about to take a backup from
 	// *copying made on a primary but backup does a secondary node
+	l.Debug("wait for tmp users %v", lw)
 	err = b.node.WaitForWrite(lw)
 	if err != nil {
 		return errors.Wrap(err, "wait for tmp users and roles replication")

--- a/pbm/backup/oplog.go
+++ b/pbm/backup/oplog.go
@@ -123,7 +123,7 @@ func (ot *Oplog) WriteTo(w io.Writer) (int64, error) {
 
 // LastWrite returns a timestamp of the last write operation readable by majority reads
 func (ot *Oplog) LastWrite() (primitive.Timestamp, error) {
-	return pbm.LastWrite(ot.node.Session())
+	return pbm.LastWrite(ot.node.Session(), true)
 }
 
 func (ot *Oplog) collectionName() (string, error) {

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -3,6 +3,7 @@ package pbm
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/pkg/errors"
@@ -255,6 +256,7 @@ func (n *Node) WaitForWrite(ts primitive.Timestamp) (err error) {
 	for i := 0; i < 21; i++ {
 		lw, err = LastWrite(n.cn)
 		if err == nil && primitive.CompareTimestamp(lw, ts) >= 0 {
+			log.Printf("got cluster time %v", lw)
 			return nil
 		}
 		time.Sleep(time.Second * 1)

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -3,7 +3,6 @@ package pbm
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/pkg/errors"
@@ -254,9 +253,8 @@ func DropTMPcoll(ctx context.Context, cn *mongo.Client) error {
 func (n *Node) WaitForWrite(ts primitive.Timestamp) (err error) {
 	var lw primitive.Timestamp
 	for i := 0; i < 21; i++ {
-		lw, err = LastWrite(n.cn)
+		lw, err = LastWrite(n.cn, false)
 		if err == nil && primitive.CompareTimestamp(lw, ts) >= 0 {
-			log.Printf("got cluster time %v", lw)
 			return nil
 		}
 		time.Sleep(time.Second * 1)
@@ -269,17 +267,20 @@ func (n *Node) WaitForWrite(ts primitive.Timestamp) (err error) {
 	return errors.New("run out of time")
 }
 
-func LastWrite(cn *mongo.Client) (primitive.Timestamp, error) {
+func LastWrite(cn *mongo.Client, majority bool) (primitive.Timestamp, error) {
 	inf := &NodeInfo{}
 	err := cn.Database("admin").RunCommand(context.Background(), bson.D{{"isMaster", 1}}).Decode(inf)
 	if err != nil {
 		return primitive.Timestamp{}, errors.Wrap(err, "get NodeInfo data")
 	}
-
-	if inf.LastWrite.MajorityOpTime.TS.T == 0 {
+	lw := inf.LastWrite.MajorityOpTime.TS
+	if !majority {
+		lw = inf.LastWrite.OpTime.TS
+	}
+	if lw.T == 0 {
 		return primitive.Timestamp{}, errors.New("last write timestamp is nil")
 	}
-	return inf.LastWrite.MajorityOpTime.TS, nil
+	return lw, nil
 }
 
 func (n *Node) CopyUsersNRolles() (lastWrite primitive.Timestamp, err error) {
@@ -312,5 +313,5 @@ func (n *Node) CopyUsersNRolles() (lastWrite primitive.Timestamp, err error) {
 		return lastWrite, errors.Wrap(err, "copy admin.system.users")
 	}
 
-	return LastWrite(cn)
+	return LastWrite(cn, false)
 }


### PR DESCRIPTION
We were writing to the primary but reading last_write of the majority.
So time_to_wait usually were some previous write because the needed one wasn't replicated yet to the majority.

Last_write to wait for should be taken not from the majority but from the node we are writing tmp users to.