### PR TITLE
[PBM-962] Selective Backup/Restore for unsharded collections in sharded cluster

### DIFF
--- a/pbm/archive/archive.go
+++ b/pbm/archive/archive.go
@@ -32,30 +32,39 @@ type Namespace struct {
 
 const MetaFile = "metadata.json"
 
+const MaxBSONSize = db.MaxBSONSize
+
 var terminatorBytes = []byte{0xFF, 0xFF, 0xFF, 0xFF}
 
-func Decompose(r io.Reader, newWriter NewWriter) error {
+type MatchFunc func(ns string) bool
+
+func Decompose(r io.Reader, newWriter NewWriter, match MatchFunc) error {
 	meta, err := readPrelude(r)
 	if err != nil {
 		return errors.WithMessage(err, "predule")
 	}
 
-	c := newConsumer(newWriter)
+	c := newConsumer(newWriter, match)
 	if err := (&archive.Parser{In: r}).ReadAllBlocks(c); err != nil {
 		return errors.WithMessage(err, "archive parser")
 	}
 
+	nss := make([]*Namespace, 0, len(meta.Namespaces))
 	for _, n := range meta.Namespaces {
 		ns := NSify(n.Database, n.Collection)
+		if !match(ns) {
+			continue
+		}
+
 		n.CRC = c.crc[ns]
 		n.Size = c.size[ns]
+		nss = append(nss, n)
 	}
+	meta.Namespaces = nss
 
 	err = writeMetadata(meta, newWriter)
 	return errors.WithMessage(err, "metadata")
 }
-
-type MatchFunc func(ns string) bool
 
 func Compose(w io.Writer, match MatchFunc, newReader NewReader) error {
 	meta, err := readMetadata(newReader)
@@ -130,7 +139,7 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 			}
 			defer r.Close()
 
-			err = splitChunks(r, db.MaxBSONSize*2, func(b []byte) error {
+			err = splitChunks(r, MaxBSONSize*2, func(b []byte) error {
 				mu.Lock()
 				defer mu.Unlock()
 				return errors.WithMessage(writeChunk(w, ns, b), "write chunk")
@@ -150,7 +159,7 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 
 func splitChunks(r io.Reader, size int, write func([]byte) error) error {
 	chunk := make([]byte, 0, size)
-	buf, err := readBSONBuffer(r, nil)
+	buf, err := ReadBSONBuffer(r, nil)
 	for err == nil {
 		if len(chunk)+len(buf) > size {
 			if err := write(chunk); err != nil {
@@ -160,7 +169,7 @@ func splitChunks(r io.Reader, size int, write func([]byte) error) error {
 		}
 
 		chunk = append(chunk, buf...)
-		buf, err = readBSONBuffer(r, buf[:cap(buf)])
+		buf, err = ReadBSONBuffer(r, buf[:cap(buf)])
 	}
 
 	if !errors.Is(err, io.EOF) {
@@ -174,8 +183,8 @@ func splitChunks(r io.Reader, size int, write func([]byte) error) error {
 	return errors.WithMessage(write(chunk), "last")
 }
 
-// readBSONBuffer reads raw bson document from r reader using buf buffer
-func readBSONBuffer(r io.Reader, buf []byte) ([]byte, error) {
+// ReadBSONBuffer reads raw bson document from r reader using buf buffer
+func ReadBSONBuffer(r io.Reader, buf []byte) ([]byte, error) {
 	var l [4]byte
 
 	_, err := io.ReadFull(r, l[:])
@@ -219,15 +228,15 @@ func writeChunk(w io.Writer, ns *Namespace, data []byte) error {
 		return errors.WithMessage(err, "marshal")
 	}
 
-	if err := secureWrite(w, header); err != nil {
+	if err := SecureWrite(w, header); err != nil {
 		return errors.WithMessage(err, "header")
 	}
 
-	if err := secureWrite(w, data); err != nil {
+	if err := SecureWrite(w, data); err != nil {
 		return errors.WithMessage(err, "data")
 	}
 
-	err = secureWrite(w, terminatorBytes)
+	err = SecureWrite(w, terminatorBytes)
 	return errors.WithMessage(err, "terminator")
 }
 
@@ -247,11 +256,11 @@ func closeChunk(w io.Writer, ns *Namespace) error {
 		return errors.WithMessage(err, "marshal")
 	}
 
-	if err := secureWrite(w, header); err != nil {
+	if err := SecureWrite(w, header); err != nil {
 		return errors.WithMessage(err, "header")
 	}
 
-	err = secureWrite(w, terminatorBytes)
+	err = SecureWrite(w, terminatorBytes)
 	return errors.WithMessage(err, "terminator")
 }
 
@@ -267,7 +276,7 @@ func writeMetadata(meta *archiveMeta, newWriter NewWriter) error {
 		return errors.WithMessage(err, "marshal")
 	}
 
-	return secureWrite(w, data)
+	return SecureWrite(w, data)
 }
 
 func readMetadata(newReader NewReader) (*archiveMeta, error) {
@@ -292,19 +301,21 @@ func ReadMetadata(r io.Reader) (*archiveMeta, error) {
 }
 
 type consumer struct {
-	open NewWriter
-	nss  map[string]io.WriteCloser
-	crc  map[string]int64
-	size map[string]int64
-	curr string
+	open  NewWriter
+	match MatchFunc
+	nss   map[string]io.WriteCloser
+	crc   map[string]int64
+	size  map[string]int64
+	curr  string
 }
 
-func newConsumer(newWriter NewWriter) *consumer {
+func newConsumer(newWriter NewWriter, match MatchFunc) *consumer {
 	return &consumer{
-		open: newWriter,
-		nss:  make(map[string]io.WriteCloser),
-		crc:  make(map[string]int64),
-		size: make(map[string]int64),
+		open:  newWriter,
+		match: match,
+		nss:   make(map[string]io.WriteCloser),
+		crc:   make(map[string]int64),
+		size:  make(map[string]int64),
 	}
 }
 
@@ -315,6 +326,10 @@ func (c *consumer) HeaderBSON(data []byte) error {
 	}
 
 	ns := NSify(h.Database, h.Collection)
+	if !c.match(ns) {
+		c.curr = ""
+		return nil
+	}
 
 	if !h.EOF {
 		c.curr = ns
@@ -334,6 +349,10 @@ func (c *consumer) HeaderBSON(data []byte) error {
 
 func (c *consumer) BodyBSON(data []byte) error {
 	ns := c.curr
+	if ns == "" {
+		return nil
+	}
+
 	w := c.nss[ns]
 	if w == nil {
 		var err error
@@ -346,7 +365,7 @@ func (c *consumer) BodyBSON(data []byte) error {
 	}
 
 	c.size[ns] += int64(len(data))
-	return errors.WithMessagef(secureWrite(w, data), "%q", ns)
+	return errors.WithMessagef(SecureWrite(w, data), "%q", ns)
 }
 
 func (c *consumer) End() error {
@@ -362,7 +381,7 @@ func (c *consumer) End() error {
 	return eg.Wait()
 }
 
-func secureWrite(w io.Writer, data []byte) error {
+func SecureWrite(w io.Writer, data []byte) error {
 	n, err := w.Write(data)
 	if err != nil {
 		return errors.WithMessage(err, "write")

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -24,6 +24,8 @@ import (
 func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPID, rsMeta *pbm.BackupReplset, inf *pbm.NodeInfo, stg storage.Storage, l *plog.Event) error {
 	var db, coll string
 	if len(bcp.Namespaces) != 0 {
+		// for selective backup, configsvr does not hold any data.
+		// only some collections from config db is required to restore cluster state
 		if inf.IsConfigSrv() {
 			db = "config"
 		} else {
@@ -119,6 +121,11 @@ func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPI
 		return errors.WithMessage(err, "get config")
 	}
 
+	nsFilter := archive.DefaultMatchFunc
+	if len(bcp.Namespaces) != 0 && inf.IsConfigSrv() {
+		nsFilter = makeConfigsvrNSFilter()
+	}
+
 	snapshotSize, err := snapshot.UploadDump(dump,
 		func(ns, ext string, r io.Reader) error {
 			stg, err := pbm.Storage(cfg, l)
@@ -132,7 +139,7 @@ func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPI
 		snapshot.UploadDumpOptions{
 			Compression:      bcp.Compression,
 			CompressionLevel: bcp.CompressionLevel,
-			NSFilter:         makeNSFilter(len(bcp.Namespaces) != 0 && inf.IsConfigSrv()),
+			NSFilter:         nsFilter,
 		})
 	if err != nil {
 		return errors.Wrap(err, "mongodump")
@@ -192,12 +199,13 @@ func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPI
 	return nil
 }
 
-func makeNSFilter(configsvr bool) archive.MatchFunc {
-	if !configsvr {
-		return func(string) bool { return true }
+func makeConfigsvrNSFilter() archive.MatchFunc {
+	// list of required namespaces for further selective restore
+	allowed := map[string]bool{
+		"config.databases": true,
 	}
 
-	return func(ns string) bool { return ns == "config.databases" }
+	return func(ns string) bool { return allowed[ns] }
 }
 
 func getNamespacesSize(ctx context.Context, m *mongo.Client, db, coll string) (map[string]int64, error) {

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -32,6 +32,8 @@ import (
 
 type Record = db.Oplog
 
+// OpFilter can be used to filter out oplog records by content.
+// Useful for apply only subset of operations depending on conditions
 type OpFilter func(*Record) bool
 
 func DefaultOpFilter(*Record) bool { return true }
@@ -133,6 +135,7 @@ func NewOplogRestore(dst *pbm.Node, sv *pbm.MongoVersion, unsafe, preserveUUID b
 	}, nil
 }
 
+// SetOpFilter allows to restrict skip ops by specific conditions
 func (o *OplogRestore) SetOpFilter(f OpFilter) {
 	if f == nil {
 		f = DefaultOpFilter

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -16,6 +16,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/pbm/archive"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
@@ -121,7 +122,7 @@ func (r *Restore) Snapshot(cmd *pbm.RestoreCmd, opid pbm.OPID, l *log.Event) (er
 		return err
 	}
 
-	err = r.RunSnapshot(dump, bcp, cmd.Namespaces)
+	err = r.RunSnapshot(dump, bcp, nss)
 	if err != nil {
 		return err
 	}
@@ -131,13 +132,19 @@ func (r *Restore) Snapshot(cmd *pbm.RestoreCmd, opid pbm.OPID, l *log.Event) (er
 		return err
 	}
 
+	oplogOption := &applyOplogOption{nss: nss}
+	if r.nodeInfo.IsConfigSrv() && isSelective(nss) {
+		oplogOption.nss = []string{"config.databases"}
+		oplogOption.filter = newConfigsvrOpFilter(nss)
+	}
+
 	err = r.applyOplog([]pbm.OplogChunk{{
 		RS:          r.nodeInfo.SetName,
 		FName:       oplog,
 		Compression: bcp.Compression,
 		StartTS:     bcp.FirstWriteTS,
 		EndTS:       bcp.LastWriteTS,
-	}}, &applyOplogOption{nss: cmd.Namespaces})
+	}}, oplogOption)
 	if err != nil {
 		return err
 	}
@@ -147,6 +154,35 @@ func (r *Restore) Snapshot(cmd *pbm.RestoreCmd, opid pbm.OPID, l *log.Event) (er
 	}
 
 	return r.Done()
+}
+
+func newConfigsvrOpFilter(nss []string) oplog.OpFilter {
+	dbs := make(map[string]bool, len(nss))
+	for _, ns := range nss {
+		db, _, _ := strings.Cut(ns, ".")
+		if db != "" && db != "*" {
+			dbs[db] = true
+		}
+	}
+
+	return func(r *oplog.Record) bool {
+		if r.Namespace != "config.databases" {
+			return false
+		}
+
+		for _, e := range r.Query {
+			if e.Key != "_id" {
+				continue
+			}
+
+			v, _ := e.Value.(string)
+			if dbs[v] {
+				return true
+			}
+		}
+
+		return false
+	}
 }
 
 // PITR do the Point-in-Time Recovery
@@ -229,7 +265,7 @@ func (r *Restore) PITR(cmd *pbm.PITRestoreCmd, opid pbm.OPID, l *log.Event) (err
 		return err
 	}
 
-	err = r.RunSnapshot(dump, bcp, cmd.Namespaces)
+	err = r.RunSnapshot(dump, bcp, nss)
 	if err != nil {
 		return err
 	}
@@ -247,7 +283,12 @@ func (r *Restore) PITR(cmd *pbm.PITRestoreCmd, opid pbm.OPID, l *log.Event) (err
 		EndTS:       bcp.LastWriteTS,
 	}
 
-	oplogOption := applyOplogOption{end: &tsTo, nss: cmd.Namespaces}
+	oplogOption := applyOplogOption{end: &tsTo, nss: nss}
+	if r.nodeInfo.IsConfigSrv() && isSelective(nss) {
+		oplogOption.nss = []string{"config.databases"}
+		oplogOption.filter = newConfigsvrOpFilter(nss)
+	}
+
 	err = r.applyOplog(append([]pbm.OplogChunk{snapshotChunk}, chunks...), &oplogOption)
 	if err != nil {
 		return err
@@ -576,6 +617,10 @@ func (r *Restore) RunSnapshot(dump string, bcp *pbm.BackupMeta, nss []string) (e
 		}
 	} else {
 		if len(nss) == 0 {
+			nss = bcp.Namespaces
+		}
+
+		if !isSelective(nss) {
 			nss = []string{"*.*"}
 		}
 
@@ -585,9 +630,14 @@ func (r *Restore) RunSnapshot(dump string, bcp *pbm.BackupMeta, nss []string) (e
 			return err
 		}
 
-		cfg, err := r.cn.GetConfig()
+		var cfg pbm.Config
+		cfg, err = r.cn.GetConfig()
 		if err != nil {
 			return errors.WithMessage(err, "get config")
+		}
+
+		if r.nodeInfo.IsConfigSrv() && isSelective(nss) {
+			return r.configsvrRestore(&cfg, bcp, nss)
 		}
 
 		rdr, err = snapshot.DownloadDump(
@@ -613,7 +663,7 @@ func (r *Restore) RunSnapshot(dump string, bcp *pbm.BackupMeta, nss []string) (e
 		return errors.Wrap(err, "mongorestore")
 	}
 
-	if isSelective(bcp.Namespaces) || isSelective(nss) {
+	if isSelective(nss) {
 		return nil
 	}
 
@@ -634,6 +684,68 @@ func (r *Restore) RunSnapshot(dump string, bcp *pbm.BackupMeta, nss []string) (e
 	}
 
 	return nil
+}
+
+func (r *Restore) configsvrRestore(cfg *pbm.Config, bcp *pbm.BackupMeta, nss []string) error {
+	stg, err := pbm.Storage(*cfg, r.log)
+	if err != nil {
+		return errors.WithMessage(err, "get storage")
+	}
+
+	rdr, err := stg.SourceReader(path.Join(bcp.Name, r.node.RS(), "config.databases"))
+	if err != nil {
+		return err
+	}
+
+	ss := make(map[string]bool, len(nss))
+	for _, ns := range nss {
+		db, _, _ := strings.Cut(ns, ".")
+		if db != "" && db != "*" {
+			ss[db] = true
+		}
+	}
+
+	models := []mongo.WriteModel{}
+	for buf := make([]byte, archive.MaxBSONSize); ; {
+		var data []byte
+
+		data, err = archive.ReadBSONBuffer(rdr, buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return err
+		}
+
+		db, _ := bson.Raw(data).Lookup("_id").StringValueOK()
+		if !ss[db] {
+			continue
+		}
+
+		doc := bson.D{}
+		err = bson.Unmarshal(data, &doc)
+		if err != nil {
+			return errors.WithMessage(err, "unmarshal")
+		}
+
+		model := mongo.NewReplaceOneModel()
+		model.SetFilter(bson.D{{"_id", db}})
+		model.SetReplacement(doc)
+		model.SetUpsert(true)
+		models = append(models, model)
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	if len(models) == 0 {
+		return nil
+	}
+
+	coll := r.cn.Conn.Database("config").Collection("databases")
+	_, err = coll.BulkWrite(r.cn.Context(), models)
+	return errors.WithMessage(err, "update config.databases")
 }
 
 func isSelective(nss []string) bool {
@@ -823,6 +935,7 @@ type applyOplogOption struct {
 	end    *primitive.Timestamp
 	nss    []string
 	unsafe bool
+	filter oplog.OpFilter
 }
 
 // In order to sync distributed transactions (commit ontly when all participated shards are committed),
@@ -865,6 +978,8 @@ func (r *Restore) applyOplog(chunks []pbm.OplogChunk, options *applyOplogOption)
 	if err != nil {
 		return errors.Wrap(err, "create oplog")
 	}
+
+	r.oplog.SetOpFilter(options.filter)
 
 	var startTS, endTS primitive.Timestamp
 	if options.start != nil {

--- a/pbm/snapshot/dump.go
+++ b/pbm/snapshot/dump.go
@@ -14,6 +14,7 @@ import (
 type UploadDumpOptions struct {
 	Compression      compress.CompressionType
 	CompressionLevel *int
+	NSFilter         archive.MatchFunc
 }
 
 type UploadFunc func(ns, ext string, r io.Reader) error
@@ -58,7 +59,7 @@ func UploadDump(wt io.WriterTo, upload UploadFunc, opts UploadDumpOptions) (int6
 		return dwc, errors.WithMessagef(err, "create compressor: %q", ns)
 	}
 
-	err := archive.Decompose(pr, newWriter)
+	err := archive.Decompose(pr, newWriter, opts.NSFilter)
 	wg.Wait()
 	return size, errors.WithMessage(err, "decompose")
 }

--- a/pbm/snapshot/dump.go
+++ b/pbm/snapshot/dump.go
@@ -14,7 +14,10 @@ import (
 type UploadDumpOptions struct {
 	Compression      compress.CompressionType
 	CompressionLevel *int
-	NSFilter         archive.MatchFunc
+	// NSFilter check whether a namespace is selected for backup.
+	// Useful when 2 or more namespaces are selected for backup.
+	// mongo-tools is limited to backup a single collection or a single db (but with all collections).
+	NSFilter archive.MatchFunc
 }
 
 type UploadFunc func(ns, ext string, r io.Reader) error


### PR DESCRIPTION
We can selectively restore unsharded collection(s) in sharded cluster, but mongos does not see the collections and their databases if these databases do not exist yet. For that, we restore (during snapshot restore and oplog replay stages) only the needed document(s) in config.databases on configsvr to make these collections/databases visible.

It also handles [movePrimary command](https://www.mongodb.com/docs/manual/reference/command/movePrimary/)