### PR TITLE
PBM-725: oplog: don't replay config.rangeDeletions

### DIFF
--- a/pbm/restore/oplog.go
+++ b/pbm/restore/oplog.go
@@ -65,7 +65,7 @@ type Oplog struct {
 
 // NewOplog creates an object for an oplog applying
 func NewOplog(dst *pbm.Node, sv *pbm.MongoVersion, preserveUUID bool) (*Oplog, error) {
-	m, err := ns.NewMatcher(excludeFromRestore)
+	m, err := ns.NewMatcher(append(excludeFromRestore, excludeFromOplog...))
 	if err != nil {
 		return nil, errors.Wrap(err, "create matcher for the collections exclude")
 	}

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -58,6 +58,10 @@ var excludeFromRestore = []string{
 	"config.system.indexBuilds",
 }
 
+var excludeFromOplog = []string{
+	"config.rangeDeletions",
+}
+
 type Restore struct {
 	name     string
 	cn       *pbm.PBM


### PR DESCRIPTION
Before starting the backup PBM disables a balancer (if it was on). So it
shouldn’t be any rangeDeletions ops in the oplog. But they are there because
oplog can capture some events from before the mongodump started. Simply because
we don’t know the cluster time of the mongodump start so replicasets do just
rely on the oldest “last write” among them as the first write for the oplog to
capture. So given that we are turning off the balancer before mongodump, all
`config.rangeDeletions` records in oplog have happened before hence they are
in the mongodump output. So basically it’s safe to skip such records during the
oplog replay.

https://jira.percona.com/browse/PBM-725