### PR TITLE
[PBM-850] pbm cleanup command

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -115,8 +115,8 @@ func (a *Agent) Start() error {
 				a.Delete(cmd.Delete, cmd.OPID, ep)
 			case pbm.CmdDeletePITR:
 				a.DeletePITR(cmd.DeletePITR, cmd.OPID, ep)
-			case pbm.CmdDeleteAll:
-				a.DeleteAll(cmd.DeleteAll, cmd.OPID, ep)
+			case pbm.CmdCleanup:
+				a.Cleanup(cmd.Cleanup, cmd.OPID, ep)
 			}
 		case err, ok := <-cerr:
 			if !ok {
@@ -274,15 +274,15 @@ func (a *Agent) DeletePITR(d *pbm.DeletePITRCmd, opid pbm.OPID, ep pbm.Epoch) {
 	l.Info("done")
 }
 
-// DeleteAll deletes backups and PITR chunks from the store and cleans up its metadata
-func (a *Agent) DeleteAll(d *pbm.DeleteAllCmd, opid pbm.OPID, ep pbm.Epoch) {
+// Cleanup deletes backups and PITR chunks from the store and cleans up its metadata
+func (a *Agent) Cleanup(d *pbm.CleanupCmd, opid pbm.OPID, ep pbm.Epoch) {
 	if d == nil {
-		l := a.log.NewEvent(string(pbm.CmdDeleteAll), "", opid.String(), ep.TS())
+		l := a.log.NewEvent(string(pbm.CmdCleanup), "", opid.String(), ep.TS())
 		l.Error("missed command")
 		return
 	}
 
-	l := a.pbm.Logger().NewEvent(string(pbm.CmdDeleteAll), "", opid.String(), ep.TS())
+	l := a.pbm.Logger().NewEvent(string(pbm.CmdCleanup), "", opid.String(), ep.TS())
 
 	nodeInfo, err := a.node.GetInfo()
 	if err != nil {
@@ -298,7 +298,7 @@ func (a *Agent) DeleteAll(d *pbm.DeleteAllCmd, opid pbm.OPID, ep pbm.Epoch) {
 	lock := a.pbm.NewLockCol(pbm.LockHeader{
 		Replset: a.node.RS(),
 		Node:    a.node.Name(),
-		Type:    pbm.CmdDeleteAll,
+		Type:    pbm.CmdCleanup,
 		OPID:    opid.String(),
 		Epoch:   &epts,
 	}, pbm.LockOpCollection)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -278,13 +278,12 @@ func (a *Agent) DeletePITR(d *pbm.DeletePITRCmd, opid pbm.OPID, ep pbm.Epoch) {
 
 // Cleanup deletes backups and PITR chunks from the store and cleans up its metadata
 func (a *Agent) Cleanup(d *pbm.CleanupCmd, opid pbm.OPID, ep pbm.Epoch) {
+	l := a.log.NewEvent(string(pbm.CmdCleanup), "", opid.String(), ep.TS())
+
 	if d == nil {
-		l := a.log.NewEvent(string(pbm.CmdCleanup), "", opid.String(), ep.TS())
 		l.Error("missed command")
 		return
 	}
-
-	l := a.pbm.Logger().NewEvent(string(pbm.CmdCleanup), "", opid.String(), ep.TS())
 
 	nodeInfo, err := a.node.GetInfo()
 	if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -323,7 +323,7 @@ func (a *Agent) Cleanup(d *pbm.CleanupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		l.Error("get storage: " + err.Error())
 	}
 
-	backups, err := backup.ListBackupsBefore(a.pbm.Context(), a.pbm.Conn, d.OlderThan)
+	backups, err := backup.ListSafeToDeleteBackups(a.pbm.Context(), a.pbm.Conn, d.OlderThan)
 	if err != nil {
 		l.Error("failed to list backups: ", err.Error())
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -138,12 +138,12 @@ func Main() {
 	deletePitrCmd.Flag("all", "Delete all chunks").Short('a').BoolVar(&deletePitr.all)
 	deletePitrCmd.Flag("force", "Force. Don't ask confirmation").Short('f').BoolVar(&deletePitr.force)
 
-	deleteAllCmd := pbmCmd.Command("delete-all", "Delete Backups and PITR chunks")
-	deleteAllOpts := deleteAllOptions{}
-	deleteAllCmd.Flag("older-than", fmt.Sprintf("Delete older than date/time in format %s or %s", datetimeFormat, dateFormat)).StringVar(&deleteAllOpts.olderThan)
-	deleteAllCmd.Flag("yes", "Don't ask confirmation").Short('y').BoolVar(&deleteAllOpts.yes)
-	deleteAllCmd.Flag("wait", "Wait for deletion done").Short('w').BoolVar(&deleteAllOpts.wait)
-	deleteAllCmd.Flag("wtimeout", "Wait timeout in seconds").Default("60").Uint32Var(&deleteAllOpts.wtimeout)
+	cleanupCmd := pbmCmd.Command("cleanup", "Delete Backups and PITR chunks")
+	cleanupOpts := cleanupOptions{}
+	cleanupCmd.Flag("older-than", fmt.Sprintf("Delete older than date/time in format %s or %s", datetimeFormat, dateFormat)).StringVar(&cleanupOpts.olderThan)
+	cleanupCmd.Flag("yes", "Don't ask confirmation").Short('y').BoolVar(&cleanupOpts.yes)
+	cleanupCmd.Flag("wait", "Wait for deletion done").Short('w').BoolVar(&cleanupOpts.wait)
+	cleanupCmd.Flag("wtimeout", "Wait timeout in seconds").Default("60").Uint32Var(&cleanupOpts.wtimeout)
 
 	logsCmd := pbmCmd.Command("logs", "PBM logs")
 	logs := logsOpts{}
@@ -228,8 +228,8 @@ func Main() {
 		out, err = deleteBackup(pbmClient, &deleteBcp, pbmOutF)
 	case deletePitrCmd.FullCommand():
 		out, err = deletePITR(pbmClient, &deletePitr, pbmOutF)
-	case deleteAllCmd.FullCommand():
-		out, err = deleteAll(pbmClient, &deleteAllOpts, pbmOutF)
+	case cleanupCmd.FullCommand():
+		out, err = retentionCleanup(pbmClient, &cleanupOpts, pbmOutF)
 	case logsCmd.FullCommand():
 		out, err = runLogs(pbmClient, &logs)
 	case statusCmd.FullCommand():

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -143,7 +143,6 @@ func Main() {
 	cleanupCmd.Flag("older-than", fmt.Sprintf("Delete older than date/time in format %s or %s", datetimeFormat, dateFormat)).StringVar(&cleanupOpts.olderThan)
 	cleanupCmd.Flag("yes", "Don't ask confirmation").Short('y').BoolVar(&cleanupOpts.yes)
 	cleanupCmd.Flag("wait", "Wait for deletion done").Short('w').BoolVar(&cleanupOpts.wait)
-	cleanupCmd.Flag("wtimeout", "Wait timeout in seconds").Default("60").Uint32Var(&cleanupOpts.wtimeout)
 
 	logsCmd := pbmCmd.Command("logs", "PBM logs")
 	logs := logsOpts{}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -453,7 +453,7 @@ func cancelBcp(cn *pbm.PBM) (fmt.Stringer, error) {
 	return outMsg{"Backup cancellation has started"}, nil
 }
 
-var errInvalidDateTimeFormat = errors.New("invalid format")
+var errInvalidFormat = errors.New("invalid format")
 
 func parseDateT(v string) (time.Time, error) {
 	switch len(v) {
@@ -463,7 +463,7 @@ func parseDateT(v string) (time.Time, error) {
 		return time.Parse(dateFormat, v)
 	}
 
-	return time.Time{}, errInvalidDateTimeFormat
+	return time.Time{}, errInvalidFormat
 }
 
 func findLock(cn *pbm.PBM, fn func(*pbm.LockHeader) ([]pbm.LockData, error)) (*pbm.LockData, error) {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -287,6 +287,8 @@ func printCleanupInfo(backups []pbm.BackupMeta, chunks []pbm.OplogChunk) {
 			t := bcp.Type
 			if len(bcp.Namespaces) != 0 {
 				t += ", selective"
+			} else if bcp.Type == pbm.IncrementalBackup && bcp.SrcBackup == "" {
+				t += ", base"
 			}
 
 			fmt.Printf(" - %s <%s> [restore_time: %s]\n",
@@ -325,8 +327,7 @@ func printCleanupInfo(backups []pbm.BackupMeta, chunks []pbm.OplogChunk) {
 		fmt.Printf(" %s:\n", rs)
 
 		for _, r := range ops {
-			fmt.Printf(" - %d,%d - %d,%d\n",
-				r.Start.T, r.Start.I, r.End.T, r.End.I)
+			fmt.Printf(" - %s - %s\n", fmtTS(int64(r.Start.T)), fmtTS(int64(r.End.T)))
 		}
 	}
 }

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -174,7 +174,6 @@ type cleanupOptions struct {
 	olderThan string
 	yes       bool
 	wait      bool
-	wtimeout  uint32
 }
 
 func retentionCleanup(pbmClient *pbm.PBM, d *cleanupOptions, _ outFormat) (fmt.Stringer, error) {
@@ -217,11 +216,7 @@ func retentionCleanup(pbmClient *pbm.PBM, d *cleanupOptions, _ outFormat) (fmt.S
 	}
 
 	fmt.Print("Waiting")
-	wtimeout := time.Duration(d.wtimeout)
-	if wtimeout == 0 {
-		wtimeout = 60
-	}
-	err = waitOp(pbmClient, &pbm.LockHeader{Type: pbm.CmdCleanup}, wtimeout*time.Second)
+	err = waitOp(pbmClient, &pbm.LockHeader{Type: pbm.CmdCleanup}, 10*time.Minute)
 	fmt.Println()
 	if err != nil {
 		if errors.Is(err, errTout) {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -12,7 +12,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
@@ -398,8 +397,7 @@ func findBackupSince(ctx context.Context, m *mongo.Client, ts primitive.Timestam
 	if fullOnly {
 		filter = append(filter, bson.E{"nss", nil})
 	}
-	opts := options.FindOne() //.SetProjection(bson.D{{"last_write_ts", 1}})
-	cur := m.Database(pbm.DB).Collection(pbm.BcpCollection).FindOne(ctx, filter, opts)
+	cur := m.Database(pbm.DB).Collection(pbm.BcpCollection).FindOne(ctx, filter)
 	if err := cur.Err(); err != nil {
 		return nil, errors.WithMessage(err, "query")
 	}

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -339,7 +339,7 @@ func askCleanupConfirmation(ctx context.Context, m *mongo.Client, ts primitive.T
 		return errors.New("no tty")
 	}
 
-	backups, err := backup.ListBackupsBefore(ctx, m, ts)
+	backups, err := backup.ListSafeToDeleteBackups(ctx, m, ts)
 	if err != nil {
 		return errors.WithMessage(err, "list backups")
 	}

--- a/pbm/backup/list.go
+++ b/pbm/backup/list.go
@@ -13,8 +13,8 @@ import (
 
 // ListBackupsBefore returns list of backups where restore cluster time is less than ts
 func ListBackupsBefore(ctx context.Context, m *mongo.Client, ts primitive.Timestamp) ([]pbm.BackupMeta, error) {
-	filter := bson.D{{"last_write_ts", bson.M{"$lt": ts}}}
-	cur, err := m.Database(pbm.DB).Collection(pbm.BcpCollection).Find(ctx, filter)
+	cur, err := m.Database(pbm.DB).Collection(pbm.BcpCollection).
+		Find(ctx, bson.D{{"last_write_ts", bson.M{"$lt": ts}}})
 	if err != nil {
 		return nil, errors.WithMessage(err, "query")
 	}
@@ -22,4 +22,61 @@ func ListBackupsBefore(ctx context.Context, m *mongo.Client, ts primitive.Timest
 	rv := []pbm.BackupMeta{}
 	err = cur.All(ctx, &rv)
 	return rv, errors.WithMessage(err, "cursor: all")
+}
+
+// ListSafeToDeleteBackups returns backups not required to restore to the ts.
+// No more than requested backups will be deleted.
+// It excludes the last incremental backups/chain if there is an incremental after the ts.
+func ListSafeToDeleteBackups(ctx context.Context, m *mongo.Client, ts primitive.Timestamp) ([]pbm.BackupMeta, error) {
+	backups, err := ListBackupsBefore(ctx, m, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = excludeLastIncrementalBase(ctx, m, backups) // exclude in-place
+	return backups, err
+}
+
+func excludeLastIncrementalBase(ctx context.Context, m *mongo.Client, bcps []pbm.BackupMeta) error {
+	// lookup for the last incremental
+	i := len(bcps) - 1
+	for ; i >= 0; i-- {
+		if bcps[i].Type == pbm.IncrementalBackup {
+			break
+		}
+	}
+	if i < 0 {
+		// not found
+		return nil
+	}
+
+	// check if there is an increment based on the backup
+	res := m.Database(pbm.DB).Collection(pbm.BcpCollection).
+		FindOne(ctx, bson.D{{"src_backup", bcps[i].Name}})
+	if err := res.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			// the backup is the last increment in the chain. safe to delete
+			return nil
+		}
+		return errors.WithMessage(err, "query")
+	}
+
+	// exclude only the last incremental chain
+	for base := bcps[i].Name; i >= 0; i-- {
+		if bcps[i].Name != base {
+			continue
+		}
+		base = bcps[i].SrcBackup
+
+		// exclude the backup from slice by index
+		copy(bcps[i:], bcps[i+1:])
+		bcps = bcps[:len(bcps)-1]
+
+		if base == "" {
+			// the root/base of the chain
+			break
+		}
+	}
+
+	return nil
 }

--- a/pbm/backup/list.go
+++ b/pbm/backup/list.go
@@ -1,0 +1,25 @@
+package backup
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+// ListBackupsBefore returns list of backups where restore cluster time is less than ts
+func ListBackupsBefore(ctx context.Context, m *mongo.Client, ts primitive.Timestamp) ([]pbm.BackupMeta, error) {
+	filter := bson.D{{"last_write_ts", bson.M{"$lt": ts}}}
+	cur, err := m.Database(pbm.DB).Collection(pbm.BcpCollection).Find(ctx, filter)
+	if err != nil {
+		return nil, errors.WithMessage(err, "query")
+	}
+
+	rv := []pbm.BackupMeta{}
+	err = cur.All(ctx, &rv)
+	return rv, errors.WithMessage(err, "cursor: all")
+}

--- a/pbm/oplog/oplog.go
+++ b/pbm/oplog/oplog.go
@@ -1,0 +1,25 @@
+package oplog
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+)
+
+// ListChunksBefore returns oplog chunks
+func ListChunksBefore(ctx context.Context, m *mongo.Client, ts primitive.Timestamp) ([]pbm.OplogChunk, error) {
+	filter := bson.D{{"end_ts", bson.M{"$lt": ts}}}
+	cur, err := m.Database(pbm.DB).Collection(pbm.PITRChunksCollection).Find(ctx, filter)
+	if err != nil {
+		return nil, errors.WithMessage(err, "query")
+	}
+
+	rv := []pbm.OplogChunk{}
+	err = cur.All(ctx, &rv)
+	return rv, errors.WithMessage(err, "cursor: all")
+}

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -76,6 +76,7 @@ const (
 	CmdPITRestore   Command = "pitrestore"
 	CmdDeleteBackup Command = "delete"
 	CmdDeletePITR   Command = "deletePitr"
+	CmdDeleteAll    Command = "deleteAll"
 )
 
 func (c Command) String() string {
@@ -98,6 +99,8 @@ func (c Command) String() string {
 		return "Delete"
 	case CmdDeletePITR:
 		return "Delete PITR chunks"
+	case CmdDeleteAll:
+		return "Delete backups and PITR chunks"
 	default:
 		return "Undefined"
 	}
@@ -113,6 +116,7 @@ type Cmd struct {
 	PITRestore *PITRestoreCmd   `bson:"pitrestore,omitempty"`
 	Delete     *DeleteBackupCmd `bson:"delete,omitempty"`
 	DeletePITR *DeletePITRCmd   `bson:"deletePitr,omitempty"`
+	DeleteAll  *DeleteAllCmd    `bson:"deleteAll,omitempty"`
 	TS         int64            `bson:"ts"`
 	OPID       OPID             `bson:"-"`
 }
@@ -223,6 +227,10 @@ type DeleteBackupCmd struct {
 
 type DeletePITRCmd struct {
 	OlderThan int64 `bson:"olderthan"`
+}
+
+type DeleteAllCmd struct {
+	OlderThan primitive.Timestamp `bson:"olderThan"`
 }
 
 func (d DeleteBackupCmd) String() string {

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -76,7 +76,7 @@ const (
 	CmdPITRestore   Command = "pitrestore"
 	CmdDeleteBackup Command = "delete"
 	CmdDeletePITR   Command = "deletePitr"
-	CmdDeleteAll    Command = "deleteAll"
+	CmdCleanup      Command = "cleanup"
 )
 
 func (c Command) String() string {
@@ -99,8 +99,8 @@ func (c Command) String() string {
 		return "Delete"
 	case CmdDeletePITR:
 		return "Delete PITR chunks"
-	case CmdDeleteAll:
-		return "Delete backups and PITR chunks"
+	case CmdCleanup:
+		return "Cleanup backups and PITR chunks"
 	default:
 		return "Undefined"
 	}
@@ -116,7 +116,7 @@ type Cmd struct {
 	PITRestore *PITRestoreCmd   `bson:"pitrestore,omitempty"`
 	Delete     *DeleteBackupCmd `bson:"delete,omitempty"`
 	DeletePITR *DeletePITRCmd   `bson:"deletePitr,omitempty"`
-	DeleteAll  *DeleteAllCmd    `bson:"deleteAll,omitempty"`
+	Cleanup    *CleanupCmd      `bson:"cleanup,omitempty"`
 	TS         int64            `bson:"ts"`
 	OPID       OPID             `bson:"-"`
 }
@@ -229,7 +229,7 @@ type DeletePITRCmd struct {
 	OlderThan int64 `bson:"olderthan"`
 }
 
-type DeleteAllCmd struct {
+type CleanupCmd struct {
 	OlderThan primitive.Timestamp `bson:"olderThan"`
 }
 


### PR DESCRIPTION
pbm cleanup --older-than="$UTC_OR_DURATION" command deletes backups and oplog with restore time less than the UTC_OR_DURATION value.

the UTC_OR_DURATION value can be one of the following formats:
- yyyy-mm-dd            (`2018-07-23`)
- yyyy-mm-ddThh:mm:ss   (`2018-07-23T13:25:01`)
- XXd                   (`30d` or `90d` or `180d`) [only days is supported]

It prints list of backups and oplog ranges and asks for confirmation. (note: oplog ranges are grouped by replset/shard name)
A user can confirm in advance with `--yes/-y` flag, so the command will run the cleanup immediately without printing the backups/oplog list.

The cleanup is done by an agent. CLI only prints the list and asks for confirmation. However, CLI can wait for the agent result.
The `--wait/-w` flag can be used to waiting the operation complete.
The `--wtimeout` can adjust wait timeout which is 60 seconds by default.
After timeout the operation is still processing (not canceled)

It can leave some backups and oplog older than UTC_OR_DURATION but will not delete anything "$gte" UTC_OR_DURATION.

Algorithm:
1. in case PITR is enabled and it is not oplog only [`pitr.enabled=true && pitr.oplogOnly=false`]:
if there is no a full backup (base snapshot) with restore time greater than or equal UTC_OR_DURATION value, the operation is not allowed (the command fails)

2. the UTC_OR_DURATION time is adjusted to the previous full logic backup restore time
if there is no full logical backup before UTC_OR_DURATION, the UTC_OR_DURATION is not adjusted

3. after the adjustment, delete all backups/oplog older than restore timeout

**special case for incremental**: if there is a base incremental backup with its further increment(s) after UTC_OR_DURATION, the whole incremental backup chain is not deleted.


NOTE about UTC_OR_DURATION:
if it is duration, the UTC time is calculated by removing the duration from now().
the UTC is converted to cluster timestamp [`Timestamp({ t: unix(UTC), i: 0 })`].
the cluster timestamp later is compared with backup's `last_write_ts` and chunks' `end_ts` strictly (with `t` and `i` values)
