### PR TITLE
Bump version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // current PBM version
-const version = "1.6.0"
+const version = "1.6.1"
 
 // !!! should be sorted in the ascending order
 var breakingChangesV = []string{


### PR DESCRIPTION
This merges `release-1.6.1` branch to `main` branch to bump the version.