### PR TITLE
PBM-858: status, always show err for insufficient oplog range

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // current PBM version
-const version = "2.0.0"
+const version = "2.0.1-dev"
 
 // !!! should be sorted in the ascending order
 var breakingChangesV = []string{


### PR DESCRIPTION
Check for the oplog sufficiency at the beginning of the streaming. And
report `start_ok` only after that check. So ErrInsuffRange from the
previous run won't be rewritten with `start_ok`.

Also, users will see errors immediately (almost) without the misleading
pause due to the timer.