### PR TITLE
[PBM-1195] allow custom endpointUrl for Azure storage

### DIFF
--- a/pbm/config.go
+++ b/pbm/config.go
@@ -115,7 +115,11 @@ func (s *StorageConf) Path() string {
 			path += "/" + s.S3.Prefix
 		}
 	case storage.Azure:
-		path = fmt.Sprintf(azure.BlobURL, s.Azure.Account) + "/" + s.Azure.Container
+		epURL := s.Azure.EndpointURL
+		if epURL == "" {
+			epURL = fmt.Sprintf(azure.BlobURL, s.Azure.Account)
+		}
+		path = epURL + "/" + s.Azure.Container
 		if s.Azure.Prefix != "" {
 			path += "/" + s.Azure.Prefix
 		}

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -34,6 +34,7 @@ const (
 type Conf struct {
 	Account     string      `bson:"account" json:"account,omitempty" yaml:"account,omitempty"`
 	Container   string      `bson:"container" json:"container,omitempty" yaml:"container,omitempty"`
+	EndpointURL string      `bson:"endpointUrl" json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
 	Prefix      string      `bson:"prefix" json:"prefix,omitempty" yaml:"prefix,omitempty"`
 	Credentials Credentials `bson:"credentials" json:"-" yaml:"credentials"`
 }
@@ -258,7 +259,11 @@ func (b *Blob) client() (*azblob.Client, error) {
 	opts.Retry = policy.RetryOptions{
 		MaxRetries: defaultRetries,
 	}
-	return azblob.NewClientWithSharedKeyCredential(fmt.Sprintf(BlobURL, b.opts.Account), cred, opts)
+	epURL := b.opts.EndpointURL
+	if epURL == "" {
+		epURL = fmt.Sprintf(BlobURL, b.opts.Account)
+	}
+	return azblob.NewClientWithSharedKeyCredential(epURL, cred, opts)
 }
 
 func isNotFound(err error) bool {


### PR DESCRIPTION
add `storage.azure.endpointUrl` config field to customize default (`https://${account}.blob.core.windows.net`) Blob URL.