### PR TITLE
PBM-1069: check for incremental backups compatibility

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -344,7 +344,7 @@ func bcpMatchCluster(bcp *pbm.BackupMeta, shards map[string]bool, mapRS, mapRevR
 	if bcp.Status != pbm.StatusDone {
 		return
 	}
-	if !version.Compatible(version.DefaultInfo.Version, bcp.PBMVersion) {
+	if !version.CompatibleWith(bcp.PBMVersion, pbm.BreakingChangesMap[bcp.Type]) {
 		bcp.SetRuntimeError(errIncompatibleVersion{bcp.PBMVersion})
 		return
 	}

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -581,7 +581,7 @@ func (r *Restore) checkSnapshot(bcp *pbm.BackupMeta) error {
 		return errors.Errorf("backup wasn't successful: status: %s, error: %s", bcp.Status, bcp.Error())
 	}
 
-	if !version.Compatible(version.DefaultInfo.Version, bcp.PBMVersion) {
+	if !version.CompatibleWith(bcp.PBMVersion, pbm.BreakingChangesMap[bcp.Type]) {
 		return errors.Errorf("backup version (v%s) is not compatible with PBM v%s", bcp.PBMVersion, version.DefaultInfo.Version)
 	}
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -32,6 +32,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/version"
 )
 
 const (
@@ -1447,6 +1448,10 @@ func (r *PhysRestore) prepareBackup(backupName string) (err error) {
 
 	if r.bcp.Status != pbm.StatusDone {
 		return errors.Errorf("backup wasn't successful: status: %s, error: %s", r.bcp.Status, r.bcp.Error())
+	}
+
+	if !version.CompatibleWith(r.bcp.PBMVersion, pbm.BreakingChangesMap[r.bcp.Type]) {
+		return errors.Errorf("backup version (v%s) is not compatible with PBM v%s", r.bcp.PBMVersion, version.DefaultInfo.Version)
 	}
 
 	mgoV, err := r.node.GetMongoVersion()

--- a/pbm/version.go
+++ b/pbm/version.go
@@ -1,0 +1,10 @@
+package pbm
+
+// BreakingChangesMap, map of versions introduced breaking changes to respective
+// backup types.
+// !!! Versions should be sorted in the ascending order.
+var BreakingChangesMap = map[BackupType][]string{
+	LogicalBackup:     {"1.5.0"},
+	IncrementalBackup: {"2.1.0"},
+	PhysicalBackup:    {},
+}

--- a/version/version.go
+++ b/version/version.go
@@ -9,12 +9,7 @@ import (
 )
 
 // current PBM version
-const version = "2.0.4"
-
-// !!! should be sorted in the ascending order
-var breakingChangesV = []string{
-	"1.5.0",
-}
+const version = "2.1.0-dev"
 
 var (
 	platform  string
@@ -96,10 +91,11 @@ func (i Info) All(format string) string {
 	}
 }
 
-// CompatibleWith tells if a given versions are compatible. Versions are not compatible
-// if one is crossed the breaking ponit (v1 >= breakingVersion) and the other isn't (v2 < breakingVersion)
-func Compatible(v1, v2 string) bool {
-	return compatible(v1, v2, breakingChangesV)
+// CompatibleWith checks if a given version is compatible the current one. It
+// is not compatible if the current is crossed the breaking ponit
+// (version >= breakingVersion) and the given isn't (v < breakingVersion)
+func CompatibleWith(v string, breakingv []string) bool {
+	return compatible(version, v, breakingv)
 }
 
 func compatible(v1, v2 string, breakingv []string) bool {


### PR DESCRIPTION
Incremental backups made on PBM pre v2.1.(incremental backups tech preview) are incompatible with  v2.1.0+ (incremental backups GA)

Check, and for incompatible backups:
- mark in `pbm status`: 
```
2023-03-22T15:19:47Z 365.04KB <incremental> [incompatible: backup version (v2.0.4) is not compatible with PBM v2.1.0-dev] [2023-03-22T15:19:49Z]
2023-03-22T15:19:11Z 402.10KB <incremental, base> [incompatible: backup version (v2.0.4) is not compatible with PBM v2.1.0-dev] [2023-03-22T15:19:13Z]
```

 - skip in `pbm list`
 - don't start restore with: 
 ``` ... error: backup version (v2.0.4) is not compatible with PBM v2.1.0-dev ```