### PR TITLE
PBM-778: add log buffer for phys restore

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -49,6 +49,12 @@ func (a *Agent) InitLogger(cn *pbm.PBM) {
 	a.log = a.pbm.Logger()
 }
 
+func (a *Agent) Close() {
+	if a.log != nil {
+		a.log.Close()
+	}
+}
+
 func (a *Agent) CanStart() error {
 	info, err := a.node.GetInfo()
 	if err != nil {

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -73,6 +73,7 @@ func runAgent(mongoURI string, dumpConns int) error {
 	}
 
 	agnt := agent.New(pbmClient)
+	defer agnt.Close()
 	err = agnt.AddNode(ctx, mongoURI, dumpConns)
 	if err != nil {
 		return errors.Wrap(err, "connect to the node")

--- a/e2e-tests/docker/docker-compose-rs.yaml
+++ b/e2e-tests/docker/docker-compose-rs.yaml
@@ -18,14 +18,9 @@ services:
   agent-cli:
     container_name: "pbmagent_cli"
     user: "1001"
-    labels:
-      - "com.percona.pbm.app=agent"
-      - "com.percona.pbm.agent.rs=cli"
     environment:
       - "PBM_MONGODB_URI=mongodb://${BACKUP_USER:-bcp}:${MONGO_PASS:-test1234}@rs101:27017"
     build:
-      labels:
-        - "com.percona.pbm.app=agent"
       dockerfile: ./e2e-tests/docker/pbm-agent/Dockerfile
       context: ../..
       args:

--- a/e2e-tests/docker/docker-compose.yaml
+++ b/e2e-tests/docker/docker-compose.yaml
@@ -20,14 +20,9 @@ services:
   agent-cli:
     container_name: "pbmagent_cli"
     user: "1001"
-    labels:
-      - "com.percona.pbm.app=agent"
-      - "com.percona.pbm.agent.rs=cli"
     environment:
       - "PBM_MONGODB_URI=mongodb://${BACKUP_USER:-bcp}:${MONGO_PASS:-test1234}@rs101:27017"
     build:
-      labels:
-        - "com.percona.pbm.app=agent"
       dockerfile: ./e2e-tests/docker/pbm-agent/Dockerfile
       context: ../..
       args:

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -139,6 +139,10 @@ func (l *Logger) SefBuffer(b Buffer) {
 
 func (l *Logger) Close() {
 	if l.bufSet.Load() == 1 && l.buf != nil {
+		// don't write buffer anymore. Flush() uses storage.Save() wich may
+		// have logging. And writing to the buffer during Flush() will cause
+		// deadlock.
+		l.bufSet.Store(0)
 		err := l.buf.Flush()
 		if err != nil {
 			log.Printf("flush log buffer on Close: %v", err)

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -24,7 +24,15 @@ type Logger struct {
 	rs   string
 	node string
 
+	buf    Buffer
+	bufSet atomic.Uint32
+
 	pauseMgo int32
+}
+
+type Buffer interface {
+	io.Writer
+	Flush() error
 }
 
 type Entry struct {
@@ -124,12 +132,30 @@ func New(cn *mongo.Collection, rs, node string) *Logger {
 	}
 }
 
+func (l *Logger) SefBuffer(b Buffer) {
+	l.buf = b
+	l.bufSet.Store(1)
+}
+
+func (l *Logger) Close() {
+	if l.bufSet.Load() == 1 && l.buf != nil {
+		err := l.buf.Flush()
+		if err != nil {
+			log.Printf("flush log buffer on Close: %v", err)
+		}
+	}
+}
+
 func (l *Logger) PauseMgo() {
 	atomic.StoreInt32(&l.pauseMgo, 1)
 }
 
 func (l *Logger) ResumeMgo() {
 	atomic.StoreInt32(&l.pauseMgo, 0)
+}
+
+func (l *Logger) SetOutput(w io.Writer) {
+	l.out = w
 }
 
 func (l *Logger) output(s Severity, event string, obj, opid string, epoch primitive.Timestamp, msg string, args ...interface{}) {
@@ -192,6 +218,17 @@ func (l *Logger) Output(e *Entry) error {
 		_, err := l.cn.InsertOne(context.TODO(), e)
 		if err != nil {
 			rerr = errors.Wrap(err, "db")
+		}
+	}
+
+	if l.bufSet.Load() == 1 && l.buf != nil {
+		err := json.NewEncoder(l.buf).Encode(e)
+
+		err = errors.Wrap(err, "buf")
+		if rerr != nil {
+			rerr = errors.Errorf("%v, %v", rerr, err)
+		} else {
+			rerr = err
 		}
 	}
 

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -154,10 +154,6 @@ func (l *Logger) ResumeMgo() {
 	atomic.StoreInt32(&l.pauseMgo, 0)
 }
 
-func (l *Logger) SetOutput(w io.Writer) {
-	l.out = w
-}
-
 func (l *Logger) output(s Severity, event string, obj, opid string, epoch primitive.Timestamp, msg string, args ...interface{}) {
 	if len(args) > 0 {
 		msg = fmt.Sprintf(msg, args...)
@@ -221,6 +217,8 @@ func (l *Logger) Output(e *Entry) error {
 		}
 	}
 
+	// once buffer is set, it's expected to remain the same
+	// until the agent is alive
 	if l.bufSet.Load() == 1 && l.buf != nil {
 		err := json.NewEncoder(l.buf).Encode(e)
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -522,8 +522,8 @@ const (
 func (n nodeStatus) is(s nodeStatus) bool { return n&s != 0 }
 
 // log buffer that will dump content to the storage on restore
-// finish (whether it's successful or not). It also dumps when
-// logs size hist limit.
+// finish (whether it's successful or not). It also dumps content
+// and reset buffer when logs size hist the limit.
 type logBuff struct {
 	buf   *bytes.Buffer
 	path  string


### PR DESCRIPTION
We shutdown mongod at the early stages of physical restores. Hence PBM logs are being written only to stderr since. It may lead to losing the logs (if agents' stderr isn't captured or isn't stored for long enough). Plus gaps in `pbm logs`.
This commit adds a log buffer for physical restores. The buffer will dump it's content to the storage on restore finish (whether it's successful or not). It also dumps content and reset buffer when logs size hist a certain limit (1 Mb).
Each log message is stored in JSON format for further automation (adding logs to pbmLogs druting pbm --force-resync, PMM integration etc).