### PR TITLE
PBM-1042: physical restore, ability to set mongod location

### DIFF
--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -312,7 +312,6 @@ func (a *Agent) Restore(r *pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch) {
 	}
 	switch bcp.Type {
 	case pbm.PhysicalBackup, pbm.IncrementalBackup:
-		a.HbPause()
 		err = a.restorePhysical(r, opid, ep, l)
 	case pbm.LogicalBackup:
 		fallthrough
@@ -431,7 +430,7 @@ func (a *Agent) restorePhysical(r *pbm.RestoreCmd, opid pbm.OPID, ep pbm.Epoch, 
 	}
 
 	l.Info("restore started")
-	err = rstr.Snapshot(r, opid, l, a.closeCMD)
+	err = rstr.Snapshot(r, opid, l, a.closeCMD, a.HbPause)
 	l.Info("restore finished %v", err)
 	if err != nil {
 		if errors.Is(err, restore.ErrNoDataForShard) {

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -135,6 +135,10 @@ type RestoreConf struct {
 	// to download files from the storage.
 	MaxDownloadBufferMb int `bson:"maxDownloadBufferMb" json:"maxDownloadBufferMb,omitempty" yaml:"maxDownloadBufferMb,omitempty"`
 	DownloadChunkMb     int `bson:"downloadChunkMb" json:"downloadChunkMb,omitempty" yaml:"downloadChunkMb,omitempty"`
+
+	// MongodLocation sets the location of mongod used for internal runs during
+	// physical restore. Will try $PATH/mongod if not set.
+	MongodLocation string `bson:"mongodLocation" json:"mongodLocation,omitempty" yaml:"mongodLocation,omitempty"`
 }
 
 type BackupConf struct {

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -138,7 +138,8 @@ type RestoreConf struct {
 
 	// MongodLocation sets the location of mongod used for internal runs during
 	// physical restore. Will try $PATH/mongod if not set.
-	MongodLocation string `bson:"mongodLocation" json:"mongodLocation,omitempty" yaml:"mongodLocation,omitempty"`
+	MongodLocation    string            `bson:"mongodLocation" json:"mongodLocation,omitempty" yaml:"mongodLocation,omitempty"`
+	MongodLocationMap map[string]string `bson:"mongodLocationMap" json:"mongodLocationMap,omitempty" yaml:"mongodLocationMap,omitempty"`
 }
 
 type BackupConf struct {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1095,6 +1095,9 @@ func (r *PhysRestore) init(name string, opid pbm.OPID, l *log.Event) (err error)
 	if r.confOpts.MongodLocation != "" {
 		r.mongod = r.confOpts.MongodLocation
 	}
+	if m, ok := r.confOpts.MongodLocationMap[r.rsConf.ID+"/"+r.nodeInfo.Me]; ok {
+		r.mongod = m
+	}
 
 	r.log = l
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1095,7 +1095,7 @@ func (r *PhysRestore) init(name string, opid pbm.OPID, l *log.Event) (err error)
 	if r.confOpts.MongodLocation != "" {
 		r.mongod = r.confOpts.MongodLocation
 	}
-	if m, ok := r.confOpts.MongodLocationMap[r.rsConf.ID+"/"+r.nodeInfo.Me]; ok {
+	if m, ok := r.confOpts.MongodLocationMap[r.nodeInfo.Me]; ok {
 		r.mongod = m
 	}
 

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -240,7 +240,7 @@ func (p *PBM) moveCollection(coll, as string) error {
 func GetPhysRestoreMeta(restore string, stg storage.Storage, l *log.Event) (rmeta *RestoreMeta, err error) {
 	mjson := filepath.Join(PhysRestoresDir, restore) + ".json"
 	_, err = stg.FileStat(mjson)
-	if err != nil && err != storage.ErrNotExist {
+	if err != nil && !errors.Is(err, storage.ErrNotExist) {
 		return nil, errors.Wrapf(err, "get file %s", mjson)
 	}
 	if err == nil {


### PR DESCRIPTION
For physical restores' internal restarts, PBM uses mongod from $PATH by default. This change allows setting custom mongod binary.

Plus added a check if mongod is available and if its version matches the version from the backup before any critical changes.

Added to the config:
```
restore:
    mongodLocation: /path/to/mongod
    mongodLocationMap:
       "node01:27017": /path/to/mongod
       "node03:27017": /another/path/to/mongod
```
If no `mongodLocation` is set, PBM will try `$PATH/mongod`. `mongodLocationMap ` redefines `mongodLocation` (and the defaults) for the particular nodes