### PR TITLE
PBM-902: fix sharded cluster detection on mongo 6.0

### DIFF
--- a/pbm/bsontypes.go
+++ b/pbm/bsontypes.go
@@ -44,11 +44,12 @@ type NodeInfo struct {
 	ClusterTime                  *ClusterTime         `bson:"$clusterTime,omitempty"`
 	ConfigServerState            *ConfigServerState   `bson:"$configServerState,omitempty"`
 	OperationTime                *primitive.Timestamp `bson:"operationTime,omitempty"`
+	opts                         MongodOpts
 }
 
 // IsSharded returns true is replset is part sharded cluster
 func (i *NodeInfo) IsSharded() bool {
-	return i.SetName != "" && (i.ConfigServerState != nil || i.ConfigSvr == 2)
+	return i.SetName != "" && (i.ConfigServerState != nil || i.opts.Sharding.ClusterRole != "" || i.ConfigSvr == 2)
 }
 
 // IsLeader returns true if node can act as backup leader (it's configsrv or non shareded rs)
@@ -233,6 +234,9 @@ type MongodOpts struct {
 		BindIp string `bson:"bindIp" json:"bindIp"`
 		Port   int    `bson:"port" json:"port"`
 	} `bson:"net" json:"net"`
+	Sharding struct {
+		ClusterRole string `bson:"clusterRole" json:"clusterRole"`
+	} `bson:"sharding" json:"sharding"`
 	Storage struct {
 		DBpath string `bson:"dbPath" json:"dbPath"`
 	} `bson:"storage" json:"storage"`

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -112,7 +112,14 @@ func (n *Node) GetInfo() (*NodeInfo, error) {
 	i := &NodeInfo{}
 	err := n.cn.Database(DB).RunCommand(n.ctx, bson.D{{"isMaster", 1}}).Decode(i)
 	if err != nil {
-		return nil, errors.Wrap(err, "run mongo command")
+		return nil, errors.Wrap(err, "get NodeInfo")
+	}
+	opts, err := n.GetOpts()
+	if err != nil {
+		return nil, errors.Wrap(err, "get mongod options")
+	}
+	if opts != nil {
+		i.opts = *opts
 	}
 	return i, nil
 }

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -962,8 +962,18 @@ func (p *PBM) GetNodeInfo() (*NodeInfo, error) {
 	inf := &NodeInfo{}
 	err := p.Conn.Database(DB).RunCommand(p.ctx, bson.D{{"isMaster", 1}}).Decode(inf)
 	if err != nil {
-		return nil, errors.Wrap(err, "run mongo command")
+		return nil, errors.Wrap(err, "get NodeInfo")
 	}
+
+	opts := struct {
+		Parsed MongodOpts `bson:"parsed" json:"parsed"`
+	}{}
+	err = p.Conn.Database("admin").RunCommand(p.ctx, bson.D{{"getCmdLineOpts", 1}}).Decode(&opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "get mongod options")
+	}
+	inf.opts = opts.Parsed
+
 	return inf, nil
 }
 


### PR DESCRIPTION
Check for `db.adminCommand({ getCmdLineOpts: 1}).parsed.sharding.clusterRole` if `ConfigServerState` is anavaliable.

Fixes https://jira.percona.com/browse/PBM-902