### PR TITLE
PBM-946: fix phys backups size in status

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -253,13 +253,13 @@ func describeBackup(cn *pbm.PBM, b *descBcp) (fmt.Stringer, error) {
 		rv.Err = &bcp.Err
 	}
 
-	if version.IsLegacyArchive(rv.PBMVersion) {
+	if bcp.Size == 0 {
 		stg, err := cn.GetStorage(cn.Logger().NewEvent("", "", "", primitive.Timestamp{}))
 		if err != nil {
 			return nil, errors.WithMessage(err, "get storage")
 		}
 
-		rv.Size, err = getLegacySnapshotSize(bcp.Replsets, stg)
+		rv.Size, err = getLegacySnapshotSize(bcp.Replsets, bcp.Type, stg)
 		if err != nil {
 			return nil, errors.WithMessage(err, "get snapshot size")
 		}

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -254,7 +254,7 @@ func (b *Backup) doPhysical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OP
 
 	size := int64(0)
 	for _, f := range rsMeta.Files {
-		size += f.Size
+		size += f.StgSize
 	}
 
 	err = b.cn.IncBackupSize(ctx, bcp.Name, size)

--- a/version/version.go
+++ b/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // current PBM version
-const version = "2.0.0-dev"
+const version = "2.0.0"
 
 // !!! should be sorted in the ascending order
 var breakingChangesV = []string{


### PR DESCRIPTION
- Legacy (pre 2.0) physical backups should be considered during size calculation.

- Storage size instead of db file size should be used for physical backup size.

- Bump version.