### PR TITLE
Fix physical backup tests

### DIFF
--- a/e2e-tests/cmd/pbm-test/run.go
+++ b/e2e-tests/cmd/pbm-test/run.go
@@ -71,7 +71,7 @@ func run(t *sharded.Cluster, typ testTyp) {
 		t.LeaderLag)
 
 	runTest("Logical Backup Data Bounds Check",
-		func() { t.BackupBoundsCheck(pbm.LogicalBackup) })
+		func() { t.BackupBoundsCheck(pbm.LogicalBackup, cVersion) })
 
 	t.SetBallastData(1e3)
 	flush(t)
@@ -131,7 +131,7 @@ func run(t *sharded.Cluster, typ testTyp) {
 	}
 
 	runTest("Clock Skew Tests",
-		func() { t.ClockSkew(pbm.LogicalBackup) })
+		func() { t.ClockSkew(pbm.LogicalBackup, cVersion) })
 
 	flushStore(t)
 }

--- a/e2e-tests/cmd/pbm-test/run_physical.go
+++ b/e2e-tests/cmd/pbm-test/run_physical.go
@@ -41,7 +41,7 @@ func runPhysical(t *sharded.Cluster, typ testTyp) {
 	}
 
 	runTest("Physical Backup Data Bounds Check",
-		func() { t.BackupBoundsCheck(pbm.PhysicalBackup) })
+		func() { t.BackupBoundsCheck(pbm.PhysicalBackup, cVersion) })
 
 	if typ == testsSharded {
 		if semver.Compare(cVersion, "v4.2") >= 0 {
@@ -51,7 +51,7 @@ func runPhysical(t *sharded.Cluster, typ testTyp) {
 	}
 
 	runTest("Clock Skew Tests",
-		func() { t.ClockSkew(pbm.PhysicalBackup) })
+		func() { t.ClockSkew(pbm.PhysicalBackup, cVersion) })
 
 	flushStore(t)
 }

--- a/e2e-tests/pkg/tests/sharded/test_clock_skew.go
+++ b/e2e-tests/pkg/tests/sharded/test_clock_skew.go
@@ -8,7 +8,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
 )
 
-func (c *Cluster) ClockSkew(typ pbmt.BackupType) {
+func (c *Cluster) ClockSkew(typ pbmt.BackupType, mongoVersion string) {
 	timeShifts := []string{
 		"+90m", "-195m", "+2d", "-7h", "+11m", "+42d", "-13h",
 	}
@@ -29,7 +29,7 @@ func (c *Cluster) ClockSkew(typ pbmt.BackupType) {
 		}
 
 		log.Printf("[START] %s Backup Data Bounds Check / ClockSkew %s %s", typ, rs, shift)
-		c.BackupBoundsCheck(typ)
+		c.BackupBoundsCheck(typ, mongoVersion)
 		log.Printf("[DONE] %s Backup Data Bounds Check / ClockSkew %s %s", typ, rs, shift)
 	}
 }

--- a/e2e-tests/pkg/tests/sharded/test_trx.go
+++ b/e2e-tests/pkg/tests/sharded/test_trx.go
@@ -5,5 +5,5 @@ func (c *Cluster) DistributedTrxSnapshot() {
 }
 
 func (c *Cluster) DistributedTrxPhysical() {
-	c.DistributedTransactions(NewPhysical(c), "test")
+	c.DistributedTransactionsPhys(NewPhysical(c), "test")
 }

