### PR TITLE
PBM-722 fix: delete-pitr crash if nothing to delete (no backup)

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -256,11 +256,11 @@ func getPitrList(cn *pbm.PBM, size int, full bool) (ranges []pitrRange, rsRanges
 	var buf []string
 	for _, tl := range pbm.MergeTimelines(rstlines...) {
 		bcp, err := cn.GetLastBackup(&primitive.Timestamp{T: tl.End, I: 0})
+		if errors.Is(err, pbm.ErrNotFound) {
+			continue
+		}
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "get backup for timeline: %s", tl)
-		}
-		if bcp == nil {
-			continue
 		}
 		buf = buf[:0]
 		bcpMatchCluster(bcp, sh, inf.SetName, &buf)

--- a/cli/status.go
+++ b/cli/status.go
@@ -620,11 +620,11 @@ func getPITRranges(cn *pbm.PBM, stg storage.Storage) (*pitrRanges, error) {
 		rng.Range.End = tl.End
 
 		bcp, err := cn.GetLastBackup(&primitive.Timestamp{T: tl.End, I: 0})
-		if err != nil {
+		if err != nil && errors.Is(err, pbm.ErrNotFound) {
 			log.Printf("ERROR: get backup for timeline: %s", tl)
 			continue
 		}
-		if bcp == nil {
+		if errors.Is(err, pbm.ErrNotFound) {
 			rng.Err = "no backup found"
 		} else if !version.Compatible(version.DefaultInfo.Version, bcp.PBMVersion) {
 			rng.Err = fmt.Sprintf("backup v%s is not compatible with PBM v%s", bcp.PBMVersion, version.DefaultInfo.Version)

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -650,11 +650,6 @@ func (p *PBM) getBackupMeta(clause bson.D) (*BackupMeta, error) {
 	return b, errors.Wrap(err, "decode")
 }
 
-// GetFirstBackup returns first successfully finished backup
-func (p *PBM) GetFirstBackup() (*BackupMeta, error) {
-	return p.getRecentBackup(nil, 1)
-}
-
 // GetLastBackup returns last successfully finished backup
 // or nil if there is no such backup yet. If ts isn't nil it will
 // search for the most recent backup that finished before specified timestamp
@@ -675,7 +670,7 @@ func (p *PBM) getRecentBackup(before *primitive.Timestamp, sort int) (*BackupMet
 	)
 	if res.Err() != nil {
 		if res.Err() == mongo.ErrNoDocuments {
-			return nil, nil
+			return nil, ErrNotFound
 		}
 		return nil, errors.Wrap(res.Err(), "get")
 	}

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -64,11 +64,11 @@ func (s *Slicer) GetSpan() time.Duration {
 func (s *Slicer) Catchup() error {
 	s.l.Debug("start_catchup")
 	baseBcp, err := s.pbm.GetLastBackup(nil)
+	if errors.Is(err, pbm.ErrNotFound) {
+		return errors.New("no backup found, a new backup is required to start PITR")
+	}
 	if err != nil {
 		return errors.Wrap(err, "get last backup")
-	}
-	if baseBcp == nil {
-		return errors.New("no backup found, a new backup is required to start PITR")
 	}
 
 	defer func() {

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -274,11 +274,11 @@ func (r *Restore) setBcp(bcp string, targetTS primitive.Timestamp) (err error) {
 	}
 
 	r.bcp, err = r.cn.GetLastBackup(&targetTS)
+	if errors.Is(err, pbm.ErrNotFound) {
+		return errors.Errorf("no backup found before ts %v", targetTS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "define last backup")
-	}
-	if r.bcp == nil {
-		return errors.Errorf("no backup found before ts %v", targetTS)
 	}
 
 	return nil


### PR DESCRIPTION
pbm.GetLastBackup() changed to be consistent with other methods and more error-resilient. Now it returns `pbm.ErrNotFound` not just nil result.
Also added debug logging to the command.

https://jira.percona.com/browse/PBM-722