### PR TITLE
[PBM-1066] warn about incompatible FCV/mongo versions

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -205,6 +205,7 @@ type bcpDesc struct {
 	LastTransitionTime string         `json:"last_transition_time" yaml:"last_transition_time"`
 	Namespaces         []string       `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
 	MongoVersion       string         `json:"mongodb_version" yaml:"mongodb_version"`
+	FCV                string         `json:"fcv" yaml:"fcv"`
 	PBMVersion         string         `json:"pbm_version" yaml:"pbm_version"`
 	Status             pbm.Status     `json:"status" yaml:"status"`
 	Size               int64          `json:"size" yaml:"-"`
@@ -262,6 +263,7 @@ func describeBackup(cn *pbm.PBM, b *descBcp) (fmt.Stringer, error) {
 		Type:               bcp.Type,
 		Namespaces:         bcp.Namespaces,
 		MongoVersion:       bcp.MongoVersion,
+		FCV:                bcp.FCV,
 		PBMVersion:         bcp.PBMVersion,
 		LastWriteTS:        int64(bcp.LastWriteTS.T),
 		LastTransitionTS:   bcp.LastTransitionTS,

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
@@ -324,7 +325,7 @@ func describeBackup(cn *pbm.PBM, b *descBcp) (fmt.Stringer, error) {
 // changed to pbm.StatusError with respective error text emitted. It doesn't change meta on
 // storage nor in DB (backup is ok, it just doesn't cluster), it is just "in-flight" changes
 // in given `bcps`.
-func bcpsMatchCluster(bcps []pbm.BackupMeta, shards []pbm.Shard, confsrv string, rsMap map[string]string) {
+func bcpsMatchCluster(bcps []pbm.BackupMeta, ver, fcv string, shards []pbm.Shard, confsrv string, rsMap map[string]string) {
 	sh := make(map[string]bool, len(shards))
 	for _, s := range shards {
 		sh[s.RS] = s.RS == confsrv
@@ -338,17 +339,29 @@ func bcpsMatchCluster(bcps []pbm.BackupMeta, shards []pbm.Shard, confsrv string,
 			continue
 		}
 
-		bcpMatchCluster(bcp, sh, mapRS, mapRevRS)
+		bcpMatchCluster(bcp, ver, fcv, sh, mapRS, mapRevRS)
 	}
 }
 
-func bcpMatchCluster(bcp *pbm.BackupMeta, shards map[string]bool, mapRS, mapRevRS pbm.RSMapFunc) {
+func bcpMatchCluster(bcp *pbm.BackupMeta, ver, fcv string, shards map[string]bool, mapRS, mapRevRS pbm.RSMapFunc) {
 	if bcp.Status != pbm.StatusDone {
 		return
 	}
 	if !version.CompatibleWith(bcp.PBMVersion, pbm.BreakingChangesMap[bcp.Type]) {
 		bcp.SetRuntimeError(errIncompatibleVersion{bcp.PBMVersion})
 		return
+	}
+	if bcp.FCV != "" {
+		if bcp.FCV != fcv {
+			bcp.SetRuntimeError(errors.Errorf("backup FCV %q is incompatible with the running mongo FCV %q",
+				bcp.FCV, fcv))
+			return
+		}
+	} else if majmin(bcp.MongoVersion) != majmin(ver) {
+		bcp.SetRuntimeError(errors.Errorf("backup mongo version %q is incompatible with the running mongo version %q",
+			bcp.MongoVersion, ver))
+		return
+
 	}
 
 	var nomatch []string
@@ -373,6 +386,18 @@ func bcpMatchCluster(bcp *pbm.BackupMeta, shards map[string]bool, mapRS, mapRevR
 		copy(names, nomatch)
 		bcp.SetRuntimeError(errMissedReplsets{names: names, configsrv: !hasconfsrv})
 	}
+}
+
+func majmin(v string) string {
+	if len(v) == 0 {
+		return v
+	}
+
+	if v[0] != 'v' {
+		v = "v" + v
+	}
+
+	return semver.MajorMinor(v)
 }
 
 var errIncompatible = errors.New("incompatible")

--- a/cli/backup_test.go
+++ b/cli/backup_test.go
@@ -168,7 +168,7 @@ func TestBcpMatchCluster(t *testing.T) {
 				b.meta.Status = pbm.StatusDone
 				m = append(m, b.meta)
 			}
-			bcpsMatchCluster(m, c.shards, c.confsrv, nil)
+			bcpsMatchCluster(m, "", "", c.shards, c.confsrv, nil)
 			for i := 0; i < len(c.bcps); i++ {
 				if c.bcps[i].expect != m[i].Status {
 					t.Errorf("wrong status for %s, expect %s, got %s", m[i].Name, c.bcps[i].expect, m[i].Status)
@@ -304,6 +304,8 @@ func TestBcpMatchRemappedCluster(t *testing.T) {
 			c.bcp.SetRuntimeError(errRSMappingWithPhysBackup{})
 		} else {
 			bcpMatchCluster(&c.bcp,
+				"",
+				"",
 				topology,
 				pbm.MakeRSMapFunc(c.rsMap),
 				pbm.MakeReverseRSMapFunc(c.rsMap))
@@ -384,7 +386,7 @@ func BenchmarkBcpMatchCluster3x10(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -410,7 +412,7 @@ func BenchmarkBcpMatchCluster3x100(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -464,7 +466,7 @@ func BenchmarkBcpMatchCluster17x100(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -490,7 +492,7 @@ func BenchmarkBcpMatchCluster3x1000(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -513,7 +515,7 @@ func BenchmarkBcpMatchCluster1000x1000(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -553,7 +555,7 @@ func BenchmarkBcpMatchCluster3x10Err(b *testing.B) {
 		})
 	}
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }
 
@@ -577,6 +579,6 @@ func BenchmarkBcpMatchCluster1000x1000Err(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bcpsMatchCluster(bcps, shards, "config", nil)
+		bcpsMatchCluster(bcps, "", "", shards, "config", nil)
 	}
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -609,6 +609,14 @@ func getStorageStat(cn *pbm.PBM, rsMap map[string]string) (fmt.Stringer, error) 
 	if err != nil {
 		return s, errors.Wrap(err, "define cluster state")
 	}
+	ver, err := pbm.GetMongoVersion(cn.Context(), cn.Conn)
+	if err != nil {
+		return nil, errors.WithMessage(err, "get mongo version")
+	}
+	fcv, err := cn.GetFeatureCompatibilityVersion()
+	if err != nil {
+		return nil, errors.WithMessage(err, "get featureCompatibilityVersion")
+	}
 
 	shards, err := cn.ClusterMembers()
 	if err != nil {
@@ -617,7 +625,7 @@ func getStorageStat(cn *pbm.PBM, rsMap map[string]string) (fmt.Stringer, error) 
 
 	// pbm.PBM is always connected either to config server or to the sole (hence main) RS
 	// which the `confsrv` param in `bcpMatchCluster` is all about
-	bcpsMatchCluster(bcps, shards, inf.SetName, rsMap)
+	bcpsMatchCluster(bcps, ver.VersionString, fcv, shards, inf.SetName, rsMap)
 
 	stg, err := cn.GetStorage(cn.Logger().NewEvent("", "", "", primitive.Timestamp{}))
 	if err != nil {

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -91,9 +91,16 @@ func (b *Backup) Init(bcp *pbm.BackupCmd, opid pbm.OPID, balancer pbm.BalancerMo
 	meta.Store = cfg.Storage
 
 	ver, err := b.node.GetMongoVersion()
-	if err == nil {
-		meta.MongoVersion = ver.VersionString
+	if err != nil {
+		return errors.WithMessage(err, "get mongo version")
 	}
+	meta.MongoVersion = ver.VersionString
+
+	fcv, err := b.node.GetFeatureCompatibilityVersion()
+	if err != nil {
+		return errors.WithMessage(err, "get featureCompatibilityVersion")
+	}
+	meta.FCV = fcv
 
 	return b.cn.SetBackupMeta(meta)
 }

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -182,7 +182,11 @@ func GetMongoVersion(ctx context.Context, m *mongo.Client) (MongoVersion, error)
 }
 
 func (n *Node) GetFeatureCompatibilityVersion() (string, error) {
-	res := n.cn.Database("admin").RunCommand(n.ctx, bson.D{
+	return getFeatureCompatibilityVersion(n.ctx, n.cn)
+}
+
+func getFeatureCompatibilityVersion(ctx context.Context, m *mongo.Client) (string, error) {
+	res := m.Database("admin").RunCommand(ctx, bson.D{
 		{"getParameter", 1},
 		{"featureCompatibilityVersion", 1},
 	})

--- a/pbm/node.go
+++ b/pbm/node.go
@@ -181,6 +181,23 @@ func GetMongoVersion(ctx context.Context, m *mongo.Client) (MongoVersion, error)
 	return ver, nil
 }
 
+func (n *Node) GetFeatureCompatibilityVersion() (string, error) {
+	res := n.cn.Database("admin").RunCommand(n.ctx, bson.D{
+		{"getParameter", 1},
+		{"featureCompatibilityVersion", 1},
+	})
+	if err := res.Err(); err != nil {
+		return "", errors.WithMessage(err, "query")
+	}
+
+	var ver struct{ FeatureCompatibilityVersion struct{ Version string } }
+	if err := res.Decode(&ver); err != nil {
+		return "", errors.WithMessage(err, "decode")
+	}
+
+	return ver.FeatureCompatibilityVersion.Version, nil
+}
+
 func (n *Node) GetReplsetStatus() (*ReplsetStatus, error) {
 	return GetReplsetStatus(n.ctx, n.cn)
 }

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -482,6 +482,7 @@ type BackupMeta struct {
 	Store            StorageConf              `bson:"store" json:"store"`
 	Size             int64                    `bson:"size" json:"size"`
 	MongoVersion     string                   `bson:"mongodb_version" json:"mongodb_version,omitempty"`
+	FCV              string                   `bson:"fcv" json:"fcv"`
 	StartTS          int64                    `bson:"start_ts" json:"start_ts"`
 	LastTransitionTS int64                    `bson:"last_transition_ts" json:"last_transition_ts"`
 	FirstWriteTS     primitive.Timestamp      `bson:"first_write_ts" json:"first_write_ts"`

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -978,6 +978,11 @@ func (p *PBM) GetNodeInfo() (*NodeInfo, error) {
 	return inf, nil
 }
 
+// GetNodeInfo returns mongo node info
+func (p *PBM) GetFeatureCompatibilityVersion() (string, error) {
+	return getFeatureCompatibilityVersion(p.ctx, p.Conn)
+}
+
 // ClusterTime returns mongo's current cluster time
 func (p *PBM) ClusterTime() (primitive.Timestamp, error) {
 	// Make a read to force the cluster timestamp update.

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -592,8 +592,9 @@ func (r *Restore) checkSnapshot(bcp *pbm.BackupMeta) error {
 		}
 
 		if bcp.FCV != fcv {
-			return errors.Errorf("backup FCV %q is incompatible with the running mongo FCV %q",
+			r.log.Warning("backup FCV %q is incompatible with the running mongo FCV %q",
 				bcp.FCV, fcv)
+			return nil
 		}
 	} else {
 		ver, err := r.node.GetMongoVersion()
@@ -602,8 +603,9 @@ func (r *Restore) checkSnapshot(bcp *pbm.BackupMeta) error {
 		}
 
 		if majmin(bcp.MongoVersion) != majmin(ver.VersionString) {
-			return errors.Errorf("backup mongo version %q is incompatible with the running mongo version %q",
+			r.log.Warning("backup mongo version %q is incompatible with the running mongo version %q",
 				bcp.MongoVersion, ver.VersionString)
+			return nil
 		}
 	}
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -581,8 +581,30 @@ func (r *Restore) checkSnapshot(bcp *pbm.BackupMeta) error {
 		return errors.Errorf("backup wasn't successful: status: %s, error: %s", bcp.Status, bcp.Error())
 	}
 
-	if !version.CompatibleWith(bcp.PBMVersion, pbm.BreakingChangesMap[bcp.Type]) {
-		return errors.Errorf("backup version (v%s) is not compatible with PBM v%s", bcp.PBMVersion, version.DefaultInfo.Version)
+	if !version.CompatibleWith(version.DefaultInfo.Version, pbm.BreakingChangesMap[bcp.Type]) {
+		return errors.Errorf("backup PBM v%s is incompatible with the running PBM v%s", bcp.PBMVersion, version.DefaultInfo.Version)
+	}
+
+	if bcp.FCV != "" {
+		fcv, err := r.node.GetFeatureCompatibilityVersion()
+		if err != nil {
+			return errors.WithMessage(err, "get featureCompatibilityVersion")
+		}
+
+		if bcp.FCV != fcv {
+			return errors.Errorf("backup FCV %q is incompatible with the running mongo FCV %q",
+				bcp.FCV, fcv)
+		}
+	} else {
+		ver, err := r.node.GetMongoVersion()
+		if err != nil {
+			return errors.WithMessage(err, "get mongo version")
+		}
+
+		if majmin(bcp.MongoVersion) != majmin(ver.VersionString) {
+			return errors.Errorf("backup mongo version %q is incompatible with the running mongo version %q",
+				bcp.MongoVersion, ver.VersionString)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
1. store FCV in backup metadata
2. show the FCV in `describe-backup`
3. print warning in logs during restore when FCV is not the same. if there is no FCV in the backup meta, use `major.minor` version.
4. show an error in `pbm status` when FCV is different. hide such backups in `pbm list`