### PR TITLE
K8SPSMDB-857 fix pbm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ MONGO_TEST_VERSION?=4.2
 
 define ENVS
 	GO111MODULE=$(GOMOD) \
-	GOOS=$(GOOS)
+	GOOS=$(GOOS) \
+	GOFLAGS='-buildvcs=false'
 endef
 
 define ENVS_STATIC


### PR DESCRIPTION
We met the error during pbm image build: 
 ```
12:03:36  GO111MODULE=on GOOS=linux go build -ldflags="-X github.com/percona/percona-backup-mongodb/version.gitCommit= -X github.com/percona/percona-backup-mongodb/version.gitBranch= -X github.com/percona/percona-backup-mongodb/version.buildTime=2023-02-07_08:03_UTC -X github.com/percona/percona-backup-mongodb/version.version=" -mod=vendor -tags gssapi -o ./bin/pbm ./cmd/pbm
12:03:37  error obtaining VCS status: exit status 128
12:03:37  	Use -buildvcs=false to disable VCS stamping.
```
As we can see from the message it can be fix by using -buildvcs=false flag. 
**Broken build:**
https://cloud.cd.percona.com/job/pbm-docker-build/497/console
**Successful build:**
https://cloud.cd.percona.com/job/pbm-docker-build/499/