### PR TITLE
PBM-1058: fix affected backups during restore

### DIFF
--- a/e2e-tests/docker/docker-compose-rs.yaml
+++ b/e2e-tests/docker/docker-compose-rs.yaml
@@ -48,7 +48,7 @@ services:
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
       - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --dbpath=/data/db/ --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs101:/data/db
       - ./scripts/start.sh:/opt/start.sh
@@ -62,7 +62,7 @@ services:
     hostname: rs102
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --dbpath=/data/db/ --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs102:/data/db
   rs103:
@@ -75,7 +75,7 @@ services:
     hostname: rs103
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --port 27017 --dbpath=/data/db/ --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs103:/data/db
   agent-rs101:

--- a/pbm/restore/pbm_1058_test.go
+++ b/pbm/restore/pbm_1058_test.go
@@ -1,0 +1,36 @@
+package restore
+
+import (
+	"testing"
+)
+
+func TestDBpathSearch(t *testing.T) {
+	cases := []struct {
+		name   string
+		is     bool
+		dbpath string
+	}{
+		{"a", false, ""},
+		{"/a", true, ""},
+		{"/path/a", true, ""},
+		{"/data/db/a", true, ""},
+		{"/data/journal/a", true, "/data/"},
+		{"/data/db/journal/a", true, "/data/db/"},
+		{"/data/journal/journal/a", true, "/data/journal/"},
+		{"/data/db/journal/journal/a", true, "/data/db/journal/"},
+		{"/data/journal/db/journal/a", true, "/data/journal/db/"},
+		{"/data/journal/db/journala", true, ""},
+		{"/data/journal/db/journal", true, ""},
+		{"/journal/a", true, "/"},
+		{"journal/a", false, ""},
+		{"collection/a", false, ""},
+		{"collection/a", false, ""},
+	}
+
+	for _, c := range cases {
+		is, path := findDBpath(c.name)
+		if is != c.is || path != c.dbpath {
+			t.Errorf("filename %s, expected: `%v` `%s`, got: `%v` `%s`", c.name, c.is, c.dbpath, is, path)
+		}
+	}
+}


### PR DESCRIPTION
Checks if dbpath exists in the file name and cut it from the destination. We suppose that "journal" will always be present in the backup and it is always in the dbpath root and doesn't contain subdirs, only files. Having a leading `/` indicates that restore was affected by PBM-1058 but only with journal files we may detect the exact prefix.