### PR TITLE
[linter] remove deprecated rand.Seed() calls

### DIFF
--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	stdlog "log"
-	"math/rand"
 	"os"
 	"time"
 
@@ -62,8 +61,6 @@ func main() {
 	if *sampleSizeF == 0 {
 		*sampleSizeF = 1
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	switch cmd {
 	case compressionCmd.FullCommand():

--- a/e2e-tests/cmd/pbm-test/main.go
+++ b/e2e-tests/cmd/pbm-test/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"log"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
 )
@@ -45,8 +43,6 @@ func main() {
 		bcpT = bcpPhysical
 	}
 	log.Println("Backup Type:", bcpT)
-
-	rand.Seed(time.Now().UnixNano())
 
 	typ := testTyp(os.Getenv("TESTS_TYPE"))
 	switch typ {

--- a/e2e-tests/cmd/pbm-test/run.go
+++ b/e2e-tests/cmd/pbm-test/run.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"time"
 
 	"golang.org/x/mod/semver"
 
@@ -31,7 +30,6 @@ func run(t *sharded.Cluster, typ testTyp) {
 		{"FS", "/etc/pbm/fs.yaml"},
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(remoteStg), func(i, j int) {
 		remoteStg[i], remoteStg[j] = remoteStg[j], remoteStg[i]
 	})

--- a/e2e-tests/cmd/pbm-test/run_physical.go
+++ b/e2e-tests/cmd/pbm-test/run_physical.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"math/rand"
-	"time"
 
 	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
@@ -22,7 +21,6 @@ func runPhysical(t *sharded.Cluster, typ testTyp) {
 		{"FS", "/etc/pbm/fs.yaml"},
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(remoteStg), func(i, j int) {
 		remoteStg[i], remoteStg[j] = remoteStg[j], remoteStg[i]
 	})

--- a/e2e-tests/pkg/tests/sharded/backuper.go
+++ b/e2e-tests/pkg/tests/sharded/backuper.go
@@ -66,8 +66,6 @@ func NewPitr(c *Cluster) *Pitr {
 }
 
 func (p *Pitr) Backup() {
-	rand.Seed(time.Now().UnixNano())
-
 	bcpName := p.c.LogicalBackup()
 	p.started <- struct{}{}
 	p.c.pitrOn()

--- a/e2e-tests/pkg/tests/sharded/test_bounds_check.go
+++ b/e2e-tests/pkg/tests/sharded/test_bounds_check.go
@@ -43,7 +43,6 @@ func (c *Cluster) BackupBoundsCheck(typ defs.BackupType, mongoVersion string) {
 		}
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	counters := make(map[string]scounter)
 	for name, shard := range c.shards {
 		c.bcheckClear(name, shard)

--- a/e2e-tests/pkg/tests/sharded/test_incremental_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_incremental_backup.go
@@ -21,7 +21,6 @@ func (c *Cluster) IncrementalBackup(mongoVersion string) {
 		inRange = lt
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	counters := make(map[string]scounter)
 	for name, shard := range c.shards {
 		c.bcheckClear(name, shard)

--- a/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
+++ b/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
@@ -18,8 +18,6 @@ func (c *Cluster) OplogReplay() {
 	log.Println("turn on PITR")
 	defer c.pitrOff()
 
-	rand.Seed(time.Now().UnixNano())
-
 	counters := make(map[string]shardCounter)
 	for name, cn := range c.shards {
 		c.bcheckClear(name, cn)

--- a/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
+++ b/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
@@ -21,8 +21,6 @@ func (c *Cluster) PITRbasic() {
 	log.Println("turn on PITR")
 	defer c.pitrOff()
 
-	rand.Seed(time.Now().UnixNano())
-
 	counters := make(map[string]shardCounter)
 	for name, cn := range c.shards {
 		c.bcheckClear(name, cn)

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -189,8 +189,6 @@ func peekTmpPort(current int) (int, error) {
 		try = 150
 	)
 
-	rand.Seed(time.Now().UnixNano())
-
 	for i := 0; i < try; i++ {
 		p := current + rand.Intn(rng) + 1
 		ln, err := net.Listen("tcp", ":"+strconv.Itoa(p))


### PR DESCRIPTION
[from docs](https://pkg.go.dev/math/rand#Seed):

> If Seed is not called, the generator is seeded randomly at program startup.

> Deprecated: As of Go 1.20 there is no reason to call Seed with a random value.