### PR TITLE
[PBM-1147, PBM-885] support link for fs storage

### DIFF
--- a/pbm/config.go
+++ b/pbm/config.go
@@ -472,7 +472,7 @@ func Storage(c Config, l *log.Event) (storage.Storage, error) {
 	case storage.Azure:
 		return azure.New(c.Storage.Azure, l)
 	case storage.Filesystem:
-		return fs.New(c.Storage.Filesystem), nil
+		return fs.New(c.Storage.Filesystem)
 	case storage.BlackHole:
 		return blackhole.New(), nil
 	case storage.Undef:


### PR DESCRIPTION
If `storage.filesystem.path` points to a symbolic link, PBM will resolve the actual path and be able to list/read the folder's content. Otherwise, it considers the path as a regular file and does not see any content in the linked folder.
However, it will not resolve any link inside the storage path.
