### PR TITLE
PBM-1060: add ability to use tmp creds with AWS S3 storage

### DIFF
--- a/pbm/config.go
+++ b/pbm/config.go
@@ -40,6 +40,9 @@ func (c Config) String() string {
 	if c.Storage.S3.Credentials.SecretAccessKey != "" {
 		c.Storage.S3.Credentials.SecretAccessKey = "***"
 	}
+	if c.Storage.S3.Credentials.SessionToken != "" {
+		c.Storage.S3.Credentials.SessionToken = "***"
+	}
 	if c.Storage.S3.Credentials.Vault.Secret != "" {
 		c.Storage.S3.Credentials.Vault.Secret = "***"
 	}
@@ -367,6 +370,9 @@ func (p *PBM) GetConfigYaml(fieldRedaction bool) ([]byte, error) {
 		}
 		if c.Storage.S3.Credentials.SecretAccessKey != "" {
 			c.Storage.S3.Credentials.SecretAccessKey = "***"
+		}
+		if c.Storage.S3.Credentials.SessionToken != "" {
+			c.Storage.S3.Credentials.SessionToken = "***"
 		}
 		if c.Storage.S3.Credentials.Vault.Secret != "" {
 			c.Storage.S3.Credentials.Vault.Secret = "***"

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -200,6 +200,7 @@ func SDKLogLevel(levels string, out io.Writer) aws.LogLevelType {
 type Credentials struct {
 	AccessKeyID     string `bson:"access-key-id" json:"access-key-id,omitempty" yaml:"access-key-id,omitempty"`
 	SecretAccessKey string `bson:"secret-access-key" json:"secret-access-key,omitempty" yaml:"secret-access-key,omitempty"`
+	SessionToken    string `bson:"session-token" json:"session-token,omitempty" yaml:"session-token,omitempty"`
 	Vault           struct {
 		Server string `bson:"server" json:"server,omitempty" yaml:"server"`
 		Secret string `bson:"secret" json:"secret,omitempty" yaml:"secret"`
@@ -521,7 +522,7 @@ func (s *S3) session() (*session.Session, error) {
 		providers = append(providers, &credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     s.opts.Credentials.AccessKeyID,
 			SecretAccessKey: s.opts.Credentials.SecretAccessKey,
-			SessionToken:    "",
+			SessionToken:    s.opts.Credentials.SessionToken,
 		}})
 	}
 


### PR DESCRIPTION
Added config option:
```
storage:
  s3:
     credentials:
       session-token: <string>
```

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html