### PR TITLE
[PBM-922]: Add support for SSE-C server-side encryption for S3 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can install Percona Backup for MongoDB in the following ways:
 
 Find the installation instructions in the [official documentation](https://www.percona.com/doc/percona-backup-mongodb/installation.html)
 
-Alternaively, you can [run Percona Backup for MongoDB as a Docker container](https://hub.docker.com/r/percona/percona-backup-mongodb).
+Alternatively, you can [run Percona Backup for MongoDB as a Docker container](https://hub.docker.com/r/percona/percona-backup-mongodb).
 
 ## Submit Bug Report / Feature Request
 

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -45,6 +45,9 @@ func (c Config) String() string {
 	if c.Storage.S3.Credentials.Vault.Token != "" {
 		c.Storage.S3.Credentials.Vault.Token = "***"
 	}
+	if c.Storage.S3.ServerSideEncryption.SseCustomerKey != "" {
+		c.Storage.S3.ServerSideEncryption.SseCustomerKey = "***"
+	}
 	if c.Storage.Azure.Credentials.Key != "" {
 		c.Storage.Azure.Credentials.Key = "***"
 	}

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -269,8 +269,8 @@ func (s *S3) Save(name string, data io.Reader, sizeb int) error {
 				uplInput.SSEKMSKeyId = aws.String(sse.KmsKeyID)
 			} else if sse.SseCustomerAlgorithm != "" {
 				uplInput.SSECustomerAlgorithm = aws.String(sse.SseCustomerAlgorithm)
-				uplInput.SSECustomerKey = aws.String(sse.SseCustomerKey)
 				decodedKey, err := base64.StdEncoding.DecodeString(sse.SseCustomerKey)
+				uplInput.SSECustomerKey = aws.String(string(decodedKey[:]))
 				if err != nil {
 					return errors.Wrap(err, "SseCustomerAlgorithm specified with invalid SseCustomerKey")
 				}
@@ -491,10 +491,10 @@ func (pr *partReader) writeNext(w io.Writer) (n int64, err error) {
 			s3obj.SSEKMSKeyId = aws.String(sse.KmsKeyID)
 		} else if sse.SseCustomerAlgorithm != "" {
 			s3obj.SSECustomerAlgorithm = aws.String(sse.SseCustomerAlgorithm)
+			decodedKey, _ := base64.StdEncoding.DecodeString(sse.SseCustomerKey)
 			// We don't pass in the key in this case, just the MD5 hash of the key
 			// for verification
-			// s3obj.SSECustomerKey = aws.String(sse.SseCustomerKey)
-			decodedKey, _ := base64.StdEncoding.DecodeString(sse.SseCustomerKey)
+			// s3obj.SSECustomerKey = aws.String(string(decodedKey[:]))
 			keyMD5 := md5.Sum(decodedKey[:])
 			s3obj.SSECustomerKeyMD5 = aws.String(base64.StdEncoding.EncodeToString(keyMD5[:]))
 		}


### PR DESCRIPTION
I have completed a partial test of this -- I am able to initialize pbm, list status etc, start a backup. I'm still running that backup so we'll see how it does.

I can confirm that the files written to the S3 repository are encrypted with SSE-C, however.

Generate a SSE-C AES256 key with:

```bash
openssl rand -base64 32
```

Example config file for Backblaze B2:

```yaml
storage:
  type: s3
  s3:
    region: us-west-002
    endpointUrl: https://s3.us-west-002.backblazeb2.com
    bucket: pbm-test-bucket-name
    prefix: data/pbm/backup
    credentials:
      access-key-id: <redacted>
      secret-access-key: <redacted>
    serverSideEncryption:
      sseCustomerAlgorithm: AES256
      sseCustomerKey: "eBYL81+sAigzkanckAeKQ0kitmVAPwN2DfbItdeMlR8="
```

I'll finish my tests but I wanted to get this pushed up for other eyes to look and see if I've missed anything. Unlike using KMS the `sseCustomerAlgorithm` and `sseCustomerKey` options need to be set on any S3 api call which reads or writes files. Deleting does not seem to need it =] I think I got them all, though.
