### PR TITLE
Fix some more typos

### DIFF
--- a/pbm/archive/archive.go
+++ b/pbm/archive/archive.go
@@ -43,7 +43,7 @@ func DefaultMatchFunc(string) bool { return true }
 func Decompose(r io.Reader, newWriter NewWriter, match MatchFunc) error {
 	meta, err := readPrelude(r)
 	if err != nil {
-		return errors.WithMessage(err, "predule")
+		return errors.WithMessage(err, "prelude")
 	}
 
 	if match == nil {
@@ -89,7 +89,7 @@ func Compose(w io.Writer, match MatchFunc, newReader NewReader) error {
 	meta.Namespaces = nss
 
 	if err := writePrelude(w, meta); err != nil {
-		return errors.WithMessage(err, "predule")
+		return errors.WithMessage(err, "prelude")
 	}
 
 	err = writeAllNamespaces(w, newReader,
@@ -99,15 +99,15 @@ func Compose(w io.Writer, match MatchFunc, newReader NewReader) error {
 }
 
 func readPrelude(r io.Reader) (*archiveMeta, error) {
-	predule := archive.Prelude{}
-	err := predule.Read(r)
+	prelude := archive.Prelude{}
+	err := prelude.Read(r)
 	if err != nil {
 		return nil, errors.WithMessage(err, "read")
 	}
 
-	m := &archiveMeta{Header: predule.Header}
-	m.Namespaces = make([]*Namespace, len(predule.NamespaceMetadatas))
-	for i, n := range predule.NamespaceMetadatas {
+	m := &archiveMeta{Header: prelude.Header}
+	m.Namespaces = make([]*Namespace, len(prelude.NamespaceMetadatas))
+	for i, n := range prelude.NamespaceMetadatas {
 		m.Namespaces[i] = &Namespace{CollectionMetadata: n}
 	}
 
@@ -115,13 +115,13 @@ func readPrelude(r io.Reader) (*archiveMeta, error) {
 }
 
 func writePrelude(w io.Writer, m *archiveMeta) error {
-	predule := archive.Prelude{Header: m.Header}
-	predule.NamespaceMetadatas = make([]*archive.CollectionMetadata, len(m.Namespaces))
+	prelude := archive.Prelude{Header: m.Header}
+	prelude.NamespaceMetadatas = make([]*archive.CollectionMetadata, len(m.Namespaces))
 	for i, n := range m.Namespaces {
-		predule.NamespaceMetadatas[i] = n.CollectionMetadata
+		prelude.NamespaceMetadatas[i] = n.CollectionMetadata
 	}
 
-	err := predule.Write(w)
+	err := prelude.Write(w)
 	return errors.WithMessage(err, "write")
 }
 

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -283,7 +283,7 @@ func New(ctx context.Context, uri, appName string) (*PBM, error) {
 	err = client.Database("admin").Collection("system.version").
 		FindOne(ctx, bson.D{{"_id", "shardIdentity"}}).Decode(&csvr)
 	if err != nil {
-		return nil, errors.Wrap(err, "get config server connetion URI")
+		return nil, errors.Wrap(err, "get config server connection URI")
 	}
 	// no need in this connection anymore, we need a new one with the ConfigServer
 	err = client.Disconnect(ctx)
@@ -293,7 +293,7 @@ func New(ctx context.Context, uri, appName string) (*PBM, error) {
 
 	chost := strings.Split(csvr.URI, "/")
 	if len(chost) < 2 {
-		return nil, errors.Wrapf(err, "define config server connetion URI from %s", csvr.URI)
+		return nil, errors.Wrapf(err, "define config server connection URI from %s", csvr.URI)
 	}
 
 	curi, err := url.Parse(uri)

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -333,7 +333,7 @@ func (s *Slicer) Stream(ctx context.Context, backupSig <-chan *pbm.OPID, compres
 		}
 
 		// in case there is a lock, even a legit one (our own, or backup's one) but it is stale
-		// we should return so the slicer would get thru the lock acquisition again.
+		// we should return so the slicer would get through the lock acquisition again.
 		ts, err := s.pbm.ClusterTime()
 		if err != nil {
 			return errors.Wrap(err, "read cluster time")
@@ -352,7 +352,7 @@ func (s *Slicer) Stream(ctx context.Context, backupSig <-chan *pbm.OPID, compres
 				return errors.Wrap(err, "define last write timestamp")
 			}
 		case pbm.CmdUndefined:
-			return errors.New("undefinded behaviour operation is running")
+			return errors.New("undefined behaviour operation is running")
 		case pbm.CmdBackup:
 			// continue only if we had `backupSig`
 			if !lastSlice || primitive.CompareTimestamp(s.lastTS, sliceTo) == 0 {


### PR DESCRIPTION
Some more typos fixes in user facing messages.
Also one fix for a variable name (`s/predule/prelude/`)