### PR TITLE
[PBM-1095] fix authSource on configsvr

### DIFF
--- a/pbm/snapshot/backup.go
+++ b/pbm/snapshot/backup.go
@@ -43,6 +43,7 @@ func NewBackup(curi string, conns int, d, c string) (io.WriterTo, error) {
 
 	opts.Direct = true
 	opts.Namespace = &options.Namespace{DB: d, Collection: c}
+	opts.Auth.Source = "admin"
 
 	backup := &backuper{}
 

--- a/pbm/snapshot/backup.go
+++ b/pbm/snapshot/backup.go
@@ -43,7 +43,13 @@ func NewBackup(curi string, conns int, d, c string) (io.WriterTo, error) {
 
 	opts.Direct = true
 	opts.Namespace = &options.Namespace{DB: d, Collection: c}
-	opts.Auth.Source = "admin"
+	if opts.Auth.IsSet() && opts.Auth.Source == "" {
+		if opts.Auth.RequiresExternalDB() {
+			opts.Auth.Source = "$external"
+		} else {
+			opts.Auth.Source = "admin"
+		}
+	}
 
 	backup := &backuper{}
 


### PR DESCRIPTION
on configsvr during selective backup, the authSource is set to "config" but should be always "admin"