### PR TITLE
PBM-640: fix logs labels

### DIFF
--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -237,7 +237,7 @@ func (a *Agent) pitrLockCheck() (moveOn bool, err error) {
 
 // PITRestore starts the point-in-time recovery
 func (a *Agent) PITRestore(r pbm.PITRestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
-	l := a.log.NewEvent(string(pbm.CmdPITR), time.Unix(r.TS, 0).UTC().Format(time.RFC3339), opid.String(), ep.TS())
+	l := a.log.NewEvent(string(pbm.CmdPITRestore), time.Unix(r.TS, 0).UTC().Format(time.RFC3339), opid.String(), ep.TS())
 
 	nodeInfo, err := a.node.GetInfo()
 	if err != nil {

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -67,7 +67,7 @@ var (
 	logsOutF   = logsCmd.Flag("out", "Output format <text>/<json>").Short('o').Default("text").Enum("json", "text")
 	logsNodeF  = logsCmd.Flag("node", "Target node in format replset[/host:posrt]").Short('n').String()
 	logsTypeF  = logsCmd.Flag("severity", "Severity level D, I, W, E or F, low to high. Choosing one includes higher levels too.").Short('s').Default("I").Enum("D", "I", "W", "E", "F")
-	logsEventF = logsCmd.Flag("event", "Event in format backup[/2020-10-06T11:45:14Z]. Events: backup, restore, cancelBackup, resyncBcpList, pitr, pitrestore, delete").Short('e').String()
+	logsEventF = logsCmd.Flag("event", "Event in format backup[/2020-10-06T11:45:14Z]. Events: backup, restore, resyncBcpList, pitr, pitrestore, delete").Short('e').String()
 	logsOPIDF  = logsCmd.Flag("opid", "Operation ID").Short('i').String()
 
 	statusCmd  = pbmCmd.Command("status", "Show PBM status")


### PR DESCRIPTION
`cancelBackup` label was removed from logs `--help` as there are no log actions happens for this even. When the backup is cancelled event related to the particular backup (in logs too).

https://jira.percona.com/browse/PBM-640