### PR TITLE
Fix CheckRestore function in e2e-tests

### DIFF
--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -223,7 +223,7 @@ func (c *Ctl) CheckRestore(bcpName string, waitFor time.Duration) error {
 				case pbm.StatusDone:
 					return nil
 				case pbm.StatusError:
-					errors.Errorf("failed with %s", r.Error)
+					return errors.Errorf("failed with %s", r.Error)
 				}
 			}
 		}


### PR DESCRIPTION
Add missing return statement if restore error has been found. Without a return statement restore is not recognized as a failure until it times out (by default 25 minutes).

Signed-off-by: ziollek <e.prace@gmail.com>