### PR TITLE
[PBM-1008] A specific collection cannot be restored from PITR if it did not exist in the full backup

### DIFF
--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -994,10 +994,7 @@ func (r *Restore) applyOplog(chunks []pbm.OplogChunk, options *applyOplogOption)
 		endTS = *options.end
 	}
 	r.oplog.SetTimeframe(startTS, endTS)
-	err = r.oplog.SetSelectedNSS(options.nss)
-	if err != nil {
-		return errors.WithMessage(err, "set include nss")
-	}
+	r.oplog.SetSelectedNSS(options.nss)
 
 	var waitTxnErr error
 	if r.nodeInfo.IsSharded() {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -994,7 +994,7 @@ func (r *Restore) applyOplog(chunks []pbm.OplogChunk, options *applyOplogOption)
 		endTS = *options.end
 	}
 	r.oplog.SetTimeframe(startTS, endTS)
-	err = r.oplog.SetIncludeNSS(options.nss)
+	err = r.oplog.SetSelectedNSS(options.nss)
 	if err != nil {
 		return errors.WithMessage(err, "set include nss")
 	}

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -994,7 +994,7 @@ func (r *Restore) applyOplog(chunks []pbm.OplogChunk, options *applyOplogOption)
 		endTS = *options.end
 	}
 	r.oplog.SetTimeframe(startTS, endTS)
-	r.oplog.SetSelectedNSS(options.nss)
+	r.oplog.SetIncludeNS(options.nss)
 
 	var waitTxnErr error
 	if r.nodeInfo.IsSharded() {


### PR DESCRIPTION
create collection commands are skipped because they have `db.$cmd`-like namespace