### PR TITLE
PBM-999: Add Incremental Backpus

### DIFF
--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -293,7 +293,7 @@ func (a *Agent) Restore(r *pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 		return
 	}
 	switch bcp.Type {
-	case pbm.PhysicalBackup:
+	case pbm.PhysicalBackup, pbm.IncrementalBackup:
 		a.HbPause()
 		err = a.restorePhysical(r, opid, ep, l)
 	case pbm.LogicalBackup:

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -88,6 +88,8 @@ func (a *Agent) Backup(cmd *pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 	switch cmd.Type {
 	case pbm.PhysicalBackup:
 		bcp = backup.NewPhysical(a.pbm, a.node)
+	case pbm.IncrementalBackup:
+		bcp = backup.NewIncremental(a.pbm, a.node, cmd.IncrBase)
 	case pbm.LogicalBackup:
 		fallthrough
 	default:

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -20,6 +20,7 @@ import (
 type backupOpts struct {
 	name             string
 	typ              string
+	base             bool
 	compression      string
 	compressionLevel []int
 	ns               string
@@ -87,6 +88,7 @@ func runBackup(cn *pbm.PBM, b *backupOpts, outf outFormat) (fmt.Stringer, error)
 		Cmd: pbm.CmdBackup,
 		Backup: &pbm.BackupCmd{
 			Type:             pbm.BackupType(b.typ),
+			IncrBase:         b.base,
 			Name:             b.name,
 			Namespaces:       nss,
 			Compression:      compression,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -82,12 +82,14 @@ func Main() {
 			string(compress.CompressionTypeS2), string(compress.CompressionTypePGZIP),
 			string(compress.CompressionTypeZstandard),
 		)
-	backupCmd.Flag("type", fmt.Sprintf("backup type: <%s>/<%s>", pbm.PhysicalBackup, pbm.LogicalBackup)).
+	backupCmd.Flag("type", fmt.Sprintf("backup type: <%s>/<%s>/<%s>", pbm.PhysicalBackup, pbm.LogicalBackup, pbm.IncrementalBackup)).
 		Default(string(pbm.LogicalBackup)).Short('t').
 		EnumVar(&backup.typ,
 			string(pbm.PhysicalBackup),
 			string(pbm.LogicalBackup),
+			string(pbm.IncrementalBackup),
 		)
+	backupCmd.Flag("base", "Is this a base for incremental backups").BoolVar(&backup.base)
 	backupCmd.Flag("compression-level", "Compression level (specific to the compression type)").
 		IntsVar(&backup.compressionLevel)
 	backupCmd.Flag("ns", `Namespaces to backup (e.g. "db.*", "db.collection"). If not set, backup all ("*.*")`).StringVar(&backup.ns)

--- a/cli/restore.go
+++ b/cli/restore.go
@@ -135,7 +135,7 @@ func waitRestore(cn *pbm.PBM, m *pbm.RestoreMeta) error {
 	var rmeta *pbm.RestoreMeta
 
 	getMeta := cn.GetRestoreMeta
-	if m.Type == pbm.PhysicalBackup {
+	if m.Type == pbm.PhysicalBackup || m.Type == pbm.IncrementalBackup {
 		getMeta = func(name string) (*pbm.RestoreMeta, error) {
 			return pbm.GetPhysRestoreMeta(name, stg)
 		}

--- a/cli/status.go
+++ b/cli/status.go
@@ -755,7 +755,7 @@ func getLegacySnapshotSize(rsets []pbm.BackupReplset, typ pbm.BackupType, stg st
 	switch typ {
 	case pbm.LogicalBackup:
 		return getLegacyLogicalSize(rsets, stg)
-	case pbm.PhysicalBackup:
+	case pbm.PhysicalBackup, pbm.IncrementalBackup:
 		return getLegacyPhysSize(rsets, stg)
 	default:
 		return 0, errors.Errorf("unknown backup type %s", typ)

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -226,7 +226,7 @@ func (b *Backup) Run(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPID, l *
 	switch b.typ {
 	case pbm.LogicalBackup:
 		err = b.doLogical(ctx, bcp, opid, &rsMeta, inf, stg, l)
-	case pbm.PhysicalBackup:
+	case pbm.PhysicalBackup, pbm.IncrementalBackup:
 		err = b.doPhysical(ctx, bcp, opid, &rsMeta, inf, stg, l)
 	default:
 		return errors.New("undefined backup type")

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -31,9 +31,10 @@ func init() {
 }
 
 type Backup struct {
-	cn   *pbm.PBM
-	node *pbm.Node
-	typ  pbm.BackupType
+	cn       *pbm.PBM
+	node     *pbm.Node
+	typ      pbm.BackupType
+	incrBase bool
 }
 
 func New(cn *pbm.PBM, node *pbm.Node) *Backup {
@@ -49,6 +50,15 @@ func NewPhysical(cn *pbm.PBM, node *pbm.Node) *Backup {
 		cn:   cn,
 		node: node,
 		typ:  pbm.PhysicalBackup,
+	}
+}
+
+func NewIncremental(cn *pbm.PBM, node *pbm.Node, base bool) *Backup {
+	return &Backup{
+		cn:       cn,
+		node:     node,
+		typ:      pbm.IncrementalBackup,
+		incrBase: base,
 	}
 }
 

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -272,7 +272,7 @@ func (b *Backup) doPhysical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OP
 	rsMeta.Journal = append(rsMeta.Journal, ju...)
 	l.Info("uploading journals")
 
-	err = b.cn.RSSetPhyFiles(bcp.Name, rsMeta.Name, rsMeta.Files)
+	err = b.cn.RSSetPhyFiles(bcp.Name, rsMeta.Name, rsMeta)
 	if err != nil {
 		return errors.Wrap(err, "set shard's files list")
 	}
@@ -280,6 +280,9 @@ func (b *Backup) doPhysical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OP
 	size := int64(0)
 	for _, f := range rsMeta.Files {
 		size += f.StgSize
+	}
+	for _, j := range rsMeta.Journal {
+		size += j.StgSize
 	}
 
 	err = b.cn.IncBackupSize(ctx, bcp.Name, size)

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -161,7 +161,7 @@ func (c Cmd) String() string {
 
 type BackupCmd struct {
 	Type             BackupType               `bson:"type"`
-	Source           string                   `bson:"src,omitempty"`
+	IncrBase         bool                     `bson:"base"`
 	Name             string                   `bson:"name"`
 	Namespaces       []string                 `bson:"nss,omitempty"`
 	Compression      compress.CompressionType `bson:"compression"`
@@ -553,6 +553,13 @@ type File struct {
 	Size    int64       `bson:"fileSize" json:"fileSize"`
 	StgSize int64       `bson:"stgSize" json:"stgSize"`
 	Fmode   os.FileMode `bson:"fmode" json:"fmode"`
+}
+
+func (f File) String() string {
+	if f.Off == 0 && f.Len == 0 {
+		return f.Name
+	}
+	return fmt.Sprintf("%s [%d:%d]", f.Name, f.Off, f.Len)
 }
 
 func (f *File) WriteTo(w io.Writer) (int64, error) {
@@ -1073,4 +1080,8 @@ func CopyColl(ctx context.Context, from, to *mongo.Collection, filter interface{
 	}
 
 	return n, nil
+}
+
+func BackupCursorName(s string) string {
+	return strings.NewReplacer("-", "", ":", "").Replace(s)
 }

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -532,8 +532,9 @@ type Condition struct {
 
 type BackupReplset struct {
 	Name             string              `bson:"name" json:"name"`
-	Files            []File              `bson:"files,omitempty" json:"files,omitempty" `
-	DumpName         string              `bson:"dump_name,omitempty" json:"backup_name,omitempty" `
+	Journal          []File              `bson:"journal,omitempty" json:"journal,omitempty"`
+	Files            []File              `bson:"files,omitempty" json:"files,omitempty"`
+	DumpName         string              `bson:"dump_name,omitempty" json:"backup_name,omitempty"`
 	OplogName        string              `bson:"oplog_name,omitempty" json:"oplog_name,omitempty"`
 	StartTS          int64               `bson:"start_ts" json:"start_ts"`
 	Status           Status              `bson:"status" json:"status"`

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -732,12 +732,13 @@ func (p *PBM) IncBackupSize(ctx context.Context, bcpName string, size int64) err
 	return err
 }
 
-func (p *PBM) RSSetPhyFiles(bcpName string, rsName string, f []File) error {
+func (p *PBM) RSSetPhyFiles(bcpName string, rsName string, rs *BackupReplset) error {
 	_, err := p.Conn.Database(DB).Collection(BcpCollection).UpdateOne(
 		p.ctx,
 		bson.D{{"name", bcpName}, {"replsets.name", rsName}},
 		bson.D{
-			{"$set", bson.M{"replsets.$.files": f}},
+			{"$set", bson.M{"replsets.$.files": rs.Files}},
+			{"$set", bson.M{"replsets.$.journal": rs.Journal}},
 		},
 	)
 

--- a/pbm/restore.go
+++ b/pbm/restore.go
@@ -18,6 +18,7 @@ type RestoreMeta struct {
 	Name             string              `bson:"name" json:"name"`
 	OPID             string              `bson:"opid" json:"opid"`
 	Backup           string              `bson:"backup" json:"backup"`
+	BcpChain         []string            `bson:"bcp_chain" json:"bcp_chain"` // for incremental
 	Namespaces       []string            `bson:"nss,omitempty" json:"nss,omitempty"`
 	StartPITR        int64               `bson:"start_pitr" json:"start_pitr"`
 	PITR             int64               `bson:"pitr" json:"pitr"`

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -57,6 +57,7 @@ type PhysRestore struct {
 	nodeInfo *pbm.NodeInfo
 	stg      storage.Storage
 	bcp      *pbm.BackupMeta
+	files    [][]pbm.File
 
 	// path to files on a storage the node will sync its
 	// state with the resto of the cluster
@@ -688,44 +689,47 @@ func (r *PhysRestore) dumpMeta(meta *pbm.RestoreMeta, s pbm.Status, msg string) 
 }
 
 func (r *PhysRestore) copyFiles() error {
-	for _, rs := range r.bcp.Replsets {
-		if rs.Name == r.nodeInfo.SetName {
-			for _, f := range rs.Files {
-				src := filepath.Join(r.bcp.Name, r.nodeInfo.SetName, f.Name+r.bcp.Compression.Suffix())
-				dst := filepath.Join(r.dbpath, f.Name)
+	bbb, _ := json.MarshalIndent(r.files, "", "\t")
+	r.log.Debug("==> FILES\n%s", bbb)
 
-				err := os.MkdirAll(filepath.Dir(dst), os.ModeDir|0o700)
-				if err != nil {
-					return errors.Wrapf(err, "create path %s", filepath.Dir(dst))
-				}
+	for i := len(r.files) - 1; i >= 0; i-- {
+		for _, f := range r.files[i] {
+			src := filepath.Join(r.bcp.Name, r.nodeInfo.SetName, f.Name+r.bcp.Compression.Suffix())
+			if f.Len != 0 {
+				src += fmt.Sprintf(".%d-%d", f.Off, f.Len)
+			}
+			dst := filepath.Join(r.dbpath, f.Name)
 
-				r.log.Info("copy <%s> to <%s>", src, dst)
-				sr, err := r.stg.SourceReader(src)
-				if err != nil {
-					return errors.Wrapf(err, "create source reader for <%s>", src)
-				}
-				defer sr.Close()
+			err := os.MkdirAll(filepath.Dir(dst), os.ModeDir|0o700)
+			if err != nil {
+				return errors.Wrapf(err, "create path %s", filepath.Dir(dst))
+			}
 
-				data, err := compress.Decompress(sr, r.bcp.Compression)
-				if err != nil {
-					return errors.Wrapf(err, "decompress object %s", src)
-				}
-				defer data.Close()
+			r.log.Info("copy <%s> to <%s>", src, dst)
+			sr, err := r.stg.SourceReader(src)
+			if err != nil {
+				return errors.Wrapf(err, "create source reader for <%s>", src)
+			}
+			defer sr.Close()
 
-				fw, err := os.Create(dst)
-				if err != nil {
-					return errors.Wrapf(err, "create destination file <%s>", dst)
-				}
-				defer fw.Close()
-				err = os.Chmod(dst, f.Fmode)
-				if err != nil {
-					return errors.Wrapf(err, "change permissions for file <%s>", dst)
-				}
+			data, err := compress.Decompress(sr, r.bcp.Compression)
+			if err != nil {
+				return errors.Wrapf(err, "decompress object %s", src)
+			}
+			defer data.Close()
 
-				_, err = io.Copy(fw, data)
-				if err != nil {
-					return errors.Wrapf(err, "copy file <%s>", dst)
-				}
+			fw, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, f.Fmode)
+			if err != nil {
+				return errors.Wrapf(err, "create/open destination file <%s>", dst)
+			}
+			defer fw.Close()
+			if f.Off != 0 {
+				_, err := fw.Seek(f.Off, io.SeekStart)
+				return errors.Wrapf(err, "set file offset <%s>|%d", dst, f.Off)
+			}
+			_, err = io.Copy(fw, data)
+			if err != nil {
+				return errors.Wrapf(err, "copy file <%s>", dst)
 			}
 		}
 	}
@@ -1125,6 +1129,54 @@ func (r *PhysRestore) setTmpConf() (err error) {
 	return nil
 }
 
+func (r *PhysRestore) setBcpFiles() (err error) {
+	bcp := r.bcp
+	partj := ""
+
+	rs := getRS(bcp, r.nodeInfo.SetName)
+	data := append([]pbm.File{}, rs.Files...)
+	for _, j := range rs.Journal {
+		data = append(data, j)
+		if j.Len != 0 && j.Len != j.Size {
+			partj = j.Name
+		}
+	}
+	r.files = append(r.files, data)
+
+	for bcp.SrcBackup != "" {
+		r.log.Debug("get src %s", bcp.SrcBackup)
+		bcp, err = r.cn.GetBackupMeta(bcp.SrcBackup)
+		if err != nil {
+			return errors.Wrapf(err, "get source backup")
+		}
+
+		rs = getRS(bcp, r.nodeInfo.SetName)
+		data := append([]pbm.File{}, rs.Files...)
+
+		if partj != "" {
+			for _, j := range rs.Journal {
+				if partj == j.Name {
+					data = append(data, j)
+				}
+				if j.Len == 0 || j.Len == j.Size {
+					partj = ""
+				}
+			}
+		}
+		r.files = append(r.files, data)
+	}
+	return nil
+}
+
+func getRS(bcp *pbm.BackupMeta, rs string) *pbm.BackupReplset {
+	for _, r := range bcp.Replsets {
+		if r.Name == rs {
+			return &r
+		}
+	}
+	return nil
+}
+
 func (r *PhysRestore) prepareBackup(backupName string) (err error) {
 	r.bcp, err = r.cn.GetBackupMeta(backupName)
 	if errors.Is(err, pbm.ErrNotFound) {
@@ -1154,6 +1206,11 @@ func (r *PhysRestore) prepareBackup(backupName string) (err error) {
 
 	if semver.Compare(majmin(r.bcp.MongoVersion), majmin(mgoV.VersionString)) != 0 {
 		return errors.Errorf("backup's Mongo version (%s) is not compatible with Mongo %s", r.bcp.MongoVersion, mgoV.VersionString)
+	}
+
+	err = r.setBcpFiles()
+	if err != nil {
+		return errors.Wrap(err, "get data for restore")
 	}
 
 	s, err := r.cn.ClusterMembers()

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -148,7 +148,7 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 
 func checkBackupFiles(ctx context.Context, bcp *BackupMeta, stg storage.Storage) error {
 	// !!! TODO: Check physical files ?
-	if bcp.Type == PhysicalBackup {
+	if bcp.Type == PhysicalBackup || bcp.Type == IncrementalBackup {
 		return nil
 	}
 


### PR DESCRIPTION
Based on [$backupCursor](https://www.percona.com/blog/2021/06/07/experimental-feature-backupcursorextend-in-percona-server-for-mongodb/) and [WT block incremental backups](https://source.wiredtiger.com/develop/backup.html#backup_incremental-block) [[2](https://github.com/mongodb/mongo/blob/de4669ee3ee4d5952b3aa79c620e38027616a7ef/src/mongo/db/catalog/README.md#file-system-backups)] features

First of all, the user would need to make a full incremental backup (a base). The node will start keeping an incremental backup history. And when a subsequent incremental buck will be requested, the system will be able to calculate and provide the difference in data blocks after the last incr backup. So PBM would store only the diffs for every next incr backup. For the restore, PBM would basically retrieve all the preceding backups chain up to the closest base, do a physical restore of the base backup and then advance forward in time (from the oldest after the base incr backup in the chain) and apply diffs onto restore files.

CLI interface updates:
```
$ pbm backup -type incremental --base // do an incremental base backup 
$ pbm backup -type incremental // do an incremental backup based on the previous one
```

WIP: this PR bring only incremental backups and restores. If a subsequent incremental backup goes to a different node, it will fail. Also need to deal with deletes (deletion of any src will invalidate succeeding backups) and testing etc.

https://jira.percona.com/browse/PBM-999