### PR TITLE
PBM-683 fix: handle retryReader errors during the restore

### DIFF
--- a/pbm/restore/oplog.go
+++ b/pbm/restore/oplog.go
@@ -108,7 +108,7 @@ func (o *Oplog) Apply(src io.ReadCloser) (lts primitive.Timestamp, err error) {
 		lts = oe.Timestamp
 	}
 
-	return lts, nil
+	return lts, bsonSource.Err()
 }
 
 func (o *Oplog) handleTxnOp(meta txn.Meta, op db.Oplog) error {

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -428,6 +428,7 @@ func (s *S3) SourceReader(name string) (io.ReadCloser, error) {
 				s.log.Info("session recreated, resuming download")
 			}
 			s.log.Error("download '%s/%s' file from S3: %v", s.opts.Bucket, name, err)
+			w.CloseWithError(errors.Wrapf(err, "download '%s/%s'", s.opts.Bucket, name))
 			return
 		}
 	}()


### PR DESCRIPTION
This commit makes the restore process fail with an error should the error happened during S3 retry read. Previously it was only logged but restore was marked as successful.

https://jira.percona.com/browse/PBM-683