### PR TITLE
PBM-1035: mark incremental base backups in status and list

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -388,6 +388,7 @@ type snapshotStat struct {
 	RestoreTS  int64          `json:"restoreTo"`
 	PBMVersion string         `json:"pbmVersion"`
 	Type       pbm.BackupType `json:"type"`
+	SrcBackup  string         `json:"src"`
 }
 
 type pitrRange struct {

--- a/cli/list.go
+++ b/cli/list.go
@@ -159,6 +159,9 @@ func (bl backupListOut) String() string {
 		if len(b.Namespaces) != 0 {
 			kind += ", selective"
 		}
+		if b.Type == pbm.IncrementalBackup && b.SrcBackup == "" {
+			kind += ", base"
+		}
 
 		s += fmt.Sprintf("  %s <%s> [restore_to_time: %s]\n", b.Name, kind, fmtTS(int64(b.RestoreTS)))
 	}
@@ -240,6 +243,7 @@ func getSnapshotList(cn *pbm.PBM, size int, rsMap map[string]string) (s []snapsh
 			RestoreTS:  int64(b.LastWriteTS.T),
 			PBMVersion: b.PBMVersion,
 			Type:       b.Type,
+			SrcBackup:  b.SrcBackup,
 		})
 	}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -551,6 +551,9 @@ func (s storageStat) String() string {
 		if len(sn.Namespaces) != 0 {
 			kind += ", selective"
 		}
+		if sn.Type == pbm.IncrementalBackup && sn.SrcBackup == "" {
+			kind += ", base"
+		}
 
 		ret += fmt.Sprintf("    %s %s <%s> %s\n",
 			sn.Name, fmtSize(sn.Size), kind, status)
@@ -634,6 +637,7 @@ func getStorageStat(cn *pbm.PBM, rsMap map[string]string) (fmt.Stringer, error) 
 			RestoreTS:  bcp.LastTransitionTS,
 			PBMVersion: bcp.PBMVersion,
 			Type:       bcp.Type,
+			SrcBackup:  bcp.SrcBackup,
 		}
 		if err := bcp.Error(); err != nil {
 			snpsht.Err = err


### PR DESCRIPTION
```
$ pbm status -s backups
Backups:
========
FS  /opt/backups/pbm
  Snapshots:
    2023-02-01T15:57:59Z 294.52MB <incremental> [restore_to_time: 2023-02-01T15:58:01Z]
    2023-02-01T15:57:08Z 46.10MB <incremental> [restore_to_time: 2023-02-01T15:57:10Z]
    2023-02-01T15:53:17Z 525.80MB <incremental, base> [restore_to_time: 2023-02-01T15:53:19Z]
```

```
$ pbm list
Backup snapshots:
  2023-02-01T15:53:17Z <incremental, base> [restore_to_time: 2023-02-01T15:53:19Z]
  2023-02-01T15:57:08Z <incremental> [restore_to_time: 2023-02-01T15:57:10Z]
  2023-02-01T15:57:59Z <incremental> [restore_to_time: 2023-02-01T15:58:01Z]
```