### PR TITLE
PBM-1063: handle directoryPerDB for incremental backups 

### DIFF
--- a/e2e-tests/docker/docker-compose-rs.yaml
+++ b/e2e-tests/docker/docker-compose-rs.yaml
@@ -48,7 +48,7 @@ services:
       - BACKUP_USER=bcp
       - MONGO_PASS=test1234
       - MONGODB_VERSION=${MONGODB_VERSION:-4.2}
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --directoryperdb --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs101:/data/db
       - ./scripts/start.sh:/opt/start.sh
@@ -62,7 +62,7 @@ services:
     hostname: rs102
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --directoryperdb --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs102:/data/db
   rs103:
@@ -75,7 +75,7 @@ services:
     hostname: rs103
     labels:
       - "com.percona.pbm.app=mongod"
-    command: mongod --replSet rs1 --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
+    command: mongod --replSet rs1 --directoryperdb --port 27017 --storageEngine wiredTiger --keyFile /opt/keyFile --wiredTigerCacheSizeGB 1
     volumes:
       - data-rs103:/data/db
   agent-rs101:


### PR DESCRIPTION
Incremental $backupCusor returns collections that were created but haven't ended up in the checkpoint yet in the format if they don't belong to this backup (see PBM-1063). PBM doesn't copy such files. But they are already in WT metadata. PSMDB (WT) handles this by creating such files during the start. But fails to do so if it runs with `directoryPerDb` option. Namely fails to create a directory for the collections. So we have to detect and create these directories during the restore.