### PR TITLE
PBM-714 fix: properly show backup status in case of no progress

### DIFF
--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -158,7 +158,7 @@ func (a *Agent) pitr() (err error) {
 		Epoch:   &epts,
 	})
 
-	got, err := a.aquireLock(lock)
+	got, err := a.aquireLock(lock, l)
 	if err != nil {
 		return errors.Wrap(err, "acquiring lock")
 	}
@@ -258,7 +258,7 @@ func (a *Agent) PITRestore(r pbm.PITRestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 		Epoch:   &epts,
 	})
 
-	got, err := a.aquireLock(lock)
+	got, err := a.aquireLock(lock, l)
 	if err != nil {
 		l.Error("acquiring lock: %v", err)
 		return

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -230,6 +230,11 @@ func (a *Agent) nominateRS(bcp, rs string, nodes [][]string, l *log.Event) error
 		}
 		l.Debug("nomination %s, set candidates %v", rs, n)
 
+		err = a.pbm.BackupHB(bcp)
+		if err != nil {
+			l.Warning("send heartbeat: %v", err)
+		}
+
 		time.Sleep(renominationFrame)
 	}
 

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -125,6 +125,7 @@ func (a *Agent) Backup(cmd pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 			l.Error("init meta: %v", err)
 			return
 		}
+		l.Debug("init backup meta")
 		nodes, err := a.pbm.BcpNodesPriority()
 		if err != nil {
 			l.Error("get nodes priority: %v", err)
@@ -164,7 +165,7 @@ func (a *Agent) Backup(cmd pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		Epoch:   &epts,
 	})
 
