### PR TITLE
Fix cancelled backups displaying in pbm status

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -568,6 +568,8 @@ func getStorageStat(cn *pbm.PBM) (fmt.Stringer, error) {
 			}
 		case pbm.StatusError:
 			snpsht.Err = bcp.Error
+		case pbm.StatusCancelled:
+			// leave as it is, not to rewrite status with the `stuck` error
 		default:
 			if bcp.Hb.T+pbm.StaleFrameSec < now.T {
 				snpsht.Err = fmt.Sprintf("Backup stuck at `%v` stage, last beat ts: %d", bcp.Status, bcp.Hb.T)


### PR DESCRIPTION
Before:
```
Backups:
========
S3 us-east-1 s3://http://minio:9000/bcp/pbme2etest
  Snapshots:
    2022-04-13T07:50:30Z 0.00B [ERROR: Backup stuck at `canceled` stage, last beat ts: 1649836246] [2022-04-13T07:50:48]
```

Now:
```
Backups:
========
S3 us-east-1 s3://http://minio:9000/bcp/pbme2etest
  Snapshots:
    2022-04-13T07:50:30Z 0.00B [!cancelled: 2022-04-13T07:50:48]
```