### PR TITLE
PBM-951: drop pbm*.old collections

### DIFF
--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -40,16 +40,12 @@ const (
 	LockOpCollection = "pbmLockOp"
 	// BcpCollection is a collection for backups metadata
 	BcpCollection = "pbmBackups"
-	// BcpOldCollection contains a backup of backups metadata
-	BcpOldCollection = "pbmBackups.old"
 	// RestoresCollection is a collection for restores metadata
 	RestoresCollection = "pbmRestores"
 	// CmdStreamCollection is the name of the mongo collection that contains backup/restore commands stream
 	CmdStreamCollection = "pbmCmd"
 	// PITRChunksCollection contains index metadata of PITR chunks
 	PITRChunksCollection = "pbmPITRChunks"
-	// PITRChunksOldCollection contains archived index metadata of PITR chunks
-	PITRChunksOldCollection = "pbmPITRChunks.old"
 	// PBMOpLogCollection contains log of acquired locks (hence run ops)
 	PBMOpLogCollection = "pbmOpLog"
 	// AgentsStatusCollection is an agents registry with its status/health checks

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -74,6 +74,16 @@ func (p *PBM) ResyncStorage(l *log.Event) error {
 	}
 	l.Debug("got backups list: %v", len(bcps))
 
+	_, err = p.Conn.Database(DB).Collection(BcpCollection).DeleteMany(p.ctx, bson.M{})
+	if err != nil {
+		return errors.Wrapf(err, "clean up %s", BcpCollection)
+	}
+
+	_, err = p.Conn.Database(DB).Collection(PITRChunksCollection).DeleteMany(p.ctx, bson.M{})
+	if err != nil {
+		return errors.Wrapf(err, "clean up %s", PITRChunksCollection)
+	}
+
 	var ins []interface{}
 	for _, b := range bcps {
 		l.Debug("bcp: %v", b.Name)

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -23,12 +23,10 @@ var ExcludeFromRestore = []string{
 	pbm.DB + "." + pbm.LogCollection,
 	pbm.DB + "." + pbm.ConfigCollection,
 	pbm.DB + "." + pbm.BcpCollection,
-	pbm.DB + "." + pbm.BcpOldCollection,
 	pbm.DB + "." + pbm.RestoresCollection,
 	pbm.DB + "." + pbm.LockCollection,
 	pbm.DB + "." + pbm.LockOpCollection,
 	pbm.DB + "." + pbm.PITRChunksCollection,
-	pbm.DB + "." + pbm.PITRChunksOldCollection,
 	pbm.DB + "." + pbm.AgentsStatusCollection,
 	pbm.DB + "." + pbm.PBMOpLogCollection,
 	"config.version",
@@ -42,6 +40,10 @@ var ExcludeFromRestore = []string{
 	"config.transaction_coordinators",
 	"admin.system.version",
 	"config.system.indexBuilds",
+
+	// deprecated PBM collections, keep it here not to bring back from old backups
+	pbm.DB + ".pbmBackups.old",
+	pbm.DB + ".pbmPITRChunks.old",
 }
 
 type restorer struct{ *mongorestore.MongoRestore }


### PR DESCRIPTION
Preserving of pbmBackups and pbmPITRChunks during resync is redundant. As storage is the source of trues anyway. And these preserved data had been never used or requested. But copying pbmPITRChunks slows resync down ALOT if there is a quite amount of chunks.