### PR TITLE
PBM-808, PBM-807: CLI - waiting for the logical restore operations

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -93,6 +93,7 @@ func Main() {
 	replayOpts := replayOptions{}
 	replayCmd.Flag("start", fmt.Sprintf("Replay oplog from the time. Set in format %s", datetimeFormat)).Required().StringVar(&replayOpts.start)
 	replayCmd.Flag("end", "Replay oplog to the time. Set in format %s").Required().StringVar(&replayOpts.end)
+	replayCmd.Flag("wait", "Wait for the restore to finish.").Short('w').BoolVar(&replayOpts.wait)
 	// todo(add oplog cancel)
 
 	listCmd := pbmCmd.Command("list", "Backup list")

--- a/cli/oplog.go
+++ b/cli/oplog.go
@@ -78,6 +78,7 @@ func replayOplog(cn *pbm.PBM, o replayOptions, outf outFormat) (fmt.Stringer, er
 		return oplogReplayResult{Name: name}, nil
 	}
 
+	fmt.Print("Started.\nWaiting to finish")
 	err = waitRestore(cn, m)
 	if err != nil {
 		return oplogReplayResult{err: err.Error()}, nil

--- a/cli/restore.go
+++ b/cli/restore.go
@@ -56,19 +56,6 @@ func (r restoreRet) String() string {
 	}
 }
 
-type replayOptions struct {
-	start string
-	end   string
-}
-
-type oplogReplayResult struct {
-	Name string `json:"name"`
-}
-
-func (r oplogReplayResult) String() string {
-	return fmt.Sprintf("Oplog replay %q has started", r.Name)
-}
-
 func runRestore(cn *pbm.PBM, o *restoreOpts, outf outFormat) (fmt.Stringer, error) {
 	if o.pitr != "" && o.bcp != "" {
 		return nil, errors.New("either a backup name or point in time should be set, non both together!")
@@ -102,11 +89,22 @@ func runRestore(cn *pbm.PBM, o *restoreOpts, outf outFormat) (fmt.Stringer, erro
 		}
 		return restoreRet{err: fmt.Sprintf("%s.\n Try to check logs on node %s", err.Error(), m.Leader)}, nil
 	case o.pitr != "":
-		err := pitrestore(cn, o.pitr, o.pitrBase, outf)
+		m, err := pitrestore(cn, o.pitr, o.pitrBase, outf)
 		if err != nil {
 			return nil, err
 		}
-		return restoreRet{PITR: o.pitr}, nil
+		if !o.wait || m == nil {
+			return restoreRet{PITR: o.pitr}, nil
+		}
+		fmt.Print("Started.\nWaiting to finish")
+		err = waitRestore(cn, m)
+		if err != nil {
+			return restoreRet{err: err.Error()}, nil
+		}
+		return restoreRet{
+			done: true,
+			PITR: o.pitr,
+		}, nil
 	default:
 		return nil, errors.New("undefined restore state")
 	}
@@ -251,15 +249,15 @@ func parseTS(t string) (ts primitive.Timestamp, err error) {
 	return primitive.Timestamp{T: uint32(tsto.Unix()), I: 0}, nil
 }
 
-func pitrestore(cn *pbm.PBM, t, base string, outf outFormat) (err error) {
+func pitrestore(cn *pbm.PBM, t, base string, outf outFormat) (rmeta *pbm.RestoreMeta, err error) {
 	ts, err := parseTS(t)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = checkConcurrentOp(cn)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	name := time.Now().UTC().Format(time.RFC3339Nano)
@@ -273,11 +271,11 @@ func pitrestore(cn *pbm.PBM, t, base string, outf outFormat) (err error) {
 		},
 	})
 	if err != nil {
-		return errors.Wrap(err, "send command")
+		return nil, errors.Wrap(err, "send command")
 	}
 
 	if outf != outText {
-		return nil
+		return nil, nil
 	}
 
 	fmt.Printf("Starting restore to the point in time '%s'", t)
@@ -285,8 +283,7 @@ func pitrestore(cn *pbm.PBM, t, base string, outf outFormat) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), pbm.WaitActionStart)
 	defer cancel()
 
-	_, err = waitForRestoreStatus(ctx, cn, name)
-	return err
+	return waitForRestoreStatus(ctx, cn, name)
 }
 
 func waitForRestoreStatus(ctx context.Context, cn *pbm.PBM, name string) (*pbm.RestoreMeta, error) {


### PR DESCRIPTION
- Added "wait" to the PITR restore and Oplog relay.
- Check for the operation heartbeats during the wait. That will prevent indefinite wait if agents are gone. All nodes in non-sharded env - is the only agent that runs a restore.