### PR TITLE
PBM-979: fix phys restore with arbiter and non-voting nodes

### DIFF
--- a/pbm/bsontypes.go
+++ b/pbm/bsontypes.go
@@ -310,4 +310,5 @@ type RSMember struct {
 	Tags               map[string]string `bson:"tags,omitempty" json:"tags"`
 	SecondaryDelayOld  int64             `bson:"slaveDelay,omitempty"`
 	SecondaryDelaySecs int64             `bson:"secondaryDelaySecs,omitempty"`
+	Votes              int               `bson:"votes" json:"votes"`
 }

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1154,7 +1154,9 @@ func (r *PhysRestore) init(name string, opid pbm.OPID, l *log.Event) (err error)
 	r.syncPathCluster = fmt.Sprintf("%s/%s/cluster", pbm.PhysRestoresDir, r.name)
 	r.syncPathPeers = make(map[string]struct{})
 	for _, m := range r.rsConf.Members {
-		r.syncPathPeers[fmt.Sprintf("%s/%s/rs.%s/node.%s", pbm.PhysRestoresDir, r.name, r.rsConf.ID, m.Host)] = struct{}{}
+		if !m.ArbiterOnly {
+			r.syncPathPeers[fmt.Sprintf("%s/%s/rs.%s/node.%s", pbm.PhysRestoresDir, r.name, r.rsConf.ID, m.Host)] = struct{}{}
+		}
 	}
 
 	err = r.hb()


### PR DESCRIPTION
Arbiters should be ignored.
And node votes should be restored during reconfig.