### PR TITLE
PBM-733: add timezone option to pbm logs output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,6 +44,7 @@ type logsOpts struct {
 	severity string
 	event    string
 	opid     string
+	location string
 	extr     bool
 }
 
@@ -141,6 +142,7 @@ func Main() {
 	logsCmd.Flag("severity", "Severity level D, I, W, E or F, low to high. Choosing one includes higher levels too.").Short('s').Default("I").EnumVar(&logs.severity, "D", "I", "W", "E", "F")
 	logsCmd.Flag("event", "Event in format backup[/2020-10-06T11:45:14Z]. Events: backup, restore, cancelBackup, resync, pitr, pitrestore, delete").Short('e').StringVar(&logs.event)
 	logsCmd.Flag("opid", "Operation ID").Short('i').StringVar(&logs.opid)
+	logsCmd.Flag("timezone", "Timezone of log output. `Local`, `UTC` or a location name corresponding to a file in the IANA Time Zone database, such as `America/New_York`").StringVar(&logs.location)
 	logsCmd.Flag("extra", "Show extra data in text format").Hidden().Short('x').BoolVar(&logs.extr)
 
 	statusOpts := statusOptions{}
@@ -332,6 +334,11 @@ func runLogs(cn *pbm.PBM, l *logsOpts) (fmt.Stringer, error) {
 	for i := len(o.Data)/2 - 1; i >= 0; i-- {
 		opp := len(o.Data) - 1 - i
 		o.Data[i], o.Data[opp] = o.Data[opp], o.Data[i]
+	}
+
+	err = o.SetLocation(l.location)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to parse timezone: %v\n\n", err)
 	}
 
 	return o, nil

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -262,6 +262,12 @@ type Entries struct {
 	Data     []Entry `json:"data"`
 	ShowNode bool    `json:"-"`
 	Extr     bool    `json:"-"`
+	loc      *time.Location
+}
+
+func (e *Entries) SetLocation(l string) (err error) {
+	e.loc, err = time.LoadLocation(l)
+	return err
 }
 
 func (e Entries) MarshalJSON() ([]byte, error) {
@@ -269,8 +275,16 @@ func (e Entries) MarshalJSON() ([]byte, error) {
 }
 
 func (e Entries) String() (s string) {
+	if e.loc == nil {
+		e.loc = time.UTC
+	}
+
+	f := func(ts int64) string {
+		return time.Unix(ts, 0).In(e.loc).Format(time.RFC3339)
+	}
+
 	for _, entry := range e.Data {
-		s += entry.string(tsUTC, e.ShowNode, e.Extr) + "\n"
+		s += entry.string(f, e.ShowNode, e.Extr) + "\n"
 	}
 
 	return s


### PR DESCRIPTION
Added flag:
usage: pbm logs [<flags>]

PBM logs

Flags:
     ...
      --timezone=TIMEZONE        Timezone of log output. `Local`, `UTC` or a location name corresponding to a file in the IANA Time Zone database, such as `America/New_York`

https://jira.percona.com/browse/PBM-733