### PR TITLE
PBM-403: hide user credential from ps output

### DIFF
--- a/cmd/pbm-agent/args.go
+++ b/cmd/pbm-agent/args.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/url"
 	"os"
@@ -22,7 +21,7 @@ func setarg(i int, as string) {
 	}
 }
 
-// hidecreds erases creds (user & pass) if there are any in mongo connection flags
+// hidecreds replaces creds (user & pass) with bunch of `x` if there are any in mongo connection flags
 func hidecreds() {
 	for k, v := range os.Args {
 		if strings.HasPrefix(v, mauthPrefix) {
@@ -36,9 +35,23 @@ func hidecreds() {
 				return
 			}
 
-			u.User = nil
-			fmt.Println(u.String())
+			var xuser, xpass []byte
+			xuser = make([]byte, len(u.User.Username()))
+			p, _ := u.User.Password()
+			xpass = make([]byte, len(p))
+
+			padx(xuser)
+			padx(xpass)
+
+			u.User = url.UserPassword(string(xuser), string(xpass))
+
 			setarg(k, mauthPrefix+u.String())
 		}
+	}
+}
+
+func padx(s []byte) {
+	for i := 0; i < len(s); i++ {
+		s[i] = 'x'
 	}
 }

--- a/cmd/pbm-agent/args.go
+++ b/cmd/pbm-agent/args.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"reflect"
+	"strings"
+	"unsafe"
+)
+
+const mauthPrefix = "--" + mongoConnFlag + "="
+
+func setarg(i int, as string) {
+	ptr := (*reflect.StringHeader)(unsafe.Pointer(&os.Args[i]))
+	arg := (*[1 << 30]byte)(unsafe.Pointer(ptr.Data))[:ptr.Len]
+
+	n := copy(arg, as)
+	for ; n < len(arg); n++ {
+		arg[n] = 0
+	}
+}
+
+// hidecreds erases creds (user & pass) if there are any in mongo connection flags
+func hidecreds() {
+	for k, v := range os.Args {
+		if strings.HasPrefix(v, mauthPrefix) {
+			str := strings.TrimPrefix(v, mauthPrefix)
+			u, err := url.Parse(str)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			if u.User == nil || u.User.String() == "" {
+				return
+			}
+
+			u.User = nil
+			fmt.Println(u.String())
+			setarg(k, mauthPrefix+u.String())
+		}
+	}
+}


### PR DESCRIPTION
When we extract creds from the argument the text became shorter while the mem size remains the same so we have to pad this difference with zeroes.
This leads to a bit strange output if shortened flag followed by any other flag - quite a few spaces between flags.

https://jira.percona.com/browse/PBM-403