### PR TITLE
PBM-1058: fix affected backups during restore

### DIFF
--- a/e2e-tests/docker/docker-compose-rs.yaml
+++ b/e2e-tests/docker/docker-compose-rs.yaml
@@ -31,7 +31,7 @@ services:
       - MONGO_USER=dba
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --dbpath=/data/db/ --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs101:/data/db
       - ./scripts/start.sh:/opt/start.sh
@@ -45,7 +45,7 @@ services:
     hostname: rs102
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1  --dbpath=/data/db/ --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs102:/data/db
   rs103:
@@ -58,7 +58,7 @@ services:
     hostname: rs103
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1  --dbpath=/data/db/ --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs103:/data/db
   agent-rs101:

--- a/packaging/conf/pbm-conf-reference.yml
+++ b/packaging/conf/pbm-conf-reference.yml
@@ -117,3 +117,11 @@
 #restore:
 #  batchSize: 500
 #  numInsertionWorkers: 10
+  
+# Options to specify the custom path to mongod binaries for internal restarts 
+# during physical restore. The mongodLocationMap option allows defining custom 
+# path per node. When undefined, the default path will be used.
+#  mongodLocation: /path/to/mongod
+#  mongodLocationMap:
+#    "node01:27017": /path/to/mongod
+#    "node03:27017": /another/path/to/mongod

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -391,6 +391,11 @@ func uploadFiles(ctx context.Context, files []pbm.File, subdir, trimPrefix strin
 		return journal, data, errors.Wrapf(err, "upload file `%s`", wfile.Name)
 	}
 	f.Name = trim(wfile.Name)
+	if strings.HasPrefix(f.Name, journalPrefix) {
+		journal = append(journal, *f)
+	} else {
+		data = append(data, *f)
+	}
 
 	return journal, data, nil
 }

--- a/pbm/restore/pbm_1058_test.go
+++ b/pbm/restore/pbm_1058_test.go
@@ -1,0 +1,35 @@
+package restore
+
+import (
+	"testing"
+)
+
+func TestDBpathSearch(t *testing.T) {
+	cases := []struct {
+		name   string
+		is     bool
+		dbpath string
+	}{
+		{"a", false, ""},
+		{"/a", true, ""},
+		{"/path/a", true, ""},
+		{"/data/db/a", true, ""},
+		{"/data/journal/a", true, "/data/"},
+		{"/data/db/journal/a", true, "/data/db/"},
+		{"/data/journal/journal/a", true, "/data/journal/"},
+		{"/data/db/journal/journal/a", true, "/data/db/journal/"},
+		{"/data/journal/db/journal/a", true, "/data/journal/db/"},
+		{"/data/journal/db/journala", true, ""},
+		{"/data/journal/db/journal", true, ""},
+		{"journal/a", false, ""},
+		{"collection/a", false, ""},
+		{"collection/a", false, ""},
+	}
+
+	for _, c := range cases {
+		is, path := findDBpath(c.name)
+		if is != c.is || path != c.dbpath {
+			t.Errorf("filename %s, expected: `%v` `%s`, got: `%v` `%s`", c.name, c.is, c.dbpath, is, path)
+		}
+	}
+}


### PR DESCRIPTION
Checks if dbpath exists in the file name  and cut it from destination. We suppose that "journal/" will always be present in the backup and it is always in the dbpath root and doesn't contain subdirs, only files.