### PR TITLE
PBM-941: add sidecar mode for pbm-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,16 @@ build-stest:
 	$(ENVS) go build -ldflags="$(LDFLAGS)" $(BUILD_FLAGS) -o ./bin/pbm-speed-test ./cmd/pbm-speed-test
 
 install: install-pbm install-agent install-stest
+install-all: install install-entrypoint
+install-k8s: install-all
 install-pbm:
 	$(ENVS) go install -ldflags="$(LDFLAGS)" $(BUILD_FLAGS) ./cmd/pbm
 install-agent:
 	$(ENVS) go install -ldflags="$(LDFLAGS)" $(BUILD_FLAGS) ./cmd/pbm-agent
 install-stest:
 	$(ENVS) go install -ldflags="$(LDFLAGS)" $(BUILD_FLAGS) ./cmd/pbm-speed-test
+install-entrypoint:
+	$(ENVS) go install -ldflags="$(LDFLAGS)" $(BUILD_FLAGS) ./cmd/pbm-agent-entrypoint
 
 # RACE DETECTOR ON
 build-race: build-pbm-race build-agent-race build-stest-race

--- a/cmd/pbm-agent-entrypoint/main.go
+++ b/cmd/pbm-agent-entrypoint/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+const (
+	envSidecar         = "PBM_AGENT_SIDECAR"
+	envSidecarSleepSec = "PBM_AGENT_SIDECAR_SLEEP"
+
+	agentCmd = "pbm-agent"
+)
+
+func main() {
+	for {
+		cmd := exec.Command(agentCmd, os.Args...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Run()
+	}
+}

--- a/cmd/pbm-agent-entrypoint/main.go
+++ b/cmd/pbm-agent-entrypoint/main.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/exec"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
 )
 
 const (
@@ -13,11 +18,77 @@ const (
 )
 
 func main() {
-	_, isSidecar := os.LookupEnv(envSidecar)
+	var procID int
+
+	l := log.New(os.Stderr, "[entrypoint] ", log.LstdFlags|log.Lmsgprefix)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		s := <-sig
+		signal.Stop(sig)
+
+		l.Printf("got %s, shutting down", s)
+		if procID != 0 {
+			err := syscall.Kill(procID, syscall.SIGTERM)
+			l.Printf("kill `%s` (%d): %v", agentCmd, procID, err)
+		}
+		os.Exit(0)
+	}()
+
+	var (
+		isSidecar bool
+		sleepSec  = 1
+
+		err error
+	)
+	if isSideStr, ok := os.LookupEnv(envSidecar); ok {
+		isSidecar, err = strconv.ParseBool(isSideStr)
+		if err != nil {
+			l.Printf("error: parsing %s value: %v", envSidecar, err)
+		}
+	}
+	if sleepStr, ok := os.LookupEnv(envSidecarSleepSec); ok {
+		sec, err := strconv.Atoi(sleepStr)
+		if err != nil {
+			l.Printf("error: parsing %s value: %v", envSidecarSleepSec, err)
+		} else {
+			sleepSec = sec
+		}
+	}
+
+	var exitCode int
 	for {
-		cmd := exec.Command(agentCmd, os.Args...)
+		cmd := exec.Command(agentCmd, os.Args[1:]...)
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = os.Stdin
-		cmd.Run()
+
+		exitCode = 1
+
+		l.Printf("starting `%s`", agentCmd)
+		err := cmd.Start()
+		if err != nil {
+			l.Printf("error: starting `%s`: %v", agentCmd, err)
+			if !isSidecar {
+				os.Exit(exitCode)
+			}
+		}
+
+		procID = cmd.Process.Pid
+
+		err = cmd.Wait()
+		if err != nil {
+			if exErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exErr.ExitCode()
+			}
+		}
+		if !isSidecar {
+			os.Exit(exitCode)
+		}
+
+		l.Printf("`%s` exited with code %d", agentCmd, exitCode)
+		l.Printf("restart in %d sec", sleepSec)
+		time.Sleep(time.Second * time.Duration(sleepSec))
 	}
 }

--- a/cmd/pbm-agent-entrypoint/main.go
+++ b/cmd/pbm-agent-entrypoint/main.go
@@ -13,6 +13,7 @@ const (
 )
 
 func main() {
+	_, isSidecar := os.LookupEnv(envSidecar)
 	for {
 		cmd := exec.Command(agentCmd, os.Args...)
 		cmd.Stderr = os.Stderr

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -2,7 +2,7 @@ FROM golang:1.19
 RUN apt-get update -y && apt-get install -y libkrb5-dev
 WORKDIR /opt/pbm
 COPY . .
-RUN make install
+RUN make install-k8s
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal
 RUN microdnf update && microdnf clean all
@@ -62,5 +62,6 @@ COPY ./docker/start-agent.sh /start-agent.sh
 
 USER nobody
 
+ENV PBM_AGENT_SIDECAR=true
 ENTRYPOINT ["/start-agent.sh"]
-CMD ["pbm-agent"]
+CMD ["pbm-agent-entrypoint"]


### PR DESCRIPTION
Add an entry point app that starts pbm-agent in k8s. In case env
`PBM_AGENT_SIDECAR` is set to true, it will restart the agent should it
exits (despite with an error or not) after the `PBM_AGENT_SIDECAR_SLEEP`
timeout in sec (default 1)

https://jira.percona.com/browse/PBM-941