-	got, err := a.aquireLock(lock)
+	got, err := a.aquireLock(lock, l)
 	if err != nil {
 		l.Error("acquiring lock: %v", err)
 		return
@@ -207,7 +208,7 @@ func (a *Agent) Backup(cmd pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 const renominationFrame = 5 * time.Second
 
 func (a *Agent) nominateRS(bcp, rs string, nodes [][]string, l *log.Event) error {
-	l.Debug("nomination %s: %v", rs, nodes)
+	l.Debug("nomination list for %s: %v", rs, nodes)
 	err := a.pbm.SetRSNomination(bcp, rs)
 	if err != nil {
 		return errors.Wrap(err, "set nomination meta")
@@ -227,6 +228,7 @@ func (a *Agent) nominateRS(bcp, rs string, nodes [][]string, l *log.Event) error
 		if err != nil {
 			return errors.Wrap(err, "set nominees")
 		}
+		l.Debug("nomination %s, set candidates %v", rs, n)
 
 		time.Sleep(renominationFrame)
 	}
@@ -288,7 +290,7 @@ func (a *Agent) Restore(r pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 		Epoch:   &epts,
 	})
 
-	got, err := a.aquireLock(lock)
+	got, err := a.aquireLock(lock, l)
 	if err != nil {
 		l.Error("acquiring lock: %v", err)
 		return

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -143,6 +143,10 @@ func bcpsMatchCluster(bcps []pbm.BackupMeta, shards []pbm.Shard, confsrv string)
 }
 
 func bcpMatchCluster(bcp *pbm.BackupMeta, shards map[string]struct{}, confsrv string, nomatch *[]string) {
+	if bcp.Status != pbm.StatusDone {
+		return
+	}
+
 	hasconfsrv := false
 	for _, rs := range bcp.Replsets {
 		if _, ok := shards[rs.Name]; !ok {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -37,6 +37,7 @@ type logsOpts struct {
 	severity string
 	event    string
 	opid     string
+	extr     bool
 }
 
 func Main() {
@@ -102,6 +103,7 @@ func Main() {
 	logsCmd.Flag("severity", "Severity level D, I, W, E or F, low to high. Choosing one includes higher levels too.").Short('s').Default("I").EnumVar(&logs.severity, "D", "I", "W", "E", "F")
 	logsCmd.Flag("event", "Event in format backup[/2020-10-06T11:45:14Z]. Events: backup, restore, cancelBackup, resyncBcpList, pitr, pitrestore, delete").Short('e').StringVar(&logs.event)
 	logsCmd.Flag("opid", "Operation ID").Short('i').StringVar(&logs.opid)
+	logsCmd.Flag("extra", "Show extra data in text format").Hidden().Short('x').BoolVar(&logs.extr)
 
 	statusCmd := pbmCmd.Command("status", "Show PBM status")
 	statusSection := statusCmd.Flag("sections", "Sections of status to display <cluster>/<pitr>/<running>/<backups>.").Short('s').Enums("cluster", "pitr", "running", "backups")
@@ -263,6 +265,7 @@ func runLogs(cn *pbm.PBM, l *logsOpts) (fmt.Stringer, error) {
 	}
 
 	o.ShowNode = r.Node == ""
+	o.Extr = l.extr
 
 	// reverse list
 	for i := len(o.Data)/2 - 1; i >= 0; i-- {

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -210,7 +210,7 @@ func (b *Backup) run(ctx context.Context, bcp pbm.BackupCmd, opid pbm.OPID, l *p
 
 		err = b.setClusterFirstWrite(bcp.Name)
 		if err != nil {
-			return errors.Wrap(err, "set cluster last write ts")
+			return errors.Wrap(err, "set cluster first write ts")
 		}
 	}
 

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -55,16 +55,16 @@ func tsUTC(ts int64) string {
 }
 
 func (e *Entry) String() (s string) {
-	return e.string(tsLocal, false)
+	return e.string(tsLocal, false, false)
 }
 
 func (e *Entry) StringNode() (s string) {
-	return e.string(tsLocal, true)
+	return e.string(tsLocal, true, false)
 }
 
 type tsformatf func(ts int64) string
 
-func (e *Entry) string(f tsformatf, showNode bool) (s string) {
+func (e *Entry) string(f tsformatf, showNode, extr bool) (s string) {
 	node := ""
 	if showNode {
 		node = " [" + e.RS + "/" + e.Node + "]"
@@ -77,6 +77,9 @@ func (e *Entry) string(f tsformatf, showNode bool) (s string) {
 		}
 		if e.ObjName != "" {
 			id = append(id, e.ObjName)
+		}
+		if extr {
+			id = append(id, e.OPID)
 		}
 		s = fmt.Sprintf("%s %s%s [%s] %s", f(e.TS), e.Severity, node, strings.Join(id, "/"), e.Msg)
 	} else {
@@ -252,6 +255,7 @@ type LogRequest struct {
 type Entries struct {
 	Data     []Entry `json:"data"`
 	ShowNode bool    `json:"-"`
+	Extr     bool    `json:"-"`
 }
 
 func (e Entries) MarshalJSON() ([]byte, error) {
@@ -260,7 +264,7 @@ func (e Entries) MarshalJSON() ([]byte, error) {
 
 func (e Entries) String() (s string) {
 	for _, entry := range e.Data {
-		s += entry.string(tsUTC, e.ShowNode) + "\n"
+		s += entry.string(tsUTC, e.ShowNode, e.Extr) + "\n"
 	}
 
 	return s

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -33,6 +33,7 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 	if err != nil {
 		return errors.Wrap(err, "get a backups list from the storage")
 	}
+	l.Debug("got backups list: %v", len(bcps))
 
 	err = p.moveCollection(BcpCollection, BcpOldCollection)
 	if err != nil {
@@ -49,6 +50,8 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 
 	var ins []interface{}
 	for _, b := range bcps {
+		l.Debug("bcp: %v", b.Name)
+
 		d, err := stg.SourceReader(b.Name)
 		if err != nil {
 			return errors.Wrapf(err, "read meta for %v", b.Name)
@@ -58,7 +61,7 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 		err = json.NewDecoder(d).Decode(&v)
 		d.Close()
 		if err != nil {
-			return errors.Wrap(err, "unmarshal backup meta")
+			return errors.Wrapf(err, "unmarshal backup meta [%s]", b.Name)
 		}
 		err = checkBackupFiles(&v, stg)
 		if err != nil {


### PR DESCRIPTION
If a backup has no progress hence status is neither `done` nor `error` and
there are no `hb` updates for a while (StaleFrameSec) it should be
PBM-714 fix: properly show backup status in case of no progress

If a backup has no progress hence status is neither `done` nor `error` and
there are no `hb` updates for a while (StaleFrameSec) it should be
properly marked in `pbm status`. Before this commit for ex. backup that had no
election progress, stuck in `starting` with empty replsets was marked as
"Backup has no data for the config server or sole replicaset" by
`bcpsMatchCluster`. Moreover only `done` backup should be processed by
`bcpsMatchCluster`.

Also, added more debug logging.