### PR TITLE
PBM-1003 Fix ability to restore with remapping replicaset names

### DIFF
--- a/e2e-tests/cmd/pbm-test/run_remapping.go
+++ b/e2e-tests/cmd/pbm-test/run_remapping.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+func runRemappingTests(t *sharded.RemappingEnvironment) {
+	storage := "/etc/pbm/minio.yaml"
+	if confExt(storage) {
+		t.Donor.ApplyConfig(storage)
+		flush(t.Donor)
+		t.Recipient.ApplyConfig(storage)
+		flush(t.Recipient)
+
+		t.Donor.SetBallastData(1e4)
+
+		runTest("Logical Backup & Restore with remapping Minio",
+			func() { t.BackupAndRestore(pbm.LogicalBackup) })
+
+		flushStore(t.Recipient)
+	}
+}

--- a/e2e-tests/docker/docker-compose-remapping.yaml
+++ b/e2e-tests/docker/docker-compose-remapping.yaml
@@ -1,0 +1,127 @@
+version: "3.4"
+services:
+  tests:
+    build:
+      dockerfile: ./e2e-tests/Dockerfile
+      context: ../..
+      args:
+        - TESTS_BCP_TYPE=logical
+    command: pbm-test
+    environment:
+      - BACKUP_USER=bcp
+      - MONGO_PASS=test1234
+      - TESTS_TYPE=remapping
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./conf:/etc/pbm
+      - ./backups:/opt/backups
+
+  rs101:
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
+    hostname: rs101
+    labels:
+      - "com.percona.pbm.app=mongod"
+    environment:
+      - REPLSET_NAME=rs1
+      - MONGO_USER=dba
+      - BACKUP_USER=bcp
+      - MONGO_PASS=test1234
+      - SINGLE_NODE=true
+    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    volumes:
+      - data-rs101:/data/db
+      - ./scripts/start.sh:/opt/start.sh
+
+  agent-rs101:
+    container_name: "pbmagent_rs101"
+    user: "1001"
+    labels:
+      - "com.percona.pbm.app=agent"
+      - "com.percona.pbm.agent.rs=rs1"
+    environment:
+      - "PBM_MONGODB_URI=mongodb://${BACKUP_USER:-bcp}:${MONGO_PASS:-test1234}@rs101:27017"
+    build:
+      labels:
+        - "com.percona.pbm.app=agent"
+      dockerfile: ./e2e-tests/docker/pbm-agent/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
+    volumes:
+      - ./conf:/etc/pbm
+      - ./backups:/opt/backups
+      - data-rs101:/data/db
+    command: pbm-agent
+    cap_add:
+      - NET_ADMIN
+
+  rs201:
+    build:
+      dockerfile: ./e2e-tests/docker/mongodb-rs/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
+        - MONGODB_IMAGE=${MONGODB_IMAGE:-percona/percona-server-mongodb}
+    hostname: rs201
+    labels:
+      - "com.percona.pbm.app=mongod"
+    environment:
+      - REPLSET_NAME=rs2
+      - MONGO_USER=dba
+      - BACKUP_USER=bcp
+      - MONGO_PASS=test1234
+      - SINGLE_NODE=true
+    command: mongod --replSet rs2 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    volumes:
+      - data-rs201:/data/db
+      - ./scripts/start.sh:/opt/start.sh
+
+  agent-rs201:
+    container_name: "pbmagent_rs201"
+    user: "1001"
+    labels:
+      - "com.percona.pbm.app=agent"
+      - "com.percona.pbm.agent.rs=rs2"
+    environment:
+      - "PBM_MONGODB_URI=mongodb://${BACKUP_USER:-bcp}:${MONGO_PASS:-test1234}@rs201:27017"
+    build:
+      labels:
+        - "com.percona.pbm.app=agent"
+      dockerfile: ./e2e-tests/docker/pbm-agent/Dockerfile
+      context: ../..
+      args:
+        - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
+    volumes:
+      - ./conf:/etc/pbm
+      - ./backups:/opt/backups
+      - data-rs201:/data/db
+    command: pbm-agent
+    cap_add:
+      - NET_ADMIN
+
+  minio:
+    image: minio/minio:RELEASE.2022-08-08T18-34-09Z
+    hostname: minio
+    # ports:
+    #   - "9000:9000"
+    volumes:
+      - backups:/backups
+    environment:
+      - "MINIO_ACCESS_KEY=minio1234"
+      - "MINIO_SECRET_KEY=minio1234"
+    command: server /backups
+  createbucket:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+volumes:
+  backups: null
+  data-rs101: null
+  data-rs201: null

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -4,6 +4,7 @@ BACKUP_USER="bcp"
 MONGO_PASS="test1234"
 BCP_NAME=""
 COMPOSE_PATH="${test_dir}/docker/docker-compose.yaml"
