### PR TITLE
PBM-1213: Backup/Restore with included Users&Roles

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -36,6 +36,7 @@ type backupOpts struct {
 	ns               string
 	wait             bool
 	externList       bool
+	usersAndRoles    bool
 }
 
 type backupOut struct {
@@ -94,6 +95,9 @@ func runBackup(
 	}
 	if len(nss) != 0 && b.typ != string(defs.LogicalBackup) {
 		return nil, errors.New("--ns flag is only allowed for logical backup")
+	}
+	if len(nss) == 0 && b.usersAndRoles {
+		return nil, errors.New("Including users and roles are only allowed for specific database (use --ns flag for selective backup)")
 	}
 
 	if err := topo.CheckTopoForBackup(ctx, conn, defs.BackupType(b.typ)); err != nil {

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -97,7 +97,7 @@ func runBackup(
 		return nil, errors.New("--ns flag is only allowed for logical backup")
 	}
 	if len(nss) == 0 && b.usersAndRoles {
-		return nil, errors.New("Including users and roles are only allowed for specific database (use --ns flag for selective backup)")
+		return nil, errors.New("Including users and roles are only allowed for selected database (use --ns flag for selective backup)")
 	}
 
 	if err := topo.CheckTopoForBackup(ctx, conn, defs.BackupType(b.typ)); err != nil {

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -99,6 +99,9 @@ func runBackup(
 	if len(nss) == 0 && b.usersAndRoles {
 		return nil, errors.New("Including users and roles are only allowed for selected database (use --ns flag for selective backup)")
 	}
+	if len(nss) >= 1 && util.CollExists(nss[0]) && b.usersAndRoles {
+		return nil, errors.New("Including users and roles are not allowed for specific collection. Use --ns='db.*' to specify the whole database instead.")
+	}
 
 	if err := topo.CheckTopoForBackup(ctx, conn, defs.BackupType(b.typ)); err != nil {
 		return nil, errors.Wrap(err, "backup pre-check")

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -140,6 +140,7 @@ func runBackup(
 			IncrBase:         b.base,
 			Name:             b.name,
 			Namespaces:       nss,
+			UsersAndRoles:    b.usersAndRoles,
 			Compression:      compression,
 			CompressionLevel: level,
 		},

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -652,10 +652,12 @@ func validateNS(b *backupOpts, nss []string) error {
 
 func validateBackupUsersAndRoles(b *backupOpts, nss []string) error {
 	if len(nss) == 0 && b.usersAndRoles {
-		return errors.New("including users and roles are only allowed for selected database (use --ns flag for selective backup)")
+		return errors.New("including users and roles are only allowed for selected database " +
+			"(use --ns flag for selective backup)")
 	}
 	if len(nss) >= 1 && util.CollExists(nss[0]) && b.usersAndRoles {
-		return errors.New("including users and roles are not allowed for specific collection. Use --ns='db.*' to backup the whole database instead.")
+		return errors.New("including users and roles are not allowed for specific collection " +
+			"(use --ns='db.*' to backup the whole database instead)")
 	}
 
 	return nil

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -172,7 +172,7 @@ func main() {
 		StringVar(&restore.pitrBase)
 	restoreCmd.Flag("ns", `Namespaces to restore (e.g. "db1.*,db2.collection2"). If not set, restore all ("*.*")`).
 		StringVar(&restore.ns)
-	restoreCmd.Flag("--with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
+	restoreCmd.Flag("with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
 		BoolVar(&restore.usersAndRoles)
 	restoreCmd.Flag("wait", "Wait for the restore to finish.").
 		Short('w').

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -172,6 +172,8 @@ func main() {
 		StringVar(&restore.pitrBase)
 	restoreCmd.Flag("ns", `Namespaces to restore (e.g. "db1.*,db2.collection2"). If not set, restore all ("*.*")`).
 		StringVar(&restore.ns)
+	restoreCmd.Flag("--with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
+		BoolVar(&restore.usersAndRoles)
 	restoreCmd.Flag("wait", "Wait for the restore to finish.").
 		Short('w').
 		BoolVar(&restore.wait)

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -129,6 +129,8 @@ func main() {
 		IntsVar(&backupOptions.compressionLevel)
 	backupCmd.Flag("ns", `Namespaces to backup (e.g. "db.*", "db.collection"). If not set, backup all ("*.*")`).
 		StringVar(&backupOptions.ns)
+	backupCmd.Flag("with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
+		BoolVar(&backupOptions.usersAndRoles)
 	backupCmd.Flag("wait", "Wait for the backup to finish").
 		Short('w').
 		BoolVar(&backupOptions.wait)

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -676,10 +676,12 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 
 func validateRestoreUsersAndRoles(o *restoreOpts, nss []string) error {
 	if len(nss) == 0 && o.usersAndRoles {
-		return errors.New("including users and roles are only allowed for selected database (use --ns flag for selective restore)")
+		return errors.New("including users and roles are only allowed for selected database " +
+			"(use --ns flag for selective restore)")
 	}
 	if len(nss) >= 1 && util.CollExists(nss[0]) && o.usersAndRoles {
-		return errors.New("including users and roles are not allowed for specific collection. Use --ns='db.*' to restore the whole database instead.")
+		return errors.New("including users and roles are not allowed for specific collection " +
+			"(use --ns='db.*' to restore the whole database instead)")
 	}
 
 	return nil

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -679,10 +679,5 @@ func validateRestoreUsersAndRoles(o *restoreOpts, nss []string) error {
 		return errors.New("including users and roles are only allowed for selected database " +
 			"(use --ns flag for selective restore)")
 	}
-	if len(nss) >= 1 && util.CollExists(nss[0]) && o.usersAndRoles {
-		return errors.New("including users and roles are not allowed for specific collection " +
-			"(use --ns='db.*' to restore the whole database instead)")
-	}
-
 	return nil
 }

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -29,15 +29,16 @@ import (
 )
 
 type restoreOpts struct {
-	bcp      string
-	pitr     string
-	pitrBase string
-	wait     bool
-	extern   bool
-	ns       string
-	rsMap    string
-	conf     string
-	ts       string
+	bcp           string
+	pitr          string
+	pitrBase      string
+	wait          bool
+	extern        bool
+	ns            string
+	usersAndRoles bool
+	rsMap         string
+	conf          string
+	ts            string
 }
 
 type restoreRet struct {
@@ -100,6 +101,9 @@ func runRestore(ctx context.Context, conn connect.Client, o *restoreOpts, outf o
 	nss, err := parseCLINSOption(o.ns)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse --ns option")
+	}
+	if len(nss) == 0 && o.usersAndRoles {
+		return nil, errors.New("Including users and roles are only allowed for selected database (use --ns flag for selective backup)")
 	}
 
 	rsMap, err := parseRSNamesMapping(o.rsMap)
@@ -315,11 +319,12 @@ func doRestore(
 	cmd := ctrl.Cmd{
 		Cmd: ctrl.CmdRestore,
 		Restore: &ctrl.RestoreCmd{
-			Name:       name,
-			BackupName: bcp,
-			Namespaces: nss,
-			RSMap:      rsMapping,
-			External:   o.extern,
+			Name:          name,
+			BackupName:    bcp,
+			Namespaces:    nss,
+			UsersAndRoles: o.usersAndRoles,
+			RSMap:         rsMapping,
+			External:      o.extern,
 		},
 	}
 	if o.pitr != "" {

--- a/pbm/archive/archive.go
+++ b/pbm/archive/archive.go
@@ -158,9 +158,10 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 	return eg.Wait()
 }
 
-// writeSpecialAuthSystemVerNS writes "$admin.system.version" namespace if such exists in the dump.
+// writeSpecialAuthSystemVerNS writes "$admin.system.version" namespace in the stream if such namespace
+// exists in the dump.
 // That namespace requires special handling because MongoRestore uses it for initial validation.
-// Therefore, it needs to be streamed down at the beginning, not in random order like all other namespaces.
+// Therefore, it needs to be streamed down beforehand, and not in the random order like all other namespaces.
 func writeSpecialAuthSystemVerNS(w io.Writer, newReader NewReader, nss []*Namespace) error {
 	for _, ns := range nss {
 		if ns.Collection == defs.SpecialCollectionAuthVersion {

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -44,7 +44,7 @@ func (b *Backup) doLogical(
 		if inf.IsConfigSrv() {
 			db = "config"
 		} else {
-			db, coll = parseNS(bcp.Namespaces[0])
+			db, coll = util.ParseNS(bcp.Namespaces[0])
 		}
 	}
 
@@ -444,17 +444,4 @@ func getNamespacesSize(ctx context.Context, m *mongo.Client, db, coll string) (m
 
 	err = eg.Wait()
 	return rv, err
-}
-
-func parseNS(ns string) (string, string) {
-	db, coll, _ := strings.Cut(ns, ".")
-
-	if db == "*" {
-		db = ""
-	}
-	if coll == "*" {
-		coll = ""
-	}
-
-	return db, coll
 }

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -128,7 +128,7 @@ func (b *Backup) doLogical(
 	if len(nssSize) == 0 {
 		dump = snapshot.DummyBackup{}
 	} else {
-		dump, err = snapshot.NewBackup(b.brief.URI, b.dumpConns, db, coll)
+		dump, err = snapshot.NewBackup(b.brief.URI, b.dumpConns, db, coll, bcp.UsersAndRoles)
 		if err != nil {
 			return errors.Wrap(err, "init mongodump options")
 		}

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -126,10 +126,11 @@ func (b BackupCmd) String() string {
 }
 
 type RestoreCmd struct {
-	Name       string            `bson:"name"`
-	BackupName string            `bson:"backupName"`
-	Namespaces []string          `bson:"nss,omitempty"`
-	RSMap      map[string]string `bson:"rsMap,omitempty"`
+	Name          string            `bson:"name"`
+	BackupName    string            `bson:"backupName"`
+	Namespaces    []string          `bson:"nss,omitempty"`
+	UsersAndRoles bool              `bson:"usersAndRoles,omitempty"`
+	RSMap         map[string]string `bson:"rsMap,omitempty"`
 
 	OplogTS primitive.Timestamp `bson:"oplogTS,omitempty"`
 

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -112,6 +112,7 @@ type BackupCmd struct {
 	Namespaces       []string                 `bson:"nss,omitempty"`
 	Compression      compress.CompressionType `bson:"compression"`
 	CompressionLevel *int                     `bson:"level,omitempty"`
+	UsersAndRoles    bool                     `bson:"usersAndRoles,omitempty"`
 }
 
 func (b BackupCmd) String() string {

--- a/pbm/defs/defs.go
+++ b/pbm/defs/defs.go
@@ -41,6 +41,8 @@ const (
 	TmpMRestoreUsersCollection = "tempUsersColl"
 	// TmpRestoreRolesCollection is temp collection that MongoRestore uses internally for restore of roles
 	TmpMRestoreRolesCollection = "tempRolesColl"
+	// MongoDump/MongoRestore special collection for users/roles versions
+	SpecialCollectionAuthVersion = "$admin.system.version"
 )
 
 const (

--- a/pbm/defs/defs.go
+++ b/pbm/defs/defs.go
@@ -36,6 +36,11 @@ const (
 	// See https://jira.percona.com/browse/PBM-425, https://jira.percona.com/browse/PBM-636
 	TmpUsersCollection = `pbmRUsers`
 	TmpRolesCollection = `pbmRRoles`
+
+	// TmpRestoreUsersCollection is temp collection that MongoRestore uses internally for restore of users
+	TmpMRestoreUsersCollection = "tempUsersColl"
+	// TmpRestoreRolesCollection is temp collection that MongoRestore uses internally for restore of roles
+	TmpMRestoreRolesCollection = "tempRolesColl"
 )
 
 const (

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -647,8 +647,7 @@ func (r *Restore) toState(ctx context.Context, status defs.Status, wait *time.Du
 	return toState(ctx, r.leadConn, status, r.name, r.nodeInfo, r.reconcileStatus, wait)
 }
 
-func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.BackupMeta,
-	nss []string, usersAndRoles bool) error {
+func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.BackupMeta, nss []string, usersAndRoles bool) error {
 	var rdr io.ReadCloser
 
 	var err error

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -731,7 +731,15 @@ func (r *Restore) RunSnapshot(
 		mapRS := util.MakeReverseRSMapFunc(r.rsMap)
 		if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 			// restore cluster specific configs only
-			return r.configsvrRestore(ctx, bcp, nss, mapRS)
+			if err := r.configsvrRestore(ctx, bcp, nss, mapRS); err != nil {
+				return err
+			}
+			if !rstOpts.restoreDBUsersAndRolesTmpColl {
+				return nil
+			}
+
+			// selective restore needs to process users and roles from the full backup,
+			// so we'll continue with selective restore
 		}
 
 		var cfg *config.Config

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1082,11 +1082,10 @@ func (r *Restore) snapshot(ctx context.Context, input io.Reader, nss []string, u
 
 	var opts *snapshot.RestoreOptions
 	if util.IsSelective(nss) {
-		db, c := util.ParseNS(nss[0])
+		db, _ := util.ParseNS(nss[0])
 		opts = &snapshot.RestoreOptions{
 			UsersAndRoles: usersAndRoles,
 			DB:            db,
-			Coll:          c,
 		}
 	} else {
 		opts = &snapshot.RestoreOptions{}

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -788,10 +788,14 @@ func (r *Restore) RunSnapshot(
 		return errors.Wrap(err, "mongorestore")
 	}
 
-	if !rstOpts.restoreDBUsersAndRolesTmpColl {
-		return nil
+	if rstOpts.restoreDBUsersAndRolesTmpColl {
+		r.restoreUsersAndRoles(ctx, nss)
 	}
 
+	return nil
+}
+
+func (r *Restore) restoreUsersAndRoles(ctx context.Context, nss []string) error {
 	r.log.Info("restoring users and roles")
 	cusr, err := topo.CurrentUser(ctx, r.nodeConn)
 	if err != nil {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1199,8 +1199,9 @@ func (r *Restore) Done(ctx context.Context) error {
 func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo, nss []string) error {
 	dbs := []string{}
 	for _, ns := range nss {
+		// ns can be "*.*" or "admin.pbmRUsers" or "admin.pbmRRoles"
 		db, _ := util.ParseNS(ns)
-		if strings.HasPrefix(db, defs.DB) {
+		if len(db) == 0 || strings.HasPrefix(db, defs.DB) {
 			continue
 		}
 		dbs = append(dbs, db)

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -761,6 +761,10 @@ func (r *Restore) loadIndexesFrom(rdr io.Reader) error {
 	}
 
 	for _, ns := range meta.Namespaces {
+		if ns.Metadata == "" {
+			// special collections ($admin.*) doesn't have metadata
+			continue
+		}
 		var md mongorestore.Metadata
 		err := bson.UnmarshalExtJSON([]byte(ns.Metadata), true, &md)
 		if err != nil {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -38,10 +38,9 @@ import (
 
 type restoreOptions struct {
 	// mongo restore flag should be used
-	restoreDbUsersAndRolesFlag bool
-
+	restoreDBUsersAndRolesFlag bool
 	// PBM restore from temp collections should be used
-	restoreDbUsersAndRolesTmpColl bool
+	restoreDBUsersAndRolesTmpColl bool
 }
 
 type Restore struct {
@@ -108,12 +107,16 @@ func (r *Restore) exit(ctx context.Context, err error) {
 	r.Close()
 }
 
-// resolveNamespaceAndRestoreOptions resolves final namespace(s) and restoring options based on the created backup and restore command.
+// resolveNamespaceAndRestoreOptions resolves final namespace(s) and restoring options based on
+// the created backup and restore commands.
 // It resolves the final result using the following input:
 // - backup namespace (should be none or single)
 // - restore namespace (can be none, single or multiple)
 // - userAndRoles option which can be turned on for selective types of backup and restore
-func resolveNamespaceAndRestoreOptions(bcpMeta *backup.BackupMeta, rstCmd *ctrl.RestoreCmd) ([]string, *restoreOptions) {
+func resolveNamespaceAndRestoreOptions(
+	bcpMeta *backup.BackupMeta,
+	rstCmd *ctrl.RestoreCmd,
+) ([]string, *restoreOptions) {
 	isSelectiveBackup := util.IsSelective(bcpMeta.Namespaces)
 	isFullBackup := !isSelectiveBackup
 
@@ -126,27 +129,27 @@ func resolveNamespaceAndRestoreOptions(bcpMeta *backup.BackupMeta, rstCmd *ctrl.
 	if isFullBackup && isFullRestore {
 		nss = []string{}
 
-		rstOpts.restoreDbUsersAndRolesFlag = false
-		rstOpts.restoreDbUsersAndRolesTmpColl = true
+		rstOpts.restoreDBUsersAndRolesFlag = false
+		rstOpts.restoreDBUsersAndRolesTmpColl = true
 	} else if isSelectiveBackup && isFullRestore {
 		nss = bcpMeta.Namespaces
 
 		// this can be enabled only for selective restore (cli validation should disallow oposit case)
-		rstOpts.restoreDbUsersAndRolesFlag = false
-		rstOpts.restoreDbUsersAndRolesTmpColl = false
+		rstOpts.restoreDBUsersAndRolesFlag = false
+		rstOpts.restoreDBUsersAndRolesTmpColl = false
 	} else if isFullBackup && isSelectiveRestore {
 		nss = rstCmd.Namespaces
 		if rstCmd.UsersAndRoles {
 			nss = append(nss, defs.DB+"."+defs.TmpUsersCollection, defs.DB+"."+defs.TmpRolesCollection)
 		}
 
-		rstOpts.restoreDbUsersAndRolesFlag = false
-		rstOpts.restoreDbUsersAndRolesTmpColl = rstCmd.UsersAndRoles
+		rstOpts.restoreDBUsersAndRolesFlag = false
+		rstOpts.restoreDBUsersAndRolesTmpColl = rstCmd.UsersAndRoles
 	} else if isSelectiveBackup && isSelectiveRestore {
 		nss = rstCmd.Namespaces
 
-		rstOpts.restoreDbUsersAndRolesFlag = rstCmd.UsersAndRoles
-		rstOpts.restoreDbUsersAndRolesTmpColl = false
+		rstOpts.restoreDBUsersAndRolesFlag = rstCmd.UsersAndRoles
+		rstOpts.restoreDBUsersAndRolesTmpColl = false
 	} else {
 		// this should never happened, but let's have restrictive default
 		nss = bcpMeta.Namespaces
@@ -783,12 +786,12 @@ func (r *Restore) RunSnapshot(
 	defer rdr.Close()
 
 	// Restore snapshot (mongorestore)
-	err = r.snapshot(ctx, rdr, nss, rstOpts.restoreDbUsersAndRolesFlag)
+	err = r.snapshot(ctx, rdr, nss, rstOpts.restoreDBUsersAndRolesFlag)
 	if err != nil {
 		return errors.Wrap(err, "mongorestore")
 	}
 
-	if !rstOpts.restoreDbUsersAndRolesTmpColl {
+	if !rstOpts.restoreDBUsersAndRolesTmpColl {
 		return nil
 	}
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -797,7 +797,7 @@ func (r *Restore) RunSnapshot(
 	}
 
 	if rstOpts.restoreDBUsersAndRolesTmpColl {
-		r.restoreUsersAndRoles(ctx, nss)
+		return r.restoreUsersAndRoles(ctx, nss)
 	}
 
 	return nil

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -281,10 +281,7 @@ func (r *Restore) PITR(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.OPID
 			"Try to set an earlier snapshot. Or leave the snapshot empty so PBM will choose one.")
 	}
 
-	nss := cmd.Namespaces
-	if len(nss) == 0 {
-		nss = bcp.Namespaces
-	}
+	nss, rstOpts := resolveNamespaceAndRestoreOptions(bcp, cmd)
 
 	if r.nodeInfo.IsLeader() {
 		err = SetOplogTimestamps(ctx, r.leadConn, r.name, 0, int64(cmd.OplogTS.T))
@@ -336,7 +333,7 @@ func (r *Restore) PITR(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.OPID
 		return err
 	}
 
-	err = r.RunSnapshot(ctx, dump, bcp, nss, &restoreOptions{})
+	err = r.RunSnapshot(ctx, dump, bcp, nss, rstOpts)
 	if err != nil {
 		return err
 	}

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -762,7 +762,7 @@ func (r *Restore) loadIndexesFrom(rdr io.Reader) error {
 
 	for _, ns := range meta.Namespaces {
 		if ns.Metadata == "" {
-			// special collections ($admin.*) doesn't have metadata
+			// for nspecial collections ($admin.*) which don't have metadata
 			continue
 		}
 		var md mongorestore.Metadata

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -647,7 +647,13 @@ func (r *Restore) toState(ctx context.Context, status defs.Status, wait *time.Du
 	return toState(ctx, r.leadConn, status, r.name, r.nodeInfo, r.reconcileStatus, wait)
 }
 
-func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.BackupMeta, nss []string, usersAndRoles bool) error {
+func (r *Restore) RunSnapshot(
+	ctx context.Context,
+	dump string,
+	bcp *backup.BackupMeta,
+	nss []string,
+	usersAndRoles bool,
+) error {
 	var rdr io.ReadCloser
 
 	var err error

--- a/pbm/snapshot/backup.go
+++ b/pbm/snapshot/backup.go
@@ -20,7 +20,7 @@ type backuper struct {
 	pm *progress.BarWriter
 }
 
-func NewBackup(curi string, conns int, d, c string) (*backuper, error) {
+func NewBackup(curi string, conns int, d, c string, usersAndRoles bool) (*backuper, error) {
 	if conns <= 0 {
 		conns = 1
 	}
@@ -60,11 +60,12 @@ func NewBackup(curi string, conns int, d, c string) (*backuper, error) {
 			// you nee to look the code to discover it.
 			Archive:                "-",
 			NumParallelCollections: conns,
+			DumpDBUsersAndRoles:    usersAndRoles,
 		},
 		InputOptions:      &mongodump.InputOptions{},
 		SessionProvider:   &db.SessionProvider{},
 		ProgressManager:   backup.pm,
-		SkipUsersAndRoles: d != "",
+		SkipUsersAndRoles: !usersAndRoles,
 	}
 	return backup, nil
 }

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -42,8 +42,8 @@ var ExcludeFromRestore = []string{
 type restorer struct{ *mongorestore.MongoRestore }
 
 type RestoreOptions struct {
-	UsersAndRoles bool
-	DB            string
+	RestoreDBUsersAndRoles bool
+	DB                     string
 }
 
 func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.ReaderFrom, error) {
@@ -71,7 +71,7 @@ func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.Reader
 
 	topts.Direct = true
 	topts.WriteConcern = writeconcern.Majority()
-	if opts.UsersAndRoles {
+	if opts.RestoreDBUsersAndRoles {
 		topts.Namespace = &options.Namespace{
 			DB: opts.DB,
 		}
@@ -90,7 +90,7 @@ func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.Reader
 	mopts.ToolOptions = topts
 	mopts.InputOptions = &mongorestore.InputOptions{
 		Archive:                "-",
-		RestoreDBUsersAndRoles: opts.UsersAndRoles,
+		RestoreDBUsersAndRoles: opts.RestoreDBUsersAndRoles,
 	}
 	mopts.OutputOptions = &mongorestore.OutputOptions{
 		BulkBufferSize:           batchSize,
@@ -113,7 +113,7 @@ func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.Reader
 	if err != nil {
 		return nil, errors.Wrap(err, "create mongorestore obj")
 	}
-	mr.SkipUsersAndRoles = !opts.UsersAndRoles
+	mr.SkipUsersAndRoles = !opts.RestoreDBUsersAndRoles
 
 	return &restorer{mr}, nil
 }

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -44,7 +44,6 @@ type restorer struct{ *mongorestore.MongoRestore }
 type RestoreOptions struct {
 	UsersAndRoles bool
 	DB            string
-	Coll          string
 }
 
 func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.ReaderFrom, error) {
@@ -74,8 +73,7 @@ func NewRestore(uri string, cfg *config.Config, opts *RestoreOptions) (io.Reader
 	topts.WriteConcern = writeconcern.Majority()
 	if opts.UsersAndRoles {
 		topts.Namespace = &options.Namespace{
-			DB:         opts.DB,
-			Collection: opts.Coll,
+			DB: opts.DB,
 		}
 	}
 

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -34,6 +34,17 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
+// CollExists ispect if collection is explicitely specified by name
+// within the namespace
+func CollExists(ns string) bool {
+	_, c := ParseNS(ns)
+	if c != "" {
+		return true
+	}
+
+	return false
+}
+
 func MakeSelectedPred(nss []string) archive.NSFilterFn {
 	if len(nss) == 0 {
 		return func(string) bool { return true }

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -20,6 +20,20 @@ func IsSelective(ids []string) bool {
 	return false
 }
 
+// ParseNS breaks namespace into database and collection parts
+func ParseNS(ns string) (string, string) {
+	db, coll, _ := strings.Cut(ns, ".")
+
+	if db == "*" {
+		db = ""
+	}
+	if coll == "*" {
+		coll = ""
+	}
+
+	return db, coll
+}
+
 func MakeSelectedPred(nss []string) archive.NSFilterFn {
 	if len(nss) == 0 {
 		return func(string) bool { return true }

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -34,8 +34,7 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
-// CollExists ispect if collection is explicitely specified by name
-// within the namespace
+// CollExists inspects if collection is specified by name within the namespace
 func CollExists(ns string) bool {
 	_, c := ParseNS(ns)
 	if c != "" {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1213

The feature expands backup & restore commands with the possibility to include database specific users and roles. Following use cases are added:
- _selective backup_ with included _users&roles_
- _selective restore_ with included _users&roles_ from _selective backup_
- _selective restore_ with included _users&roles_ from _full backup_

In existing `pbm backup` and `pbm restore` commands the new options `--with-users-and-roles` are added.

Selective backup & restore with users&roles example:
```
$ pbm backup --ns="mydb.*" --with-users-and-roles

$ pbm describe-backup --with-collections 2024-03-25T15:33:48Z  
name: "2024-03-25T15:33:48Z"
namespaces:
- mydb.*
replsets:
- name: rs0
  collections:
  - mydb.$admin.system.roles
  - mydb.$admin.system.users
  - mydb.$admin.system.version
  - mydb.c1
  - mydb.c2

$ pbm restore --ns="mydb.*" --with-users-and-roles 2024-03-25T15:33:48Z
```

Selective restore from full backup example:
```
$ pbm backup
Starting backup '2024-03-27T16:48:21Z'.......

$ pbm restore --ns="mydb1.*, mydb2.*" --with-users-and-roles 
```
