### PR TITLE
PBM-1047: fix physical restore to new sharded cluster

### DIFF
--- a/pbm/node.go
+++ b/pbm/node.go
@@ -367,6 +367,31 @@ func (n *Node) GetRSconf() (*RSConfig, error) {
 	return GetReplSetConfig(n.ctx, n.cn)
 }
 
+func (n *Node) GetShardsConfig() (map[string]string, error) {
+	cur, err := n.cn.Database("config").Collection("shards").Find(n.ctx, bson.M{})
+	if err != nil {
+		return nil, errors.Wrap(err, "query mongo")
+	}
+
+	defer cur.Close(n.ctx)
+
+	shards := make(map[string]string)
+	for cur.Next(n.ctx) {
+		s := Shard{}
+		err := cur.Decode(&s)
+		if err != nil {
+			return nil, errors.Wrap(err, "message decode")
+		}
+		shards[s.ID] = s.Host
+	}
+
+	return shards, nil
+}
+
+func (n *Node) ConfSvrConn() (string, error) {
+	return ConfSvrConn(n.ctx, n.cn)
+}
+
 func (n *Node) Shutdown() error {
 	err := n.cn.Database("admin").RunCommand(n.ctx, bson.D{{"shutdown", 1}}).Err()
 	if err == nil || strings.Contains(err.Error(), "socket was unexpectedly closed") {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -54,7 +54,9 @@ type PhysRestore struct {
 	// an ephemeral port to restart mongod on during the restore
 	tmpPort int
 	tmpConf *os.File
-	rsConf  *pbm.RSConfig // original replset config
+	rsConf  *pbm.RSConfig     // original replset config
+	shards  map[string]string // original shards list on config server
+	cfgConn string            // shardIdentity configsvrConnectionString
 	startTS int64
 	secOpts *pbm.MongodOptsSec
 
@@ -109,6 +111,20 @@ func NewPhysical(cn *pbm.PBM, node *pbm.Node, inf *pbm.NodeInfo) (*PhysRestore, 
 		return nil, errors.Wrap(err, "get replset config")
 	}
 
+	var shards map[string]string
+	var csvr string
+	if inf.IsConfigSrv() {
+		shards, err = node.GetShardsConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, "get shards list")
+		}
+	} else if inf.IsSharded() {
+		csvr, err = node.ConfSvrConn()
+		if err != nil {
+			return nil, errors.Wrap(err, "get configsvrConnectionString")
+		}
+	}
+
 	if inf.SetName == "" {
 		return nil, errors.New("undefined replica set")
 	}
@@ -123,6 +139,8 @@ func NewPhysical(cn *pbm.PBM, node *pbm.Node, inf *pbm.NodeInfo) (*PhysRestore, 
 		node:     node,
 		dbpath:   p,
 		rsConf:   rcf,
+		shards:   shards,
+		cfgConn:  csvr,
 		nodeInfo: inf,
 		tmpPort:  tmpPort,
 		secOpts:  opts.Security,
@@ -903,6 +921,30 @@ func (r *PhysRestore) resetRS() error {
 		err = c.Database("config").Collection("lockpings").Drop(ctx)
 		if err != nil {
 			return errors.Wrap(err, "drop config.lockpings")
+		}
+		for id, host := range r.shards {
+			_, err = c.Database("config").Collection("shards").UpdateOne(
+				ctx,
+				bson.D{{"_id", id}},
+				bson.D{
+					{"$set", bson.M{"host": host}},
+				},
+			)
+
+			if err != nil {
+				return errors.Wrapf(err, "update config.shards for %s %s", id, host)
+			}
+		}
+	} else {
+		_, err = c.Database("admin").Collection("system.version").UpdateOne(
+			ctx,
+			bson.D{{"_id", "shardIdentity"}},
+			bson.D{
+				{"$set", bson.M{"configsvrConnectionString": r.cfgConn}},
+			},
+		)
+		if err != nil {
+			return errors.Wrap(err, "update shardIdentity in admin.system.version")
 		}
 	}
 


### PR DESCRIPTION
A `shardIdentity` document in `admin.system.version` collection on shards contains the config server connection string.
A `config.shards` on the config server contains information about shards.
This info should be updated during the restore with data from the target cluster. Otherwise, shards won't start after the restore if the target is a cluster with new (compared to the backup) IPs/hostnames