### PR TITLE
Fix bcp type display in status/list for old backups

### DIFF
--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -796,6 +796,9 @@ func (p *PBM) BackupsList(limit int64) ([]BackupMeta, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "message decode")
 		}
+		if b.Type == "" {
+			b.Type = LogicalBackup
+		}
 		backups = append(backups, b)
 	}
 


### PR DESCRIPTION
The previous versions didn't have `Type` in bcp meta. Such backups were
displayed with an empty type. Like:
```
Backup snapshots:
  2021-10-18T10:10:24Z <> [complete: 2021-10-18T10:10:32]
  2021-10-18T11:31:23Z <> [complete: 2021-10-18T11:31:32]
  ```

This commit fixes that:
```
 Backup snapshots:
  2021-10-18T10:10:24Z <logical> [complete: 2021-10-18T10:10:32]
  2021-10-18T11:31:23Z <logical> [complete: 2021-10-18T11:31:32]
```