### PR TITLE
PBM-1046: incremental backup: handle phantom changes

### DIFF
--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -361,10 +361,12 @@ func uploadFiles(ctx context.Context, files []pbm.File, subdir, trimPrefix strin
 		default:
 		}
 
-		// skip uploading unchanged files if incremental
-		// but add them to the meta to keep track files to be restored
-		// from prev backups
-		if incr && file.Len == 0 {
+		// Skip uploading unchanged files if incremental
+		// but add them to the meta to keep track of files to be restored
+		// from prev backups. Plus sometimes the cursor can return an offset
+		// beyond the current file size. Such phantom changes shouldn't
+		// be copied. But save meta to have file size.
+		if incr && (file.Len == 0 || file.Off >= file.Size) {
 			file.Off = -1
 			file.Len = -1
 			file.Name = strings.TrimPrefix(file.Name, trimPrefix)


### PR DESCRIPTION
Sometimes the cursor can return files with an offset beyond the current file size. Such phantom changes shouldn't be copied. But save meta to have file size.

```
...
  {
    filename: '/data/db/collection-0-1152525642850732577.wt',
    offset: Long("100663296"),
    length: Long("16777216"),
    fileSize: Long("385024")
  },
  {
    filename: '/data/db/collection-0-1152525642850732577.wt',
    offset: Long("117440512"),
    length: Long("16777216"),
    fileSize: Long("385024")
  },
...
```
