### PR TITLE
PBM-1001: truncate incremental restore files

### DIFF
--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -348,14 +348,15 @@ func uploadFiles(ctx context.Context, files []pbm.File, subdir, trimPrefix strin
 		default:
 		}
 
-		// skip onchanged files if increment
-		if incr && file.Off == 0 && file.Len == 0 {
+		// skip unchanged files if increment
+		if incr && file.Len == 0 {
 			continue
 		}
 
 		if wfile.Name == file.Name &&
 			wfile.Off+wfile.Len == file.Off {
 			wfile.Len += file.Len
+			wfile.Size = file.Size
 			continue
 		}
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -744,6 +744,12 @@ func (r *PhysRestore) copyFiles() error {
 			if err != nil {
 				return errors.Wrapf(err, "copy file <%s>", dst)
 			}
+			if f.Size != 0 {
+				err = fw.Truncate(f.Size)
+				if err != nil {
+					return errors.Wrapf(err, "truncate file <%s>|%d", dst, f.Size)
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Changes in incremental blocks also reflect changes in file sizes. We should consider a file might shrink down and truncate it during a restore.