### PR TITLE
PBM-652: delete PITR chunks

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,6 +44,8 @@ func Main() {
 		pbmOutFormat = pbmCmd.Flag("out", "Output format <text>/<json>").Short('o').Default(string(outText)).Enum(string(outJSON), string(outJSONpretty), string(outText))
 	)
 
+	pbmCmd.HelpFlag.Short('h')
+
 	configCmd := pbmCmd.Command("config", "Set, change or list the config")
 	cfg := configOpts{set: make(map[string]string)}
 	configCmd.Flag("force-resync", "Resync backup list with the current store").BoolVar(&cfg.rsync)
@@ -81,6 +83,12 @@ func Main() {
 	deleteBcpCmd.Arg("name", "Backup name").StringVar(&deleteBcp.name)
 	deleteBcpCmd.Flag("older-than", fmt.Sprintf("Delete backups older than date/time in format %s or %s", datetimeFormat, dateFormat)).StringVar(&deleteBcp.olderThan)
 	deleteBcpCmd.Flag("force", "Force. Don't ask confirmation").Short('f').BoolVar(&deleteBcp.force)
+
+	deletePitrCmd := pbmCmd.Command("delete-pitr", "Delete PITR chunks")
+	deletePitr := deletePitrOpts{}
+	deletePitrCmd.Flag("older-than", fmt.Sprintf("Delete backups older than date/time in format %s or %s", datetimeFormat, dateFormat)).StringVar(&deletePitr.olderThan)
+	deletePitrCmd.Flag("all", "Delete all chunks").Short('a').BoolVar(&deletePitr.all)
+	deletePitrCmd.Flag("force", "Force. Don't ask confirmation").Short('f').BoolVar(&deletePitr.force)
 
 	logsCmd := pbmCmd.Command("logs", "PBM logs")
 	logs := logsOpts{}
@@ -130,6 +138,8 @@ func Main() {
 		out, err = runList(pbmClient, &list)
 	case deleteBcpCmd.FullCommand():
 		out, err = deleteBackup(pbmClient, &deleteBcp, pbmOutF)
+	case deletePitrCmd.FullCommand():
+		out, err = deletePITR(pbmClient, &deletePitr, pbmOutF)
 	case logsCmd.FullCommand():
 		out, err = runLogs(pbmClient, &logs)
 	case statusCmd.FullCommand():

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -83,3 +83,79 @@ func deleteBackup(pbmClient *pbm.PBM, d *deleteBcpOpts, outf outFormat) (fmt.Str
 
 	return runList(pbmClient, &listOpts{})
 }
+
+type deletePitrOpts struct {
+	olderThan string
+	force     bool
+	all       bool
+}
+
+func deletePITR(pbmClient *pbm.PBM, d *deletePitrOpts, outf outFormat) (fmt.Stringer, error) {
+	if !d.all && len(d.olderThan) == 0 {
+		return nil, errors.New("either --older-than or --all should be set")
+	}
+
+	if !d.force && isTTY() {
+		all := ""
+		if d.all {
+			all = " ALL"
+		}
+		fmt.Printf("Are you sure you want delete%s chunks? [y/N] ", all)
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		switch strings.TrimSpace(scanner.Text()) {
+		case "yes", "Yes", "YES", "Y", "y":
+		default:
+			return nil, nil
+		}
+	}
+
+	cmd := pbm.Cmd{
+		Cmd: pbm.CmdDeletePITR,
+	}
+	if !d.all && len(d.olderThan) > 0 {
+		t, err := parseDateT(d.olderThan)
+		if err != nil {
+			return nil, errors.Wrap(err, "parse date")
+		}
+		cmd.DeletePITR.OlderThan = t.UTC().Unix()
+	}
+	tsop := time.Now().UTC().Unix()
+	err := pbmClient.SendCmd(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "schedule pitr delete")
+	}
+	if outf != outText {
+		return nil, nil
+	}
+
+	fmt.Print("Waiting for delete to be done ")
+	err = waitOp(pbmClient,
+		&pbm.LockHeader{
+			Type: pbm.CmdDeletePITR,
+		},
+		time.Second*60)
+	if err != nil && err != errTout {
+		return nil, err
+	}
+
+	errl, err := lastLogErr(pbmClient, pbm.CmdDeletePITR, tsop)
+	if err != nil {
+		return nil, errors.Wrap(err, "read agents log")
+	}
+
+	if errl != "" {
+		return nil, errors.New(errl)
+	}
+
+	if err == errTout {
+		fmt.Println("\nOperation is still in progress, please check status in a while")
+	} else {
+		time.Sleep(time.Second)
+		fmt.Print(".")
+		time.Sleep(time.Second)
+		fmt.Println("[done]")
+	}
+
+	return runList(pbmClient, &listOpts{})
+}

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -115,12 +115,21 @@ func (c *Ctl) List() (*ListOut, error) {
 		return nil, errors.Wrap(err, "run pbm list -o json")
 	}
 	l := new(ListOut)
-	err = json.Unmarshal(stripCtl(o), l)
+	err = json.Unmarshal(skipCtl(o), l)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal list")
 	}
 
 	return l, nil
