### PR TITLE
PBM-799: Make WriteConcern option configurable

### DIFF
--- a/pbm/connect/connect.go
+++ b/pbm/connect/connect.go
@@ -36,8 +36,8 @@ func Direct(direct bool) MongoOption {
 }
 
 // ReadConcern option sets availability guarantees for read operation.
-// For PBM typically use: [readconcern.Local()] or [readconcern.Majority()].
-// If the option is not specified the default is: [readconcern.Majority()].
+// For PBM typically use: [readconcern.Local] or [readconcern.Majority].
+// If the option is not specified the default is: [readconcern.Majority].
 func ReadConcern(readConcern *readconcern.ReadConcern) MongoOption {
 	return func(opts *options.ClientOptions) error {
 		if readConcern == nil {
@@ -49,8 +49,8 @@ func ReadConcern(readConcern *readconcern.ReadConcern) MongoOption {
 }
 
 // WriteConcern option sets level of acknowledgment for write operation.
-// For PBM typically use: [writeconcern.W1()] or [writeconcern.Majority()].
-// If the option is not specified the default is: [writeconcern.Majority()].
+// For PBM typically use: [writeconcern.W1] or [writeconcern.Majority].
+// If the option is not specified the default is: [writeconcern.Majority].
 func WriteConcern(writeConcern *writeconcern.WriteConcern) MongoOption {
 	return func(opts *options.ClientOptions) error {
 		if writeConcern == nil {
@@ -61,6 +61,7 @@ func WriteConcern(writeConcern *writeconcern.WriteConcern) MongoOption {
 	}
 }
 
+// NoRS option removes replica set name setting
 func NoRS() MongoOption {
 	return func(opts *options.ClientOptions) error {
 		opts.SetReplicaSet("")

--- a/pbm/connect/connect.go
+++ b/pbm/connect/connect.go
@@ -34,12 +34,28 @@ func Direct(direct bool) MongoOption {
 	}
 }
 
+// ReadConcern option sets availability guarantees for read operation.
+// For PBM typically use: [readconcern.Local()] or [readconcern.Majority()].
+// If the option is not specified the default is: [readconcern.Majority()].
 func ReadConcern(readConcern *readconcern.ReadConcern) MongoOption {
 	return func(opts *options.ClientOptions) error {
 		if readConcern == nil {
 			return errors.New("ReadConcern not specified")
 		}
 		opts.SetReadConcern(readConcern)
+		return nil
+	}
+}
+
+// WriteConcern option sets level of acknowledgment for write operation.
+// For PBM typically use: [writeconcern.W1()] or [writeconcern.Majority()].
+// If the option is not specified the default is: [writeconcern.Majority()].
+func WriteConcern(writeConcern *writeconcern.WriteConcern) MongoOption {
+	return func(opts *options.ClientOptions) error {
+		if writeConcern == nil {
+			return errors.New("WriteConcern not specified")
+		}
+		opts.SetWriteConcern(writeConcern)
 		return nil
 	}
 }

--- a/pbm/connect/connect.go
+++ b/pbm/connect/connect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -63,6 +64,20 @@ func WriteConcern(writeConcern *writeconcern.WriteConcern) MongoOption {
 func NoRS() MongoOption {
 	return func(opts *options.ClientOptions) error {
 		opts.SetReplicaSet("")
+		return nil
+	}
+}
+
+func ConnectTimeout(d time.Duration) MongoOption {
+	return func(opts *options.ClientOptions) error {
+		opts.SetConnectTimeout(d)
+		return nil
+	}
+}
+
+func ServerSelectionTimeout(d time.Duration) MongoOption {
+	return func(opts *options.ClientOptions) error {
+		opts.SetServerSelectionTimeout(d)
 		return nil
 	}
 }

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -23,6 +23,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
 
@@ -1674,6 +1675,7 @@ func tryConn(port int, logpath string) (*mongo.Client, error) {
 		cn, err = connect.MongoConnect(context.Background(), host,
 			connect.AppName("pbm-physical-restore"),
 			connect.Direct(true),
+			connect.WriteConcern(writeconcern.W1()),
 			connect.ConnectTimeout(time.Second*120),
 			connect.ServerSelectionTimeout(tryConnTimeout),
 		)


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1159 .
It expands #911 with the ability to specify `WriteConcern` connection string option.

Example:
```jsx
mongodb://pbmuser:secretpwd@localhost:27017/?authSource=admin&w=1
```