+COMPOSE_REMAPPING_PATH="${test_dir}/docker/docker-compose-remapping.yaml"
 COMPOSE_RS_PATH="${test_dir}/docker/docker-compose-rs.yaml"
 COMPOSE_SINGLE_PATH="${test_dir}/docker/docker-compose-single.yaml"
 PBM_TEST_CLEANUP=${PBM_TEST_CLEANUP:-true}
@@ -16,6 +17,9 @@ run() {
     case $compose in
         $COMPOSE_PATH)
             start_cluster "$mongo_version"
+        ;;
+        $COMPOSE_REMAPPING_PATH)
+            start_replset "$mongo_version" "$COMPOSE_REMAPPING_PATH"
         ;;
         $COMPOSE_RS_PATH)
             start_replset "$mongo_version" "$COMPOSE_RS_PATH"
@@ -34,8 +38,14 @@ run() {
             docker-compose -f $compose logs --no-color --tail=100
             desc 'PBM logs'
             docker-compose -f $compose exec -T agent-rs101 pbm logs -t 0 -s D -x || true
+            if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
+                docker-compose -f $compose exec -T agent-rs201 pbm logs -t 0 -s D -x || true
+            fi
             desc 'PBM status'
             docker-compose -f $compose exec -T agent-rs101 pbm status || true
+            if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
+                docker-compose -f $compose exec -T agent-rs201 pbm status || true
+            fi
         fi
 
         desc 'Destroy cluster'
@@ -173,6 +183,9 @@ start_replset() {
     if [ $compose == $COMPOSE_SINGLE_PATH ]; then
         local nodes="rs101 minio createbucket"
         local agents="agent-rs101"
+    elif [ $compose == $COMPOSE_REMAPPING_PATH ]; then
+        local nodes="rs101 rs201 minio createbucket"
+        local agents="agent-rs101 agent-rs201"
     fi
 
     genMongoKey
@@ -194,6 +207,9 @@ start_replset() {
     docker-compose -f $compose ps
     export COMPOSE_INTERACTIVE_NO_CLI=1
     docker-compose -f $compose exec -T rs101 /opt/start.sh
+    if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
+        docker-compose -f $compose exec -T rs201 /opt/start.sh
+    fi
     sleep 15
 
     docker-compose -f $compose up -d $agents

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -26,7 +26,7 @@ type Ctl struct {
 
 var backupNameRE = regexp.MustCompile(`Backup '([0-9\-\:TZ]+)' to remote store`)
 
-func NewCtl(ctx context.Context, host string) (*Ctl, error) {
+func NewCtl(ctx context.Context, host, pbmContainer string) (*Ctl, error) {
 	cn, err := docker.NewClient(host, "1.39", nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "docker client")
@@ -35,7 +35,7 @@ func NewCtl(ctx context.Context, host string) (*Ctl, error) {
 	return &Ctl{
 		cn:        cn,
 		ctx:       ctx,
-		container: "pbmagent_rs101",
+		container: pbmContainer,
 	}, nil
 }
 
@@ -277,8 +277,9 @@ func (c *Ctl) waitForRestore(rinlist string, waitFor time.Duration) error {
 }
 
 // Restore starts restore and returns the name of op
-func (c *Ctl) Restore(bcpName string) (string, error) {
-	o, err := c.RunCmd("pbm", "restore", bcpName, "-o", "json")
+func (c *Ctl) Restore(bcpName string, options []string) (string, error) {
+	command := append([]string{"pbm", "restore", bcpName, "-o", "json"}, options...)
+	o, err := c.RunCmd(command...)
 	if err != nil {
 		return "", errors.Wrap(err, "run meta")
 	}

--- a/e2e-tests/pkg/tests/sharded/cluster.go
+++ b/e2e-tests/pkg/tests/sharded/cluster.go
@@ -36,6 +36,7 @@ type ClusterConf struct {
 	Mongos          string
 	Shards          map[string]string
 	DockerSocket    string
+	PbmContainer    string
 	ConfigsrvRsName string
 }
 
@@ -53,7 +54,7 @@ func New(cfg ClusterConf) *Cluster {
 		c.shards[name] = mgoConn(ctx, uri)
 	}
 
-	pbmObj, err := pbm.NewCtl(c.ctx, cfg.DockerSocket)
+	pbmObj, err := pbm.NewCtl(c.ctx, cfg.DockerSocket, cfg.PbmContainer)
 	if err != nil {
 		log.Fatalln("connect to mongo:", err)
 	}
@@ -117,8 +118,13 @@ func (c *Cluster) DeleteBallast() {
 }
 
 func (c *Cluster) LogicalRestore(bcpName string) {
+	c.LogicalRestoreWithParams(bcpName, []string{})
+}
+
+func (c *Cluster) LogicalRestoreWithParams(bcpName string, options []string) {
+
 	log.Println("restoring the backup")
-	_, err := c.pbm.Restore(bcpName)
+	_, err := c.pbm.Restore(bcpName, options)
 	if err != nil {
 		log.Fatalln("restoring the backup:", err)
 	}
@@ -134,8 +140,12 @@ func (c *Cluster) LogicalRestore(bcpName string) {
 }
 
 func (c *Cluster) PhysicalRestore(bcpName string) {
+	c.PhysicalRestoreWithParams(bcpName, []string{})
+}
+
+func (c *Cluster) PhysicalRestoreWithParams(bcpName string, options []string) {
 	log.Println("restoring the backup")
-	name, err := c.pbm.Restore(bcpName)
+	name, err := c.pbm.Restore(bcpName, options)
 	if err != nil {
 		log.Fatalln("restoring the backup:", err)
 	}

--- a/e2e-tests/pkg/tests/sharded/test_remapping.go
+++ b/e2e-tests/pkg/tests/sharded/test_remapping.go
@@ -1,0 +1,85 @@
+package sharded
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+type RemappingEnvironment struct {
+	Donor     *Cluster
+	Recipient *Cluster
+	Remapping map[string]string
+}
+
+func (re *RemappingEnvironment) prepareRestoreOptions(typ pbm.BackupType) []string {
+	var remappings []string
+	if typ == pbm.PhysicalBackup || len(re.Remapping) == 0 {
+		return []string{}
+	}
+
+	for to, from := range re.Remapping {
+		remappings = append(remappings, fmt.Sprintf("%s=%s", to, from))
+	}
+	return []string{"--replset-remapping", strings.Join(remappings, ",")}
+}
+
+func (re *RemappingEnvironment) BackupAndRestore(typ pbm.BackupType) {
+	backup := re.Donor.LogicalBackup
+	restore := re.Recipient.LogicalRestoreWithParams
+	if typ == pbm.PhysicalBackup {
+		backup = re.Donor.PhysicalBackup
+		restore = re.Recipient.PhysicalRestoreWithParams
+	}
+
+	checkData := re.DataChecker()
+
+	bcpName := backup()
+	re.Donor.BackupWaitDone(bcpName)
+
+	// to be sure the backup didn't vanish after the resync
+	// i.e. resync finished correctly
+	log.Println("resync backup list")
+	err := re.Recipient.mongopbm.StoreResync()
+	if err != nil {
+		log.Fatalln("Error: resync backup lists:", err)
+	}
+
+	restore(bcpName, re.prepareRestoreOptions(typ))
+	checkData()
+}
+
+func (re *RemappingEnvironment) DataChecker() (check func()) {
+	hashes1 := make(map[string]map[string]string)
+	for name, s := range re.Donor.shards {
+		h, err := s.DBhashes()
+		if err != nil {
+			log.Fatalf("get db hashes %s: %v\n", name, err)
+		}
+		log.Printf("current Donor %s db hash %s\n", name, h["_all_"])
+		hashes1[name] = h
+	}
+
+	return func() {
+		log.Println("Checking restored backup with remapping")
+
+		for name, s := range re.Recipient.shards {
+			if donorName, ok := re.Remapping[name]; ok {
+				h, err := s.DBhashes()
+				if err != nil {
+					log.Fatalf("get db hashes %s: %v\n", name, err)
+				}
+				if hashes1[donorName]["_all_"] != h["_all_"] {
+					log.Fatalf(
+						"%s: hashes don't match. before %s now %s",
+						name, hashes1[donorName]["_all_"], h["_all_"],
+					)
+				}
+			} else {
+				log.Fatalf("%s: cannot find appropriate mapping in: %v", name, re.Remapping)
+			}
+		}
+	}
+}

--- a/e2e-tests/run-all
+++ b/e2e-tests/run-all
@@ -16,6 +16,7 @@ $dir/run-new-cluster || fail "restore-on-new-cluster"
 $dir/run-sharded || fail "sharded-cluster"
 $dir/run-rs || fail "replica-set-cluster"
 $dir/run-single || fail "single-node-replica-set"
+$dir/run-remapping || fail "restore-with-remapping"
 
 export TESTS_BCP_TYPE=physical
 $dir/run-sharded || fail "sharded-cluster"

--- a/e2e-tests/run-remapping
+++ b/e2e-tests/run-remapping
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o xtrace
+
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/functions
+
+MONGO_VERSION=${MONGODB_VERSION:-"4.2"}
+
+desc 'RUN REMAPPING TESTS'
+
+run $COMPOSE_REMAPPING_PATH $MONGO_VERSION

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -647,14 +647,17 @@ func (r *Restore) RunSnapshot(dump string, bcp *pbm.BackupMeta, nss []string) (e
 			return errors.WithMessage(err, "get config")
 		}
 
+		mapRS := pbm.MakeReverseRSMapFunc(r.rsMap)
 		rdr, err = snapshot.DownloadDump(
 			func(ns string) (io.ReadCloser, error) {
 				stg, err := pbm.Storage(cfg, r.log)
 				if err != nil {
 					return nil, errors.WithMessage(err, "get storage")
 				}
-
-				return stg.SourceReader(path.Join(bcp.Name, r.node.RS(), ns))
+				// while importing backup made by RS with another name
+				// that current RS we can't use our r.node.RS() to point files
+				// we have to use mapping passed by --replset-mapping option
+				return stg.SourceReader(path.Join(bcp.Name, mapRS(r.node.RS()), ns))
 			},
 			bcp.Compression,
 			m.Has)


### PR DESCRIPTION
When the logical backup is made by replicaset with a different name than the current one it is now posible to use that backup.

Changes include also refactor enabling the use of "e2e-ecosystem" for remapping tests. As a part of refactoring the following changes have been made:
- the ability to pass additional options to pbm restore command
- the ability to pass the name of the container with pbm agent
- new kind of tests (remapping) with dedicated docker-compose

Signed-off-by: ziollek <e.prace@gmail.com>