### PR TITLE
 PBM-911: clarify restore time in ctl output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -323,7 +323,7 @@ type snapshotStat struct {
 	Size       int64          `json:"size,omitempty"`
 	Status     pbm.Status     `json:"status"`
 	Err        error          `json:"error,omitempty"`
-	StateTS    int64          `json:"completeTS"`
+	RestoreTS  int64          `json:"restoreTo"`
 	PBMVersion string         `json:"pbmVersion"`
 	Type       pbm.BackupType `json:"type"`
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -145,10 +145,10 @@ func (bl backupListOut) String() string {
 	s := fmt.Sprintln("Backup snapshots:")
 
 	sort.Slice(bl.Snapshots, func(i, j int) bool {
-		return bl.Snapshots[i].StateTS < bl.Snapshots[j].StateTS
+		return bl.Snapshots[i].RestoreTS < bl.Snapshots[j].RestoreTS
 	})
 	for _, b := range bl.Snapshots {
-		s += fmt.Sprintf("  %s <%s> [complete: %s]\n", b.Name, b.Type, fmtTS(int64(b.StateTS)))
+		s += fmt.Sprintf("  %s <%s> [restore_to_time: %s]\n", b.Name, b.Type, fmtTS(int64(b.RestoreTS)))
 	}
 	if bl.PITR.On {
 		s += fmt.Sprintln("\nPITR <on>:")
@@ -224,7 +224,7 @@ func getSnapshotList(cn *pbm.PBM, size int, rsMap map[string]string) (s []snapsh
 		s = append(s, snapshotStat{
 			Name:       b.Name,
 			Status:     b.Status,
-			StateTS:    int64(b.LastWriteTS.T),
+			RestoreTS:  int64(b.LastWriteTS.T),
 			PBMVersion: b.PBMVersion,
 			Type:       b.Type,
 		})

--- a/cli/status.go
+++ b/cli/status.go
@@ -480,24 +480,24 @@ func (s storageStat) String() string {
 
 	sort.Slice(s.Snapshot, func(i, j int) bool {
 		a, b := s.Snapshot[i], s.Snapshot[j]
-		return a.StateTS > b.StateTS
+		return a.RestoreTS > b.RestoreTS
 	})
 
 	for _, sn := range s.Snapshot {
 		var status string
 		switch sn.Status {
 		case pbm.StatusDone:
-			status = fmt.Sprintf("[complete: %s]", fmtTS(sn.StateTS))
+			status = fmt.Sprintf("[restore_to_time: %s]", fmtTS(sn.RestoreTS))
 		case pbm.StatusCancelled:
-			status = fmt.Sprintf("[!canceled: %s]", fmtTS(sn.StateTS))
+			status = fmt.Sprintf("[!canceled: %s]", fmtTS(sn.RestoreTS))
 		case pbm.StatusError:
 			if errors.Is(sn.Err, errIncompatible) {
-				status = fmt.Sprintf("[incompatible: %s] [%s]", sn.Err.Error(), fmtTS(sn.StateTS))
+				status = fmt.Sprintf("[incompatible: %s] [%s]", sn.Err.Error(), fmtTS(sn.RestoreTS))
 			} else {
-				status = fmt.Sprintf("[ERROR: %s] [%s]", sn.Err.Error(), fmtTS(sn.StateTS))
+				status = fmt.Sprintf("[ERROR: %s] [%s]", sn.Err.Error(), fmtTS(sn.RestoreTS))
 			}
 		default:
-			status = fmt.Sprintf("[running: %s / %s]", sn.Status, fmtTS(sn.StateTS))
+			status = fmt.Sprintf("[running: %s / %s]", sn.Status, fmtTS(sn.RestoreTS))
 		}
 
 		ret += fmt.Sprintf("    %s %s <%s> %s\n", sn.Name, fmtSize(sn.Size), sn.Type, status)
@@ -577,7 +577,7 @@ func getStorageStat(cn *pbm.PBM, rsMap map[string]string) (fmt.Stringer, error) 
 		snpsht := snapshotStat{
 			Name:       bcp.Name,
 			Status:     bcp.Status,
-			StateTS:    bcp.LastTransitionTS,
+			RestoreTS:  bcp.LastTransitionTS,
 			PBMVersion: bcp.PBMVersion,
 			Type:       bcp.Type,
 			Err:        bcp.Error(),
@@ -590,7 +590,7 @@ func getStorageStat(cn *pbm.PBM, rsMap map[string]string) (fmt.Stringer, error) 
 			}
 			fallthrough
 		case pbm.StatusDone:
-			snpsht.StateTS = int64(bcp.LastWriteTS.T)
+			snpsht.RestoreTS = int64(bcp.LastWriteTS.T)
 			var err error
 			switch bcp.Type {
 			case pbm.PhysicalBackup:

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -111,7 +111,7 @@ type SnapshotStat struct {
 	Size       int64      `json:"size,omitempty"`
 	Status     pbm.Status `json:"status"`
 	Err        string     `json:"error,omitempty"`
-	StateTS    int64      `json:"completeTS"`
+	RestoreTS  int64      `json:"restoreTo"`
 	PBMVersion string     `json:"pbmVersion"`
 }
 

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -102,7 +102,7 @@ func (c *Cluster) BackupDelete(storage string) {
 		os.Exit(1)
 	}
 
-	tsp := time.Unix(list.Snapshots[len(list.Snapshots)-1].StateTS, 0).Add(time.Second * 10)
+	tsp := time.Unix(list.Snapshots[len(list.Snapshots)-1].RestoreTS, 0).Add(time.Second * 10)
 
 	log.Printf("delete pitr older than %s \n", tsp.Format("2006-01-02T15:04:05"))
 	_, err = c.pbm.RunCmd("pbm", "delete-pitr", "-f", "--older-than", tsp.Format("2006-01-02T15:04:05"))
@@ -127,8 +127,8 @@ func (c *Cluster) BackupDelete(storage string) {
 		log.Fatalf("ERROR: empty spanpshots list")
 	}
 
-	if list.PITR.Ranges[0].Range.Start-1 != uint32(list.Snapshots[len(list.Snapshots)-1].StateTS) {
-		log.Printf("ERROR: expected range starts the next second after the backup complete time, %v | %v", list.PITR.Ranges[0].Range.Start+1, uint32(list.Snapshots[len(list.Snapshots)-1].StateTS))
+	if list.PITR.Ranges[0].Range.Start-1 != uint32(list.Snapshots[len(list.Snapshots)-1].RestoreTS) {
+		log.Printf("ERROR: expected range starts the next second after the backup complete time, %v | %v", list.PITR.Ranges[0].Range.Start+1, uint32(list.Snapshots[len(list.Snapshots)-1].RestoreTS))
 		c.printBcpList()
 		os.Exit(1)
 	}


### PR DESCRIPTION
Rename "complete" => "restore_to_time" for backups in pbm list and pbm status output. 

https://jira.percona.com/browse/PBM-911