### PR TITLE
Test: cleanup TS collections

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -6,7 +6,7 @@ BCP_NAME=""
 COMPOSE_PATH="${test_dir}/docker/docker-compose.yaml"
 COMPOSE_RS_PATH="${test_dir}/docker/docker-compose-rs.yaml"
 COMPOSE_SINGLE_PATH="${test_dir}/docker/docker-compose-single.yaml"
-
+PBM_TEST_CLEANUP=${PBM_TEST_CLEANUP:-true}
 
 run() {
     local compose=$1
@@ -31,16 +31,18 @@ run() {
     docker-compose -f $compose logs -f --no-color tests
     EXIT_CODE=$(docker-compose -f $compose ps -q tests | xargs docker inspect -f '{{ .State.ExitCode }}')
 
-    if [ $EXIT_CODE != 0 ]; then
-        docker-compose -f $compose logs --no-color --tail=100
-        desc 'PBM logs'
-        docker-compose -f $compose exec -T agent-rs101 pbm logs -t 0 -s D
-        desc 'PBM status'
-        docker-compose -f $compose exec -T agent-rs101 pbm status
-    fi
+    if [ $PBM_TEST_CLEANUP == true ]; then
+        if [ $EXIT_CODE != 0 ]; then
+            docker-compose -f $compose logs --no-color --tail=100
+            desc 'PBM logs'
+            docker-compose -f $compose exec -T agent-rs101 pbm logs -t 0 -s D
+            desc 'PBM status'
+            docker-compose -f $compose exec -T agent-rs101 pbm status
+        fi
 
-    desc 'Destroy cluster'
-    destroy_cluster $compose
+        desc 'Destroy cluster'
+        destroy_cluster $compose
+    fi
 
     exit $EXIT_CODE
 }

--- a/e2e-tests/pkg/tests/sharded/test_timeseries.go
+++ b/e2e-tests/pkg/tests/sharded/test_timeseries.go
@@ -77,6 +77,17 @@ func (c *Cluster) Timeseries() {
 	if ts2.count() != uint64(ts2c) {
 		log.Fatalf("ERROR: wrong timeseries count, expect %d got %d", ts2.count(), ts2c)
 	}
+
+	// cleanup
+	err = c.mongos.Drop("ts1")
+	if err != nil {
+		log.Fatalf("ERROR: drop ts1: %v", err)
+	}
+
+	err = c.mongos.Drop("ts2")
+	if err != nil {
+		log.Fatalf("ERROR: drop ts2: %v", err)
+	}
 }
 
 type ts struct {


### PR DESCRIPTION
Otherwise, further tests checking db hashes will fail since ts data always restores with the new UUIDs.