### PR TITLE
chore: Rename module for v2 version

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 type Agent struct {

--- a/agent/oplog.go
+++ b/agent/oplog.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/restore"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/restore"
 )
 
 // OplogReplay replays oplog between r.Start and r.End timestamps (wall time in UTC tz)

--- a/agent/pitr.go
+++ b/agent/pitr.go
@@ -7,10 +7,10 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/backup"
-	"github.com/percona/percona-backup-mongodb/pbm/pitr"
-	"github.com/percona/percona-backup-mongodb/pbm/restore"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/pitr"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/restore"
 )
 
 type currentPitr struct {

--- a/agent/snapshot.go
+++ b/agent/snapshot.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/backup"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/restore"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/restore"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 type currentBackup struct {

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -12,9 +12,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 type backupOpts struct {

--- a/cli/backup_test.go
+++ b/cli/backup_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 func TestBcpMatchCluster(t *testing.T) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,10 +13,10 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 const (

--- a/cli/config.go
+++ b/cli/config.go
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type configOpts struct {

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 	"github.com/pkg/errors"
 )
 

--- a/cli/list.go
+++ b/cli/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type listOpts struct {

--- a/cli/list_test.go
+++ b/cli/list_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 

--- a/cli/oplog.go
+++ b/cli/oplog.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type replayOptions struct {

--- a/cli/restore.go
+++ b/cli/restore.go
@@ -12,8 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
 )
 
 type restoreOpts struct {

--- a/cli/status.go
+++ b/cli/status.go
@@ -17,10 +17,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	plog "github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/pitr"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	plog "github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/pitr"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 type statusOptions struct {

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -12,9 +12,9 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/agent"
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/agent"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 const mongoConnFlag = "mongodb-uri"

--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -10,11 +10,11 @@ import (
 	"github.com/alecthomas/kingpin"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/blackhole"
-	"github.com/percona/percona-backup-mongodb/speedt"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/blackhole"
+	"github.com/percona/percona-backup-mongodb/v2/speedt"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 func main() {

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/percona/percona-backup-mongodb/cli"
+	"github.com/percona/percona-backup-mongodb/v2/cli"
 )
 
 func main() {

--- a/e2e-tests/cmd/ensure-oplog/main.go
+++ b/e2e-tests/cmd/ensure-oplog/main.go
@@ -17,11 +17,11 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/backup"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/oplog"
-	"github.com/percona/percona-backup-mongodb/pbm/pitr"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/oplog"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/pitr"
 )
 
 var logger = log.New(os.Stdout, "", log.Ltime)

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/tests/sharded"
 )
 
 type testTyp string

--- a/e2e-tests/cmd/pbm-test/run.go
+++ b/e2e-tests/cmd/pbm-test/run.go
@@ -8,8 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/mod/semver"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/tests/sharded"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func run(t *sharded.Cluster, typ testTyp) {

--- a/e2e-tests/cmd/pbm-test/run_physical.go
+++ b/e2e-tests/cmd/pbm-test/run_physical.go
@@ -3,8 +3,8 @@ package main
 import (
 	"golang.org/x/mod/semver"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/tests/sharded"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func runPhysical(t *sharded.Cluster, typ testTyp) {

--- a/e2e-tests/cmd/pbm-test/run_remapping.go
+++ b/e2e-tests/cmd/pbm-test/run_remapping.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/tests/sharded"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func runRemappingTests(t *sharded.RemappingEnvironment) {

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -8,8 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 type MongoPBM struct {

--- a/e2e-tests/pkg/pbm/mongod.go
+++ b/e2e-tests/pkg/pbm/mongod.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func init() {

--- a/e2e-tests/pkg/pbm/pbm_ctl.go
+++ b/e2e-tests/pkg/pbm/pbm_ctl.go
@@ -14,7 +14,7 @@ import (
 	docker "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type Ctl struct {

--- a/e2e-tests/pkg/tests/sharded/backuper.go
+++ b/e2e-tests/pkg/tests/sharded/backuper.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 type Backuper interface {

--- a/e2e-tests/pkg/tests/sharded/cluster.go
+++ b/e2e-tests/pkg/tests/sharded/cluster.go
@@ -11,10 +11,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 type Cluster struct {

--- a/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
+++ b/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
@@ -11,8 +11,8 @@ import (
 	"github.com/minio/minio-go"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func (c *Cluster) BackupCancellation(storage string) {

--- a/e2e-tests/pkg/tests/sharded/test_basic.go
+++ b/e2e-tests/pkg/tests/sharded/test_basic.go
@@ -3,7 +3,7 @@ package sharded
 import (
 	"log"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func (c *Cluster) BackupAndRestore(typ pbm.BackupType) {

--- a/e2e-tests/pkg/tests/sharded/test_bounds_check.go
+++ b/e2e-tests/pkg/tests/sharded/test_bounds_check.go
@@ -6,11 +6,11 @@ import (
 	"math/rand"
 	"time"
 
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/mod/semver"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 type scounter struct {

--- a/e2e-tests/pkg/tests/sharded/test_clock_skew.go
+++ b/e2e-tests/pkg/tests/sharded/test_clock_skew.go
@@ -3,9 +3,9 @@ package sharded
 import (
 	"log"
 
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 func (c *Cluster) ClockSkew(typ pbmt.BackupType, mongoVersion string) {

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/minio/minio-go"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type backupDelete struct {

--- a/e2e-tests/pkg/tests/sharded/test_dr_restart_agents.go
+++ b/e2e-tests/pkg/tests/sharded/test_dr_restart_agents.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 const (

--- a/e2e-tests/pkg/tests/sharded/test_incremental_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_incremental_backup.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
 	"golang.org/x/mod/semver"
 )
 

--- a/e2e-tests/pkg/tests/sharded/test_leader_lag.go
+++ b/e2e-tests/pkg/tests/sharded/test_leader_lag.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
 )
 
 // LeaderLag checks if cluster deals with leader lag during backup start

--- a/e2e-tests/pkg/tests/sharded/test_network_cut.go
+++ b/e2e-tests/pkg/tests/sharded/test_network_cut.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 func (c *Cluster) NetworkCut() {

--- a/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
+++ b/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
@@ -8,7 +8,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	tpbm "github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	tpbm "github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 func (c *Cluster) OplogReplay() {

--- a/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
+++ b/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
@@ -9,9 +9,9 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	pbmt "github.com/percona/percona-backup-mongodb/pbm"
+	pbmt "github.com/percona/percona-backup-mongodb/v2/pbm"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 func (c *Cluster) PITRbasic() {

--- a/e2e-tests/pkg/tests/sharded/test_remapping.go
+++ b/e2e-tests/pkg/tests/sharded/test_remapping.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 type RemappingEnvironment struct {

--- a/e2e-tests/pkg/tests/sharded/test_selective.go
+++ b/e2e-tests/pkg/tests/sharded/test_selective.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests"
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/tests"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 var clusterSpec = []tests.GenDBSpec{

--- a/e2e-tests/pkg/tests/sharded/test_timeseries.go
+++ b/e2e-tests/pkg/tests/sharded/test_timeseries.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 func (c *Cluster) Timeseries() {

--- a/e2e-tests/pkg/tests/sharded/trx.go
+++ b/e2e-tests/pkg/tests/sharded/trx.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
-	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/e2e-tests/pkg/pbm"
 )
 
 const trxdb = "trx"

--- a/e2e-tests/pkg/tests/state.go
+++ b/e2e-tests/pkg/tests/state.go
@@ -18,8 +18,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/sel"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/sel"
 )
 
 type (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/percona/percona-backup-mongodb
+module github.com/percona/percona-backup-mongodb/v2
 
 go 1.19
 

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -12,11 +12,11 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	plog "github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	plog "github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 func init() {

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -12,14 +12,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/archive"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	plog "github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/oplog"
-	"github.com/percona/percona-backup-mongodb/pbm/sel"
-	"github.com/percona/percona-backup-mongodb/pbm/snapshot"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	plog "github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/oplog"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/sel"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/snapshot"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPID, rsMeta *pbm.BackupReplset, inf *pbm.NodeInfo, stg storage.Storage, l *plog.Event) error {

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -16,10 +16,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	plog "github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	plog "github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 const cursorCreateRetries = 10

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -15,13 +15,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/azure"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/blackhole"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/azure"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/blackhole"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/fs"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/s3"
 )
 
 // Config is a pbm config

--- a/pbm/delete.go
+++ b/pbm/delete.go
@@ -9,9 +9,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 // DeleteBackup deletes backup with the given name from the current storage

--- a/pbm/oplog/backup.go
+++ b/pbm/oplog/backup.go
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 // OplogBackup is used for reading the Mongodb oplog

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -26,8 +26,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/snapshot"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/snapshot"
 )
 
 type Record = db.Oplog

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -20,8 +20,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
 )
 
 const (

--- a/pbm/pitr.go
+++ b/pbm/pitr.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
 )
 
 const (

--- a/pbm/pitr/pitr.go
+++ b/pbm/pitr/pitr.go
@@ -12,12 +12,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/backup"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/oplog"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/oplog"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 // Slicer is an incremental backup object

--- a/pbm/restore.go
+++ b/pbm/restore.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/s3"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -14,14 +14,14 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/oplog"
-	"github.com/percona/percona-backup-mongodb/pbm/sel"
-	"github.com/percona/percona-backup-mongodb/pbm/snapshot"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/oplog"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/sel"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/snapshot"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 type Restore struct {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -26,11 +26,11 @@ import (
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/s3"
 )
 
 const (

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 func init() {

--- a/pbm/restore/selective.go
+++ b/pbm/restore/selective.go
@@ -9,11 +9,11 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
-	"github.com/percona/percona-backup-mongodb/pbm/archive"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/sel"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/sel"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 const (

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -15,11 +15,11 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/percona/percona-backup-mongodb/pbm/archive"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 const (

--- a/pbm/sel/sel.go
+++ b/pbm/sel/sel.go
@@ -7,7 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	"github.com/percona/percona-backup-mongodb/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/archive"
 )
 
 func IsSelective(ids []string) bool {

--- a/pbm/sel/sel_test.go
+++ b/pbm/sel/sel_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/percona/percona-backup-mongodb/pbm/sel"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/sel"
 )
 
 func TestSelectedPred(t *testing.T) {

--- a/pbm/snapshot/backup.go
+++ b/pbm/snapshot/backup.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mongodb/mongo-tools/mongodump"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/version"
+	"github.com/percona/percona-backup-mongodb/v2/version"
 )
 
 type backuper struct {

--- a/pbm/snapshot/dump.go
+++ b/pbm/snapshot/dump.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm/archive"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
 )
 
 type UploadDumpOptions struct {

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
-	"github.com/percona/percona-backup-mongodb/pbm"
+	"github.com/percona/percona-backup-mongodb/v2/pbm"
 )
 
 const (

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 const (

--- a/pbm/storage/blackhole/blackhole.go
+++ b/pbm/storage/blackhole/blackhole.go
@@ -3,7 +3,7 @@ package blackhole
 import (
 	"io"
 
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 type Blackhole struct{}

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 type Conf struct {

--- a/pbm/storage/s3/download.go
+++ b/pbm/storage/s3/download.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
 )
 
 // Downloading objects from the storage.

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -30,8 +30,8 @@ import (
 	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/pkg/errors"
 
-	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/log"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 const (

--- a/speedt/speedt.go
+++ b/speedt/speedt.go
@@ -14,9 +14,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
-	"github.com/percona/percona-backup-mongodb/pbm/backup"
-	"github.com/percona/percona-backup-mongodb/pbm/compress"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/v2/pbm/storage"
 )
 
 func init() {


### PR DESCRIPTION
Hey,

Since v2.0.0 go module naming doesn't follow go recommendation (module should be named "github.com/percona/percona-backup-mongodb/v2") and can't be imported easily. For example in the mongodb operator: https://github.com/percona/percona-server-mongodb-operator/blob/v1.14.0/go.mod#L17

Go authors recommended for a while to create a v2/ folder and maintain several version of the code (https://go.dev/blog/v2-go-modules) but doesn't seem to reach a vast adhesion in the community. I personally - as many open source projects - prefer the approach to rename the module and the imports but keep the folder organization. Let me know what you think about it.

Sorry if it has already been discussed, I haven't found anything about it