### PR TITLE
PBM-941: fix `Dockerfile.k8s`

### DIFF
--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -57,7 +57,7 @@ RUN set -ex; \
 
 RUN microdnf install percona-server-mongodb-shell
 
-COPY --from=0 /go/bin/pbm /go/bin/pbm-agent /go/bin/pbm-speed-test /usr/local/bin/
+COPY --from=0 /go/bin/pbm /go/bin/pbm-agent /go/bin/pbm-agent-entrypoint /go/bin/pbm-speed-test /usr/local/bin/
 COPY ./docker/start-agent.sh /start-agent.sh
 
 USER nobody


### PR DESCRIPTION
https://jira.percona.com/browse/PBM-941

This PR adds missing `pbm-agent-entrypoint` binary to the image