### PR TITLE
PBM-709 fix: don't overwrite error in defer

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -143,9 +143,9 @@ func (b *Backup) run(ctx context.Context, bcp pbm.BackupCmd, opid pbm.OPID, l *p
 			return
 		}
 
-		err = b.cn.SetBalancerStatus(pbm.BalancerModeOn)
-		if err != nil {
-			l.Error("set balancer ON: %v", err)
+		errd := b.cn.SetBalancerStatus(pbm.BalancerModeOn)
+		if errd != nil {
+			l.Error("set balancer ON: %v", errd)
 			return
 		}
 		l.Debug("set balancer on")

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -494,9 +494,9 @@ func (r *Restore) RunSnapshot() (err error) {
 	}
 
 	defer func() {
-		err = pbm.DropTMPcoll(r.cn.Context(), r.node.Session())
-		if err != nil {
-			r.log.Warning("drop tmp collections: %v", err)
+		errd := pbm.DropTMPcoll(r.cn.Context(), r.node.Session())
+		if errd != nil {
+			r.log.Warning("drop tmp collections: %v", errd)
 		}
 	}()
 

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -291,7 +291,7 @@ func (s *S3) newPartReader(fname string) *partReader {
 }
 
 func (pr *partReader) setSession(s *s3.S3) {
-	s.Client.Config.HTTPClient.Timeout = time.Second * 30
+	s.Client.Config.HTTPClient.Timeout = time.Second * 60
 	pr.sess = s
 }
 


### PR DESCRIPTION
Defers in a couple of methods were using err variable of the parent func.
And were overwriting the returned errors with nil.

https://jira.percona.com/browse/PBM-709