+}
+
+func skipCtl(str string) []byte {
+	for i := 0; i < len(str); i++ {
+		if str[i] == '{' {
+			return []byte(str[i:])
+		}
+	}
+	return []byte(str)
 }
 
 func stripCtl(str string) []byte {

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -71,6 +71,7 @@ const (
 	CmdPITR             Command = "pitr"
 	CmdPITRestore       Command = "pitrestore"
 	CmdDeleteBackup     Command = "delete"
+	CmdDeletePITR       Command = "deletePitr"
 )
 
 func (c Command) String() string {
@@ -89,6 +90,8 @@ func (c Command) String() string {
 		return "PITR restore"
 	case CmdDeleteBackup:
 		return "Delete"
+	case CmdDeletePITR:
+		return "Delete PITR chunks"
 	default:
 		return "Undefined"
 	}
@@ -102,6 +105,7 @@ type Cmd struct {
 	Restore    RestoreCmd      `bson:"restore,omitempty"`
 	PITRestore PITRestoreCmd   `bson:"pitrestore,omitempty"`
 	Delete     DeleteBackupCmd `bson:"delete,omitempty"`
+	DeletePITR DeletePITRCmd   `bson:"deletePitr,omitempty"`
 	TS         int64           `bson:"ts"`
 	OPID       OPID            `bson:"-"`
 }
@@ -182,6 +186,10 @@ func (p PITRestoreCmd) String() string {
 type DeleteBackupCmd struct {
 	Backup    string `bson:"backup"`
 	OlderThan int64  `bson:"olderthan"`
+}
+
+type DeletePITRCmd struct {
+	OlderThan int64 `bson:"olderthan"`
 }
 
 func (d DeleteBackupCmd) String() string {
@@ -649,7 +657,7 @@ func (p *PBM) GetFirstBackup() (*BackupMeta, error) {
 }
 
 // GetLastBackup returns last successfully finished backup
-// and nil if there is no such backup yet. If ts isn't nil it will
+// or nil if there is no such backup yet. If ts isn't nil it will
 // search for the most recent backup that finished before specified timestamp
 func (p *PBM) GetLastBackup(before *primitive.Timestamp) (*BackupMeta, error) {
 	return p.getRecentBackup(before, -1)

--- a/pbm/pitr.go
+++ b/pbm/pitr.go
@@ -101,14 +101,32 @@ func (p *PBM) pitrChunk(rs string, sort int) (*PITRChunk, error) {
 }
 
 // PITRGetChunksSlice returns slice of PITR oplog chunks which Start TS
-// lies in a given time frame
+// lies in a given time frame. Returns all chunks if `to` is 0.
 func (p *PBM) PITRGetChunksSlice(rs string, from, to primitive.Timestamp) ([]PITRChunk, error) {
 	q := bson.D{}
 	if rs != "" {
 		q = bson.D{{"rs", rs}}
 	}
-	q = append(q, bson.E{"start_ts", bson.M{"$gte": from, "$lte": to}})
+	if to.T > 0 {
+		q = append(q, bson.E{"start_ts", bson.M{"$gte": from, "$lte": to}})
+	}
 
+	return p.pitrGetChunksSlice(rs, q)
+}
+
+// PITRGetChunksSliceUntil returns slice of PITR oplog chunks that starts up until timestamp (exclusively)
+func (p *PBM) PITRGetChunksSliceUntil(rs string, t primitive.Timestamp) ([]PITRChunk, error) {
+	q := bson.D{}
+	if rs != "" {
+		q = bson.D{{"rs", rs}}
+	}
+
+	q = append(q, bson.E{"start_ts", bson.M{"$lt": t}})
+
+	return p.pitrGetChunksSlice(rs, q)
+}
+
+func (p *PBM) pitrGetChunksSlice(rs string, q bson.D) ([]PITRChunk, error) {
 	cur, err := p.Conn.Database(DB).Collection(PITRChunksCollection).Find(
 		p.ctx,
 		q,
@@ -121,7 +139,6 @@ func (p *PBM) PITRGetChunksSlice(rs string, from, to primitive.Timestamp) ([]PIT
 	defer cur.Close(p.ctx)
 
 	chnks := []PITRChunk{}
-
 	for cur.Next(p.ctx) {
 		var chnk PITRChunk
 		err := cur.Decode(&chnk)


### PR DESCRIPTION
Added command `pbm delete-pitr`. With two flags:
- ` -a, --all` - delete all chunks
- `--older-than`

If `--older-than` set, it will be rounded down to the last write of the closest preceding backup in order not to make gaps. So usually it gonna leave some extra chunks. E.g. if `older-than = 13` and the last write of the closest preceding backup is `10` it will leave `11` and `12` chunks as well since `13` won't be restorable without `11` and `12` (contiguous timeline from the backup).

https://jira.percona.com/browse/PBM-652