### PR TITLE
PBM-1006: fix panic during phys restore S3 retries

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1032,7 +1032,7 @@ func (r *PhysRestore) startMongo(opts ...string) error {
 const hbFrameSec = 60 * 2
 
 func (r *PhysRestore) init(name string, opid pbm.OPID, l *log.Event) (err error) {
-	r.stg, err = r.cn.GetStorage(r.log)
+	r.stg, err = r.cn.GetStorage(l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}


### PR DESCRIPTION
Physical restore wasn't properly initialising the logger for storage. That caused panics when S3 storage tried to log some actions.

https://jira.percona.com/browse/PBM-1006