### PR TITLE
PBM-978: fix phys restore of hidden nodes

### DIFF
--- a/pbm/bsontypes.go
+++ b/pbm/bsontypes.go
@@ -308,10 +308,10 @@ type RSConfig struct {
 type RSMember struct {
 	ID                 int               `bson:"_id" json:"_id"`
 	Host               string            `bson:"host" json:"host"`
-	ArbiterOnly        bool              `bson:"arbiterOnly,omitempty" json:"arbiterOnly"`
-	BuildIndexes       bool              `bson:"buildIndexes,omitempty" json:"buildIndexes"`
-	Hidden             bool              `bson:"hidden,omitempty" json:"hidden"`
-	Priority           float64           `bson:"priority,omitempty" json:"priority"`
+	ArbiterOnly        bool              `bson:"arbiterOnly" json:"arbiterOnly"`
+	BuildIndexes       bool              `bson:"buildIndexes" json:"buildIndexes"`
+	Hidden             bool              `bson:"hidden" json:"hidden"`
+	Priority           float64           `bson:"priority" json:"priority"`
 	Tags               map[string]string `bson:"tags,omitempty" json:"tags"`
 	SecondaryDelayOld  int64             `bson:"slaveDelay"`
 	SecondaryDelaySecs int64             `bson:"secondaryDelaySecs"`

--- a/pbm/bsontypes.go
+++ b/pbm/bsontypes.go
@@ -313,6 +313,6 @@ type RSMember struct {
 	Hidden             bool              `bson:"hidden" json:"hidden"`
 	Priority           float64           `bson:"priority" json:"priority"`
 	Tags               map[string]string `bson:"tags,omitempty" json:"tags"`
-	SecondaryDelayOld  int64             `bson:"slaveDelay"`
-	SecondaryDelaySecs int64             `bson:"secondaryDelaySecs"`
+	SecondaryDelayOld  int64             `bson:"slaveDelay,omitempty"`
+	SecondaryDelaySecs int64             `bson:"secondaryDelaySecs,omitempty"`
 }


### PR DESCRIPTION
When bson value is "omitempty" it won't passi to the mongo and mongo writes default. As the default for float64 is 0, it will be omited by driver (omitempty) and mongo will write its default for an option. And default for `priority` is 1. So when it was 0 it became 1 after the PBM write.
This commit fixes it.

https://jira.percona.com/browse/PBM-978