### PR TITLE
[PBM-1154] add backup.timeouts.startingStatus

### DIFF
--- a/agent/backup.go
+++ b/agent/backup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 type currentBackup struct {
@@ -96,6 +97,17 @@ func (a *Agent) Backup(cmd *pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 		bcp = backup.New(a.pbm, a.node)
 	}
 
+	cfg, err := a.pbm.GetConfig()
+	if err != nil {
+		l.Error("unable to get PBM config settings: " + err.Error())
+		return
+	}
+	if storage.ParseType(string(cfg.Storage.Type)) == storage.Undef {
+		l.Error("backups cannot be saved because PBM storage configuration hasn't been set yet")
+		return
+	}
+	bcp.SetTimeouts(cfg.Backup.Timeouts)
+
 	if nodeInfo.IsClusterLeader() {
 		balancer := pbm.BalancerModeOff
 		if nodeInfo.IsSharded() {
@@ -108,7 +120,7 @@ func (a *Agent) Backup(cmd *pbm.BackupCmd, opid pbm.OPID, ep pbm.Epoch) {
 				balancer = pbm.BalancerModeOn
 			}
 		}
-		err = bcp.Init(cmd, opid, nodeInfo, balancer)
+		err = bcp.Init(cmd, opid, nodeInfo, cfg.Storage, balancer)
 		if err != nil {
 			l.Error("init meta: %v", err)
 			return

--- a/agent/restore.go
+++ b/agent/restore.go
@@ -211,7 +211,7 @@ func (a *Agent) pitr() (err error) {
 			w:      w,
 		})
 
-		streamErr := ibcp.Stream(ctx, w, cfg.PITR.Compression, cfg.PITR.CompressionLevel)
+		streamErr := ibcp.Stream(ctx, w, cfg.PITR.Compression, cfg.PITR.CompressionLevel, cfg.Backup.Timeouts)
 		if streamErr != nil {
 			switch streamErr.(type) {
 			case pitr.ErrOpMoved:

--- a/cli/backup.go
+++ b/cli/backup.go
@@ -134,7 +134,7 @@ func runBackup(cn *pbm.PBM, b *backupOpts, outf outFormat) (fmt.Stringer, error)
 	}
 
 	fmt.Printf("Starting backup '%s'", b.name)
-	ctx, cancel := context.WithTimeout(context.Background(), pbm.WaitBackupStart)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Backup.Timeouts.StartingStatus())
 	defer cancel()
 	err = waitForBcpStatus(ctx, cn, b.name)
 	if err != nil {

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -68,7 +68,11 @@ func NewIncremental(cn *pbm.PBM, node *pbm.Node, base bool) *Backup {
 	}
 }
 
-func (b *Backup) Init(bcp *pbm.BackupCmd, opid pbm.OPID, inf *pbm.NodeInfo, balancer pbm.BalancerMode) error {
+func (b *Backup) SetTimeouts(t *pbm.BackupTimeouts) {
+	b.timeouts = t
+}
+
+func (b *Backup) Init(bcp *pbm.BackupCmd, opid pbm.OPID, inf *pbm.NodeInfo, store pbm.StorageConf, balancer pbm.BalancerMode) error {
 	ts, err := b.cn.ClusterTime()
 	if err != nil {
 		return errors.Wrap(err, "read cluster time")
@@ -80,6 +84,7 @@ func (b *Backup) Init(bcp *pbm.BackupCmd, opid pbm.OPID, inf *pbm.NodeInfo, bala
 		Name:           bcp.Name,
 		Namespaces:     bcp.Namespaces,
 		Compression:    bcp.Compression,
+		Store:          store,
 		StartTS:        time.Now().Unix(),
 		Status:         pbm.StatusStarting,
 		Replsets:       []pbm.BackupReplset{},
@@ -90,15 +95,6 @@ func (b *Backup) Init(bcp *pbm.BackupCmd, opid pbm.OPID, inf *pbm.NodeInfo, bala
 		BalancerStatus: balancer,
 		Hb:             ts,
 	}
-
-	cfg, err := b.cn.GetConfig()
-	if err == pbm.ErrStorageUndefined {
-		return errors.New("backups cannot be saved because PBM storage configuration hasn't been set yet")
-	} else if err != nil {
-		return errors.Wrap(err, "unable to get PBM config settings")
-	}
-	meta.Store = cfg.Storage
-	b.timeouts = cfg.Backup.Timeouts
 
 	ver, err := b.node.GetMongoVersion()
 	if err != nil {

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -60,7 +60,7 @@ func (b *Backup) doLogical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OPI
 	}
 
 	if inf.IsLeader() {
-		err := b.reconcileStatus(bcp.Name, opid.String(), pbm.StatusRunning, &pbm.WaitBackupStart)
+		err := b.reconcileStatus(bcp.Name, opid.String(), pbm.StatusRunning, ref(b.timeouts.StartingStatus()))
 		if err != nil {
 			if errors.Cause(err) == errConvergeTimeOut {
 				return errors.Wrap(err, "couldn't get response from all shards")

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -245,7 +245,7 @@ func (b *Backup) doPhysical(ctx context.Context, bcp *pbm.BackupCmd, opid pbm.OP
 	}
 
 	if inf.IsLeader() {
-		err := b.reconcileStatus(bcp.Name, opid.String(), pbm.StatusRunning, &pbm.WaitBackupStart)
+		err := b.reconcileStatus(bcp.Name, opid.String(), pbm.StatusRunning, ref(b.timeouts.StartingStatus()))
 		if err != nil {
 			if errors.Cause(err) == errConvergeTimeOut {
 				return errors.Wrap(err, "couldn't get response from all shards")

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -267,7 +267,9 @@ func (p *PBM) SetConfigVar(key, val string) error {
 	switch _confmap[key] {
 	case reflect.String:
 		v = val
-	case reflect.Int, reflect.Int64:
+	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+		v, err = strconv.ParseUint(val, 10, 64)
+	case reflect.Int, reflect.Int32, reflect.Int64:
 		v, err = strconv.ParseInt(val, 10, 64)
 	case reflect.Float32, reflect.Float64:
 		v, err = strconv.ParseFloat(val, 64)

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -148,8 +148,24 @@ type RestoreConf struct {
 
 type BackupConf struct {
 	Priority         map[string]float64       `bson:"priority,omitempty" json:"priority,omitempty" yaml:"priority,omitempty"`
+	Timeouts         *BackupTimeouts          `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
 	Compression      compress.CompressionType `bson:"compression,omitempty" json:"compression,omitempty" yaml:"compression,omitempty"`
 	CompressionLevel *int                     `bson:"compressionLevel,omitempty" json:"compressionLevel,omitempty" yaml:"compressionLevel,omitempty"`
+}
+
+type BackupTimeouts struct {
+	// Starting is timeout (in seconds) to wait for a backup to start.
+	Starting *uint32 `bson:"startingStatus,omitempty" json:"startingStatus,omitempty" yaml:"startingStatus,omitempty"`
+}
+
+// StartingStatus returns timeout duration for .
+// If not set or zero, returns default value (WaitBackupStart).
+func (t *BackupTimeouts) StartingStatus() time.Duration {
+	if t == nil || t.Starting == nil || *t.Starting == 0 {
+		return WaitBackupStart
+	}
+
+	return time.Duration(*t.Starting) * time.Second
 }
 
 type confMap map[string]reflect.Kind

--- a/pbm/config.go
+++ b/pbm/config.go
@@ -267,11 +267,17 @@ func (p *PBM) SetConfigVar(key, val string) error {
 	switch _confmap[key] {
 	case reflect.String:
 		v = val
-	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint32:
+		v, err = strconv.ParseUint(val, 10, 32)
+	case reflect.Uint64:
 		v, err = strconv.ParseUint(val, 10, 64)
-	case reflect.Int, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int32:
+		v, err = strconv.ParseInt(val, 10, 32)
+	case reflect.Int64:
 		v, err = strconv.ParseInt(val, 10, 64)
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		v, err = strconv.ParseFloat(val, 32)
+	case reflect.Float64:
 		v, err = strconv.ParseFloat(val, 64)
 	case reflect.Bool:
 		v, err = strconv.ParseBool(val)

--- a/pbm/pbm.go
+++ b/pbm/pbm.go
@@ -199,7 +199,6 @@ func (r RestoreCmd) String() string {
 	}
 
 	return fmt.Sprintf("name: %s, %s", r.Name, bcp)
-
 }
 
 type ReplayCmd struct {
@@ -237,7 +236,7 @@ const (
 
 var (
 	WaitActionStart = time.Second * 15
-	WaitBackupStart = WaitActionStart + PITRcheckRange*12/10
+	WaitBackupStart = WaitActionStart + PITRcheckRange*12/10 // 33 seconds
 )
 
 // OpLog represents log of started operation.

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -42,3 +42,19 @@ type Storage interface {
 	// Copy makes a copy of the src objec/file under dst name
 	Copy(src, dst string) error
 }
+
+// ParseType parses string and returns storage type
+func ParseType(s string) Type {
+	switch s {
+	case string(S3):
+		return S3
+	case string(Azure):
+		return Azure
+	case string(Filesystem):
+		return Filesystem
+	case string(BlackHole):
+		return BlackHole
+	default:
+		return Undef
+	}
+}


### PR DESCRIPTION
```yaml
backup: 
  timeouts: 
    startingStatus: 60  # wait 1 minute before marking as a failure
```
`backup.timeouts.startingStatus` is _uint32_ value. `0` (zero) means to use the default (33s)

```bash
# set 2 mins
pbm config --set backup.timeouts.startingStatus=120

# reset to the default
pbm config --set backup.timeouts.startingStatus=0
```