### PR TITLE
add the license file to the deb package

### DIFF
--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -6,3 +6,4 @@ default/pbm-agent /etc/default/
 pbm-storage.conf /etc/
 pbm-agent.service /lib/systemd/system/
 pbm-conf-reference.yml /etc/
+LICENSE /usr/share/doc/percona-backup-mongodb/

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -66,6 +66,7 @@ override_dh_auto_install:
 	cp -f packaging/conf/pbm-agent.env  $(TMP)/default/pbm-agent
 	cp -f packaging/conf/pbm-agent.service $(TMP)/pbm-agent.service
 	cp -f packaging/conf/pbm-conf-reference.yml $(TMP)/pbm-conf-reference.yml
+	cp -f LICENSE $(TMP)/LICENSE
 	ls -la $(TMP)
 
 override_dh_systemd_start:


### PR DESCRIPTION
It is very important (from the legal point of view) to distribute the license together with binaries.