### PR TITLE
PBM-929: recreate UUID for ts collections

### DIFF
--- a/pbm/restore/oplog.go
+++ b/pbm/restore/oplog.go
@@ -195,6 +195,16 @@ func (o *Oplog) handleOp(oe db.Oplog) error {
 	if o.cnamespase != oe.Namespace {
 		o.preserveUUID = o.preserveUUIDopt
 
+		// if this is a create operation, the namesape would be
+		// inside the object to create
+		if oe.Operation == "c" {
+			if len(oe.Object) == 0 {
+				return errors.Errorf("empty object value for op: %v", oe)
+			}
+			if oe.Object[0].Key == "create" && o.noUUIDns.Has(oe.Namespace+"."+oe.Object[0].Value.(string)) {
+				o.preserveUUID = false
+			}
+		}
 		// don't preserve UUID for certain namespaces
 		if o.noUUIDns.Has(oe.Namespace) {
 			o.preserveUUID = false


### PR DESCRIPTION
If the creation of a timeseries collection was captured by oplog, it will cause mongod failure during (sometimes after) the restore. 
 
```
{"t":{"$date":"2022-08-10T14:59:23.606+00:00"},"s":"F",  "c":"ASSERT",   "id":23081,   "ctx":"conn130","msg":"Invariant failure","attr":{"expr":"isTimeseriesBucketsCollection()","msg":"test.tmpAvOB6.create","file":"src/mongo/db/namespace_string.cpp","line":404}}{"t":{"$date":"2022-08-10T14:59:23.606+00:00"},"s":"F",  "c":"ASSERT",   "id":23082,   "ctx":"conn130","msg":"\n\n***aborting after invariant() failure\n\n"}{"t":{"$date":"2022-08-10T14:59:23.606+00:00"},"s":"F",  "c":"CONTROL",  "id":4757800, "ctx":"conn130","msg":"Writing fatal message","attr":{"message":"Got signal: 6 (Aborted).\n"}} 
 ```
 
`tmp%%%%%.create` is created by mongo during applyOps when UUID is preserved. But it apparently doesn't work well with the timeseries collections.
 
To avoid this we'd have to recreate UUID for ts collections.

The recreation of UUID will screw shared collection at this point, meaning a config server will lose traction of such collection and it became a "different collections on different shards"