### PR TITLE
PBM-1070: cli improvements for physical restores

### DIFF
--- a/cli/oplog.go
+++ b/cli/oplog.go
@@ -90,7 +90,7 @@ func replayOplog(cn *pbm.PBM, o replayOptions, outf outFormat) (fmt.Stringer, er
 	}
 
 	fmt.Print("Started.\nWaiting to finish")
-	err = waitRestore(cn, m)
+	err = waitRestore(cn, m, 0)
 	if err != nil {
 		return oplogReplayResult{err: err.Error()}, nil
 	}

--- a/pbm/rsync.go
+++ b/pbm/rsync.go
@@ -381,7 +381,7 @@ func ParsePhysRestoreStatus(restore string, stg storage.Storage, l *log.Event) (
 		}
 	}
 
-	// If all nodes in the rs are in "error" stae, set rs as "error".
+	// If all nodes in the rs are in "error" state, set rs as "error".
 	// We have "partlyDone", so it's not an error if at least one node is "done".
 	for _, rs := range rss {
 		noerr := 0


### PR DESCRIPTION
1. Parsing of the restore meta and `pbm restore -w` now properly reports errors when all nodes have failed but the replica set and cluster status weren't changed. This may happen when all nodes have failed with an error but they can't set the replica set and cluster statuses to error as we have partlyDone status.

2. Parsing of the restore meta and `pbm restore -w` now properly handle situations when all nodes have died, hence hb not progressing.

3. Added message to the `pbm restore` output when it's run without -w:
```
...
Check restore status with: pbm describe-restore 2023-04-07T14:14:58.434144169Z -c </path/to/pbm.conf.yaml>
No other pbm command is available while the restore is running!
```