### PR TITLE
PBM-686: skip a first second displaying PITR range

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -268,6 +268,7 @@ func getPitrList(cn *pbm.PBM, size int, full bool) (ranges []pitrRange, rsRanges
 		if bcp.Status != pbm.StatusDone || !version.Compatible(version.DefaultInfo.Version, bcp.PBMVersion) {
 			continue
 		}
+		tl.Start++
 		ranges = append(ranges, pitrRange{Range: tl})
 	}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -602,7 +602,7 @@ func getPITRranges(cn *pbm.PBM, stg storage.Storage) (*pitrRanges, error) {
 	for i := len(merged) - 1; i >= 0; i-- {
 		tl := merged[i]
 		var rng pitrRange
-		rng.Range.Start = tl.Start
+		rng.Range.Start = tl.Start + 1
 		rng.Range.End = tl.End
 
 		bcp, err := cn.GetLastBackup(&primitive.Timestamp{T: tl.End, I: 0})

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -127,8 +127,8 @@ func (c *Cluster) BackupDelete(storage string) {
 		log.Fatalf("ERROR: empty spanpshots list")
 	}
 
-	if list.PITR.Ranges[0].Range.Start != uint32(list.Snapshots[len(list.Snapshots)-1].StateTS) {
-		log.Println("ERROR: expected range match the last backup complete time")
+	if list.PITR.Ranges[0].Range.Start+1 != uint32(list.Snapshots[len(list.Snapshots)-1].StateTS) {
+		log.Println("ERROR: expected range starts the next second after the backup complete time")
 		c.printBcpList()
 		os.Exit(1)
 	}

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -127,8 +127,8 @@ func (c *Cluster) BackupDelete(storage string) {
 		log.Fatalf("ERROR: empty spanpshots list")
 	}
 
-	if list.PITR.Ranges[0].Range.Start+1 != uint32(list.Snapshots[len(list.Snapshots)-1].StateTS) {
-		log.Println("ERROR: expected range starts the next second after the backup complete time")
+	if list.PITR.Ranges[0].Range.Start-1 != uint32(list.Snapshots[len(list.Snapshots)-1].StateTS) {
+		log.Printf("ERROR: expected range starts the next second after the backup complete time, %v | %v", list.PITR.Ranges[0].Range.Start+1, uint32(list.Snapshots[len(list.Snapshots)-1].StateTS))
 		c.printBcpList()
 		os.Exit(1)
 	}

--- a/pbm/pitr.go
+++ b/pbm/pitr.go
@@ -256,7 +256,7 @@ func gettimelines(slices []PITRChunk) (tlines []Timeline) {
 			tl = Timeline{}
 		}
 		if tl.Start == 0 {
-			tl.Start = s.StartTS.T + 1
+			tl.Start = s.StartTS.T
 		}
 		prevEnd = s.EndTS
 		tl.End = s.EndTS.T

--- a/pbm/pitr.go
+++ b/pbm/pitr.go
@@ -256,7 +256,7 @@ func gettimelines(slices []PITRChunk) (tlines []Timeline) {
 			tl = Timeline{}
 		}
 		if tl.Start == 0 {
-			tl.Start = s.StartTS.T
+			tl.Start = s.StartTS.T + 1
 		}
 		prevEnd = s.EndTS
 		tl.End = s.EndTS.T


### PR DESCRIPTION
In fact, this second is overlaps with the backup's complete time. To restore to this time user should restore the snapshot instead of PITR.

https://jira.percona.com/browse/PBM-686