--- a/e2e-tests/pkg/tests/sharded/trx.go
+++ b/e2e-tests/pkg/tests/sharded/trx.go
@@ -116,7 +116,7 @@ func (c *Cluster) DistributedTransactions(bcp Backuper, col string) {
 	// distributed transaction that commits before the backup ends
 	// should be visible after restore
 	log.Println("Run trx1")
-	sess.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
+	_, _ = sess.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
 		c.trxSet(sc, 30, col)
 		c.trxSet(sc, 530, col)
 
@@ -140,14 +140,14 @@ func (c *Cluster) DistributedTransactions(bcp Backuper, col string) {
 	log.Println("Run trx2")
 	// distributed transaction that commits after the backup ends
 	// should NOT be visible after the restore
-	mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
+	_ = mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
 		err := sess.StartTransaction()
 		if err != nil {
 			log.Fatalln("ERROR: start transaction:", err)
 		}
 		defer func() {
 			if err != nil {
-				sess.AbortTransaction(sc)
+				_ = sess.AbortTransaction(sc)
 				log.Fatalln("ERROR: transaction:", err)
 			}
 		}()

--- a/e2e-tests/pkg/tests/sharded/trx_phys.go
+++ b/e2e-tests/pkg/tests/sharded/trx_phys.go
@@ -83,7 +83,7 @@ func (c *Cluster) DistributedTransactionsPhys(bcp Backuper, col string) {
 	// distributed transaction that commits before the backup ends
 	// should be visible after restore
 	log.Println("Run trx1")
-	sess.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
+	_, _ = sess.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
 		c.trxSet(sc, 30, col)
 		c.trxSet(sc, 530, col)
 		c.trxSet(sc, 130, col)
@@ -103,14 +103,14 @@ func (c *Cluster) DistributedTransactionsPhys(bcp Backuper, col string) {
 	log.Println("Run trx2")
 	// distributed transaction that commits after the backup ends
 	// should NOT be visible after the restore
-	mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
+	_ = mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
 		err := sess.StartTransaction()
 		if err != nil {
 			log.Fatalln("ERROR: start transaction:", err)
 		}
 		defer func() {
 			if err != nil {
-				sess.AbortTransaction(sc)
+				_ = sess.AbortTransaction(sc)
 				log.Fatalln("ERROR: transaction:", err)
 			}
 		}()

--- a/e2e-tests/pkg/tests/sharded/trx_phys.go
+++ b/e2e-tests/pkg/tests/sharded/trx_phys.go
@@ -1,0 +1,141 @@
+package sharded
+
+import (
+	"context"
+	"log"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+)
+
+func (c *Cluster) DistributedTransactionsPhys(bcp Backuper, col string) {
+	const trxLimitT = 300
+
+	dbcol := trxdb + "." + col
+
+	ctx := context.Background()
+	conn := c.mongos.Conn()
+
+	log.Println("Updating transactionLifetimeLimitSeconds to", trxLimitT)
+	err := c.mongopbm.Conn().Database("admin").RunCommand(
+		ctx,
+		bson.D{{"setParameter", 1}, {"transactionLifetimeLimitSeconds", trxLimitT}},
+	).Err()
+	if err != nil {
+		log.Fatalln("ERROR: update transactionLifetimeLimitSeconds:", err)
+	}
+	for sname, cn := range c.shards {
+		log.Printf("Updating transactionLifetimeLimitSeconds for %s to %d", sname, trxLimitT)
+		err := cn.Conn().Database("admin").RunCommand(
+			ctx,
+			bson.D{{"setParameter", 1}, {"transactionLifetimeLimitSeconds", trxLimitT}},
+		).Err()
+		if err != nil {
+			log.Fatalf("ERROR: update transactionLifetimeLimitSeconds for shard %s: %v", sname, err)
+		}
+	}
+
+	c.setupTrxCollection(ctx, col)
+
+	_, err = conn.Database(trxdb).Collection(col).DeleteMany(ctx, bson.M{})
+	if err != nil {
+		log.Fatalf("ERROR: delete data from %s: %v", dbcol, err)
+	}
+
+	err = c.mongos.GenData(trxdb, col, 0, 5000)
+	if err != nil {
+		log.Fatalln("ERROR: GenData:", err)
+	}
+
+	sess, err := conn.StartSession(
+		options.Session().
+			SetDefaultReadPreference(readpref.Primary()).
+			SetCausalConsistency(true).
+			SetDefaultReadConcern(readconcern.Majority()).
+			SetDefaultWriteConcern(writeconcern.New(writeconcern.WMajority())),
+	)
+	if err != nil {
+		log.Fatalln("ERROR: start session:", err)
+	}
+	defer sess.EndSession(ctx)
+
+	err = conn.Database("admin").RunCommand(
+		ctx,
+		bson.D{
+			{"moveChunk", dbcol},
+			{"find", bson.M{"idx": 2000}},
+			{"to", "rsx"},
+		},
+	).Err()
+	if err != nil {
+		log.Printf("ERROR: moveChunk %s/idx:2000: %v", dbcol, err)
+	}
+
+	c.printBalancerStatus(ctx)
+
+	log.Println("Starting a backup")
+	go bcp.Backup()
+
+	// distributed transaction that commits before the backup ends
+	// should be visible after restore
+	log.Println("Run trx1")
+	sess.WithTransaction(ctx, func(sc mongo.SessionContext) (interface{}, error) {
+		c.trxSet(sc, 30, col)
+		c.trxSet(sc, 530, col)
+		c.trxSet(sc, 130, col)
+		c.trxSet(sc, 131, col)
+		c.trxSet(sc, 630, col)
+		c.trxSet(sc, 631, col)
+		c.trxSet(sc, 110, col)
+		c.trxSet(sc, 730, col)
+		c.trxSet(sc, 3000, col)
+		c.trxSet(sc, 3001, col)
+
+		return nil, nil
+	})
+
+	bcp.WaitStarted()
+
+	log.Println("Run trx2")
+	// distributed transaction that commits after the backup ends
+	// should NOT be visible after the restore
+	mongo.WithSession(ctx, sess, func(sc mongo.SessionContext) error {
+		err := sess.StartTransaction()
+		if err != nil {
+			log.Fatalln("ERROR: start transaction:", err)
+		}
+		defer func() {
+			if err != nil {
+				sess.AbortTransaction(sc)
+				log.Fatalln("ERROR: transaction:", err)
+			}
+		}()
+
+		c.trxSet(sc, 0, col)
+		c.trxSet(sc, 89, col)
+		c.trxSet(sc, 180, col)
+
+		log.Println("Waiting for the backup to done")
+		bcp.WaitDone()
+		log.Println("Backup done")
+
+		c.trxSet(sc, 99, col)
+		c.trxSet(sc, 199, col)
+		c.trxSet(sc, 2001, col)
+
+		log.Println("Commiting the transaction")
+		err = sess.CommitTransaction(sc)
+		if err != nil {
+			log.Fatalln("ERROR: commit in transaction:", err)
+		}
+
+		return nil
+	})
+	sess.EndSession(ctx)
+
+	c.checkTrxCollection(ctx, col, bcp)
+}

--- a/e2e-tests/pkg/tests/sharded/trx_phys.go
+++ b/e2e-tests/pkg/tests/sharded/trx_phys.go
@@ -127,7 +127,7 @@ func (c *Cluster) DistributedTransactionsPhys(bcp Backuper, col string) {
 		c.trxSet(sc, 199, col)
 		c.trxSet(sc, 2001, col)
 
-		log.Println("Commiting the transaction")
+		log.Println("Committing the transaction")
 		err = sess.CommitTransaction(sc)
 		if err != nil {
 			log.Fatalln("ERROR: commit in transaction:", err)


### PR DESCRIPTION
Unlike with the logical backups, the LastWrite of physical once
"happening" in seconds after the backup start. So, in tests, we should
wait before committing the first transaction.