### PR TITLE
fix tests for UID!=1001

### DIFF
--- a/e2e-tests/docker/docker-compose-rs.yaml
+++ b/e2e-tests/docker/docker-compose-rs.yaml
@@ -15,7 +15,12 @@ services:
       - ./backups:/opt/backups
 
   rs101:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs101
     environment:
       - REPLSET_NAME=rs1
@@ -25,21 +30,27 @@ services:
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
-      - ./keyFile:/opt/keyFile
   rs102:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs102
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   rs103:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs103
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   agent-rs101:
     container_name: "pbmagent_rs101"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"
@@ -60,6 +71,7 @@ services:
       - rs101
   agent-rs102:
     container_name: "pbmagent_rs102"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"
@@ -79,6 +91,7 @@ services:
       - ./backups:/opt/backups
   agent-rs103:
     container_name: "pbmagent_rs103"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"

--- a/e2e-tests/docker/docker-compose-single.yaml
+++ b/e2e-tests/docker/docker-compose-single.yaml
@@ -15,7 +15,12 @@ services:
       - ./backups:/opt/backups
 
   rs101:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs101
     environment:
       - REPLSET_NAME=rs1
@@ -26,10 +31,10 @@ services:
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
-      - ./keyFile:/opt/keyFile
 
   agent-rs101:
     container_name: "pbmagent_rs101"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -17,7 +17,12 @@ services:
       - mongos
 
   cfg01:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: cfg01
     environment:
       - REPLSET_NAME=cfg
@@ -28,21 +33,27 @@ services:
     command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger  --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
-      - ./keyFile:/opt/keyFile
   cfg02:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: cfg02
     command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   cfg03:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: cfg03
     command: mongod --configsvr --dbpath /data/db --replSet cfg --bind_ip_all --port 27017 --keyFile /opt/keyFile --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   agent-cfg01:
     container_name: "pbmagent_cfg01"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=cfg"
@@ -62,6 +73,7 @@ services:
       - ./backups:/opt/backups
   agent-cfg02:
     container_name: "pbmagent_cfg02"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=cfg"
@@ -81,6 +93,7 @@ services:
       - ./backups:/opt/backups
   agent-cfg03:
     container_name: "pbmagent_cfg03"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=cfg"
@@ -100,7 +113,12 @@ services:
       - ./backups:/opt/backups
 
   rs101:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs101
     environment:
       - REPLSET_NAME=rs1
@@ -111,21 +129,27 @@ services:
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
-      - ./keyFile:/opt/keyFile
   rs102:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs102
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   rs103:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs103
     command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   agent-rs101:
     container_name: "pbmagent_rs101"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"
@@ -146,6 +170,7 @@ services:
       - rs101
   agent-rs102:
     container_name: "pbmagent_rs102"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"
@@ -165,6 +190,7 @@ services:
       - ./backups:/opt/backups
   agent-rs103:
     container_name: "pbmagent_rs103"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs1"
@@ -184,7 +210,12 @@ services:
       - ./backups:/opt/backups
     
   rs201:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs201
     environment:
       - REPLSET_NAME=rs2
@@ -195,21 +226,27 @@ services:
     command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - ./scripts/start.sh:/opt/start.sh
-      - ./keyFile:/opt/keyFile
   rs202:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs202
     command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   rs203:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: rs203
     command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --shardsvr  --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
-    volumes:
-      - ./keyFile:/opt/keyFile
   agent-rs201:
     container_name: "pbmagent_rs201"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs2"
@@ -229,6 +266,7 @@ services:
       - ./backups:/opt/backups
   agent-rs202:
     container_name: "pbmagent_rs202"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs2"
@@ -248,6 +286,7 @@ services:
       - ./backups:/opt/backups
   agent-rs203:
     container_name: "pbmagent_rs203"
+    user: ${USER_ID}
     labels:
       - "com.percona.pbm.app=agent"
       - "com.percona.pbm.agent.rs=rs2"
@@ -267,14 +306,18 @@ services:
       - ./backups:/opt/backups
 
   mongos:
-    image: ${MONGODB_IMAGE:-percona/percona-server-mongodb}:${MONGODB_VERSION:-3.6}
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-3.6}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
     hostname: mongos
     command: mongos --port 27017 --bind_ip_all --keyFile /opt/keyFile --configdb cfg/cfg01:27017,cfg02:27017,cfg03:27017
     ports:
       - "27017:27017"
     volumes:
       - ./scripts/sharded/mongos_init.js:/opt/mongos_init.js
-      - ./keyFile:/opt/keyFile
     depends_on:
       - cfg01
       - cfg02

--- a/e2e-tests/docker/mongodb-rs/Dockerfile
+++ b/e2e-tests/docker/mongodb-rs/Dockerfile
@@ -1,0 +1,7 @@
+ARG MONGODB_VERSION=3.6
+ARG MONGODB_IMAGE=percona/percona-server-mongodb
+FROM ${MONGODB_IMAGE}:${MONGODB_VERSION}
+USER root
+COPY e2e-tests/docker/keyFile /opt/keyFile
+RUN chown mongodb /opt/keyFile && chmod 400 /opt/keyFile && mkdir -p /home/mongodb/ && chown mongodb /home/mongodb
+USER mongodb

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -12,7 +12,6 @@ run() {
     local compose=$1
     local mongo_version=$2
 
-
     desc 'Start cluster'
     case $compose in
         $COMPOSE_PATH)
@@ -139,6 +138,7 @@ start_cluster() {
     local mongo_version=$1
 
     genMongoKey
+    export USER_ID=$(id -u)
 
     local no_build=${PBM_TESTS_NO_BUILD:-false}
     if $no_build ; then
@@ -151,7 +151,7 @@ start_cluster() {
     if [ -d "${test_dir}/docker/backups" ]; then rm -Rf "${test_dir}/docker/backups"; fi
     mkdir "${test_dir}/docker/backups"
     chmod -R 777 "${test_dir}/docker/backups"
-
+    
     export MONGODB_VERSION=${mongo_version:-"3.6"}
     export MONGODB_IMAGE=${MONGODB_IMAGE:-"percona/percona-server-mongodb"}
     docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d
@@ -175,6 +175,7 @@ start_replset() {
     local compose=$2
 
     genMongoKey
+    export USER_ID=$(id -u)    
 
     local no_build=${PBM_TESTS_NO_BUILD:-false}
     if $no_build ; then
@@ -189,6 +190,7 @@ start_replset() {
     chmod -R 777 "${test_dir}/docker/backups"
 
     export MONGODB_VERSION=${mongo_version:-"3.6"}
+    export MONGODB_IMAGE=${MONGODB_IMAGE:-"percona/percona-server-mongodb"}
     docker-compose -f $compose up --quiet-pull --no-color -d
 
     sleep 25
@@ -210,6 +212,7 @@ genMongoKey() {
 }
 
 destroy_cluster() {
+    export USER_ID=$(id -u)
     local compose=$1
 
     docker-compose -f $compose ps


### PR DESCRIPTION
It was unable to run tests with UID!=1001 due to permissions on keyFile.
Also there was issues with volume /opt/backup which mounts to docker/backup - pbm creates files with 664 permissions belongs to nobody:nogroup - so directory cannot be deleted locally without using sudo
Here are some fixes
