### PR TITLE
PBM-543 feature: Configurable duration PITR slices' span

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_FLAGS=-mod=vendor -tags gssapi
 versionpath?=github.com/percona/percona-backup-mongodb/version
 LDFLAGS= -X $(versionpath).gitCommit=$(GITCOMMIT) -X $(versionpath).gitBranch=$(GITBRANCH) -X $(versionpath).buildTime=$(BUILDTIME) -X $(versionpath).version=$(VERSION)
 LDFLAGS_STATIC=$(LDFLAGS) -extldflags "-static"
-LDFLAGS_TESTS_BUILD=$(LDFLAGS) -X github.com/percona/percona-backup-mongodb/pbm/pitr.ibackupspan=30000000000
+LDFLAGS_TESTS_BUILD=$(LDFLAGS)
 
 test:
 	MONGODB_VERSION=$(MONGO_TEST_VERSION) e2e-tests/run-all

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -103,7 +103,9 @@ func (a *Agent) Backup(cmd pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		l.Warning("clearing pitr locks: %v", err)
 	}
 	// wakeup the slicer not to wait for the tick
-	a.wakeupPitr()
+	if p := a.getPitr(); p != nil {
+		p.wakeup <- struct{}{}
+	}
 
 	bcp := backup.New(a.pbm, a.node)
 	if nodeInfo.IsClusterLeader() {

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -39,12 +39,18 @@ func NewCtl(ctx context.Context, host string) (*Ctl, error) {
 func (c *Ctl) PITRon() error {
 	out, err := c.RunCmd("pbm", "config", "--set", "pitr.enabled=true")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "config set pitr.enabled=true")
+	}
+
+	_, err = c.RunCmd("pbm", "config", "--set", "pitr.oplogSpanMin=0.5")
+	if err != nil {
+		return errors.Wrap(err, "config set pitr.oplogSpanMin=0.5")
 	}
 
 	fmt.Println("done", out)
 	return nil
 }
+
 func (c *Ctl) PITRoff() error {
 	out, err := c.RunCmd("pbm", "config", "--set", "pitr.enabled=false")
 	if err != nil {

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -33,7 +33,8 @@ type Config struct {
 
 // PITRConf is a Point-In-Time Recovery options
 type PITRConf struct {
-	Enabled bool `bson:"enabled" json:"enabled" yaml:"enabled"`
+	Enabled      bool    `bson:"enabled" json:"enabled" yaml:"enabled"`
+	OplogSpanMin float64 `bson:"oplogSpanMin" json:"oplogSpanMin" yaml:"oplogSpanMin"`
 }
 
 // StorageType represents a type of the destination storage for backups


### PR DESCRIPTION
Set in minutes via config option `pitr.oplogSpanMin`. Option is float so fractures of minutes could be set. E.g. `0.5` is 30 sec.

PITR routine every 15 seconds along with `pitr.enabled` would be check `pitr.oplogSpanMin`.
And if the agent runs slicer and span duration has changed, the slicer would be updated with the new value. If the new value is smaller, the slicer also would be woken up to immediately make a slice and reset the timer.
If the new value is bigger, then the slicer won't be woken up (it will apply a new value only after the current span finishes).