### PR TITLE
PBM-1213: Selective Logical Restore with included Users&Roles

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -170,6 +170,8 @@ func main() {
 		StringVar(&restore.pitrBase)
 	restoreCmd.Flag("ns", `Namespaces to restore (e.g. "db1.*,db2.collection2"). If not set, restore all ("*.*")`).
 		StringVar(&restore.ns)
+	restoreCmd.Flag("--with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
+		BoolVar(&restore.usersAndRoles)
 	restoreCmd.Flag("wait", "Wait for the restore to finish.").
 		Short('w').
 		BoolVar(&restore.wait)

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -170,7 +170,7 @@ func main() {
 		StringVar(&restore.pitrBase)
 	restoreCmd.Flag("ns", `Namespaces to restore (e.g. "db1.*,db2.collection2"). If not set, restore all ("*.*")`).
 		StringVar(&restore.ns)
-	restoreCmd.Flag("--with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
+	restoreCmd.Flag("with-users-and-roles", "Includes users and roles for selected database (--ns flag)").
 		BoolVar(&restore.usersAndRoles)
 	restoreCmd.Flag("wait", "Wait for the restore to finish.").
 		Short('w').

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -105,6 +105,9 @@ func runRestore(ctx context.Context, conn connect.Client, o *restoreOpts, outf o
 	if len(nss) == 0 && o.usersAndRoles {
 		return nil, errors.New("Including users and roles are only allowed for selected database (use --ns flag for selective backup)")
 	}
+	if len(nss) >= 1 && util.AnyCollExists(nss) && o.usersAndRoles {
+		return nil, errors.New("Including users and roles are not allowed for specific collection. Use --ns='db.*' to specify the whole database instead.")
+	}
 
 	rsMap, err := parseRSNamesMapping(o.rsMap)
 	if err != nil {

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -675,11 +675,11 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 }
 
 func validateRestoreUsersAndRoles(usersAndRoles bool, nss []string) error {
-	if len(nss) == 0 && usersAndRoles {
+	if util.IsSelective(nss) && usersAndRoles {
 		return errors.New("Including users and roles are only allowed for selected database " +
 			"(use --ns flag for selective backup)")
 	}
-	if len(nss) >= 1 && util.AnyCollExists(nss) && usersAndRoles {
+	if len(nss) >= 1 && util.ContainsSpecifiedColl(nss) && usersAndRoles {
 		return errors.New("Including users and roles are not allowed for specific collection. " +
 			"Use --ns='db.*' to specify the whole database instead.")
 	}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -675,7 +675,7 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 }
 
 func validateRestoreUsersAndRoles(usersAndRoles bool, nss []string) error {
-	if util.IsSelective(nss) && usersAndRoles {
+	if !util.IsSelective(nss) && usersAndRoles {
 		return errors.New("Including users and roles are only allowed for selected database " +
 			"(use --ns flag for selective backup)")
 	}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -29,15 +29,16 @@ import (
 )
 
 type restoreOpts struct {
-	bcp      string
-	pitr     string
-	pitrBase string
-	wait     bool
-	extern   bool
-	ns       string
-	rsMap    string
-	conf     string
-	ts       string
+	bcp           string
+	pitr          string
+	pitrBase      string
+	wait          bool
+	extern        bool
+	ns            string
+	usersAndRoles bool
+	rsMap         string
+	conf          string
+	ts            string
 }
 
 type restoreRet struct {
@@ -100,6 +101,9 @@ func runRestore(ctx context.Context, conn connect.Client, o *restoreOpts, outf o
 	nss, err := parseCLINSOption(o.ns)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse --ns option")
+	}
+	if len(nss) == 0 && o.usersAndRoles {
+		return nil, errors.New("Including users and roles are only allowed for selected database (use --ns flag for selective backup)")
 	}
 
 	rsMap, err := parseRSNamesMapping(o.rsMap)
@@ -315,11 +319,12 @@ func doRestore(
 	cmd := ctrl.Cmd{
 		Cmd: ctrl.CmdRestore,
 		Restore: &ctrl.RestoreCmd{
-			Name:       name,
-			BackupName: bcp,
-			Namespaces: nss,
-			RSMap:      rsMapping,
-			External:   o.extern,
+			Name:          name,
+			BackupName:    bcp,
+			Namespaces:    nss,
+			UsersAndRoles: o.usersAndRoles,
+			RSMap:         rsMapping,
+			External:      o.extern,
 		},
 	}
 	if o.pitr != "" {

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -44,7 +44,7 @@ func (b *Backup) doLogical(
 		if inf.IsConfigSrv() {
 			db = "config"
 		} else {
-			db, coll = parseNS(bcp.Namespaces[0])
+			db, coll = util.ParseNS(bcp.Namespaces[0])
 		}
 	}
 
@@ -444,17 +444,4 @@ func getNamespacesSize(ctx context.Context, m *mongo.Client, db, coll string) (m
 
 	err = eg.Wait()
 	return rv, err
-}
-
-func parseNS(ns string) (string, string) {
-	db, coll, _ := strings.Cut(ns, ".")
-
-	if db == "*" {
-		db = ""
-	}
-	if coll == "*" {
-		coll = ""
-	}
-
-	return db, coll
 }

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -126,10 +126,11 @@ func (b BackupCmd) String() string {
 }
 
 type RestoreCmd struct {
-	Name       string            `bson:"name"`
-	BackupName string            `bson:"backupName"`
-	Namespaces []string          `bson:"nss,omitempty"`
-	RSMap      map[string]string `bson:"rsMap,omitempty"`
+	Name          string            `bson:"name"`
+	BackupName    string            `bson:"backupName"`
+	Namespaces    []string          `bson:"nss,omitempty"`
+	UsersAndRoles bool              `bson:"usersAndRoles,omitempty"`
+	RSMap         map[string]string `bson:"rsMap,omitempty"`
 
 	OplogTS primitive.Timestamp `bson:"oplogTS,omitempty"`
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -724,7 +724,15 @@ func (r *Restore) RunSnapshot(
 		mapRS := util.MakeReverseRSMapFunc(r.rsMap)
 		if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 			// restore cluster specific configs only
-			return r.configsvrRestore(ctx, bcp, nss, mapRS)
+			if err := r.configsvrRestore(ctx, bcp, nss, mapRS); err != nil {
+				return err
+			}
+			if !rstOpts.restoreDBUsersAndRolesTmpColl {
+				return nil
+			}
+
+			// selective restore needs to process users and roles from the full backup,
+			// so we'll continue with selective restore
 		}
 
 		var cfg *config.Config

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -106,9 +106,6 @@ func (r *Restore) exit(ctx context.Context, err error) {
 // resolveNamespace resolves final namespace(s) based on the backup namespace,
 // restore namespace, and option whether we should restore users&roles
 func resolveNamespace(nssBackup, nssRestore []string, usingUsersAndRoles bool) []string {
-	if util.IsSelective(nssBackup) {
-		return nssBackup
-	}
 	if util.IsSelective(nssRestore) {
 		if usingUsersAndRoles {
 			var nss []string
@@ -121,6 +118,9 @@ func resolveNamespace(nssBackup, nssRestore []string, usingUsersAndRoles bool) [
 		}
 
 		return nssRestore
+	}
+	if util.IsSelective(nssBackup) {
+		return nssBackup
 	}
 
 	return nssBackup

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -781,10 +781,16 @@ func (r *Restore) RunSnapshot(
 		return errors.Wrap(err, "mongorestore")
 	}
 
-	if !rstOpts.restoreDBUsersAndRolesTmpColl {
-		return nil
+	if rstOpts.restoreDBUsersAndRolesTmpColl {
+		if err := r.restoreUsersAndRoles(ctx, nss); err != nil {
+			return errors.Wrap(err, "restoring users and roles")
+		}
 	}
 
+	return nil
+}
+
+func (r *Restore) restoreUsersAndRoles(ctx context.Context, nss []string) error {
 	r.log.Info("restoring users and roles")
 	cusr, err := topo.CurrentUser(ctx, r.nodeConn)
 	if err != nil {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -64,6 +64,11 @@ type Restore struct {
 	indexCatalog *idx.IndexCatalog
 }
 
+type restoreOptions struct {
+	// PBM restore from temp collections (pbmRUsers/pbmRRoles)should be used
+	restoreDBUsersAndRolesTmpColl bool
+}
+
 // New creates a new restore object
 func New(leadConn connect.Client, nodeConn *mongo.Client, brief topo.NodeBrief, rsMap map[string]string) *Restore {
 	if rsMap == nil {
@@ -100,6 +105,52 @@ func (r *Restore) exit(ctx context.Context, err error) {
 	r.Close()
 }
 
+// resolveNamespaceAndRestoreOptions resolves final namespace(s) and restoring options
+// based on the created backup and restore command.
+// It resolves the final result using the following input:
+// - backup namespace (should be none or single)
+// - restore namespace (can be none, single or multiple)
+// - userAndRoles option which can be turned on for selective types of backup and restore
+func resolveNamespaceAndRestoreOptions(
+	bcpMeta *backup.BackupMeta,
+	rstCmd *ctrl.RestoreCmd,
+) ([]string, *restoreOptions) {
+	isSelectiveBackup := util.IsSelective(bcpMeta.Namespaces)
+	isFullBackup := !isSelectiveBackup
+
+	isSelectiveRestore := util.IsSelective(rstCmd.Namespaces)
+	isFullRestore := !isSelectiveRestore
+
+	rstOpts := &restoreOptions{}
+
+	var nss []string
+	if isFullBackup && isFullRestore {
+		nss = []string{}
+
+		rstOpts.restoreDBUsersAndRolesTmpColl = true
+	} else if isSelectiveBackup && isFullRestore {
+		nss = bcpMeta.Namespaces
+
+		rstOpts.restoreDBUsersAndRolesTmpColl = false
+	} else if isFullBackup && isSelectiveRestore {
+		nss = rstCmd.Namespaces
+		if rstCmd.UsersAndRoles {
+			nss = append(nss, defs.DB+"."+defs.TmpUsersCollection, defs.DB+"."+defs.TmpRolesCollection)
+		}
+
+		rstOpts.restoreDBUsersAndRolesTmpColl = rstCmd.UsersAndRoles
+	} else if isSelectiveBackup && isSelectiveRestore {
+		nss = rstCmd.Namespaces
+
+		rstOpts.restoreDBUsersAndRolesTmpColl = false
+	} else {
+		// this should never happened, but let's have restrictive default
+		nss = bcpMeta.Namespaces
+	}
+
+	return nss, rstOpts
+}
+
 // Snapshot do the snapshot's (mongo dump) restore
 //
 //nolint:nonamedreturns
@@ -116,10 +167,7 @@ func (r *Restore) Snapshot(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.
 		return err
 	}
 
-	nss := cmd.Namespaces
-	if !util.IsSelective(nss) {
-		nss = bcp.Namespaces
-	}
+	nss, rstOpts := resolveNamespaceAndRestoreOptions(bcp, cmd)
 
 	err = setRestoreBackup(ctx, r.leadConn, r.name, cmd.BackupName, nss)
 	if err != nil {
@@ -150,7 +198,7 @@ func (r *Restore) Snapshot(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.
 		return err
 	}
 
-	err = r.RunSnapshot(ctx, dump, bcp, nss)
+	err = r.RunSnapshot(ctx, dump, bcp, nss, rstOpts)
 	if err != nil {
 		return err
 	}
@@ -226,10 +274,7 @@ func (r *Restore) PITR(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.OPID
 			"Try to set an earlier snapshot. Or leave the snapshot empty so PBM will choose one.")
 	}
 
-	nss := cmd.Namespaces
-	if len(nss) == 0 {
-		nss = bcp.Namespaces
-	}
+	nss, rstOpts := resolveNamespaceAndRestoreOptions(bcp, cmd)
 
 	if r.nodeInfo.IsLeader() {
 		err = SetOplogTimestamps(ctx, r.leadConn, r.name, 0, int64(cmd.OplogTS.T))
@@ -281,7 +326,7 @@ func (r *Restore) PITR(ctx context.Context, cmd *ctrl.RestoreCmd, opid ctrl.OPID
 		return err
 	}
 
-	err = r.RunSnapshot(ctx, dump, bcp, nss)
+	err = r.RunSnapshot(ctx, dump, bcp, nss, rstOpts)
 	if err != nil {
 		return err
 	}
@@ -647,7 +692,13 @@ func (r *Restore) toState(ctx context.Context, status defs.Status, wait *time.Du
 	return toState(ctx, r.leadConn, status, r.name, r.nodeInfo, r.reconcileStatus, wait)
 }
 
-func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.BackupMeta, nss []string) error {
+func (r *Restore) RunSnapshot(
+	ctx context.Context,
+	dump string,
+	bcp *backup.BackupMeta,
+	nss []string,
+	rstOpts *restoreOptions,
+) error {
 	var rdr io.ReadCloser
 
 	var err error
@@ -730,7 +781,7 @@ func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.Back
 		return errors.Wrap(err, "mongorestore")
 	}
 
-	if util.IsSelective(nss) {
+	if !rstOpts.restoreDBUsersAndRolesTmpColl {
 		return nil
 	}
 
@@ -740,7 +791,7 @@ func (r *Restore) RunSnapshot(ctx context.Context, dump string, bcp *backup.Back
 		return errors.Wrap(err, "get current user")
 	}
 
-	err = r.swapUsers(ctx, cusr)
+	err = r.swapUsers(ctx, cusr, nss)
 	if err != nil {
 		return errors.Wrap(err, "swap users 'n' roles")
 	}
@@ -1123,7 +1174,17 @@ func (r *Restore) Done(ctx context.Context) error {
 	return nil
 }
 
-func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo) error {
+func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo, nss []string) error {
+	dbs := []string{}
+	for _, ns := range nss {
+		// ns can be "*.*" or "admin.pbmRUsers" or "admin.pbmRRoles"
+		db, _ := util.ParseNS(ns)
+		if len(db) == 0 || strings.HasPrefix(db, defs.DB) {
+			continue
+		}
+		dbs = append(dbs, db)
+	}
+
 	rolesC := r.nodeConn.Database("admin").Collection("system.roles")
 
 	eroles := []string{}
@@ -1131,14 +1192,21 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo) error {
 		eroles = append(eroles, r.DB+"."+r.Role)
 	}
 
+	rolesFilter := bson.M{
+		"_id": bson.M{"$nin": eroles},
+	}
+	if len(dbs) > 0 {
+		rolesFilter["db"] = bson.M{"$in": dbs}
+	}
+
 	curr, err := r.nodeConn.Database(defs.DB).Collection(defs.TmpRolesCollection).
-		Find(ctx, bson.M{"_id": bson.M{"$nin": eroles}})
+		Find(ctx, rolesFilter)
 	if err != nil {
 		return errors.Wrap(err, "create cursor for tmpRoles")
 	}
 	defer curr.Close(ctx)
 
-	_, err = rolesC.DeleteMany(ctx, bson.M{"_id": bson.M{"$nin": eroles}})
+	_, err = rolesC.DeleteMany(ctx, rolesFilter)
 	if err != nil {
 		return errors.Wrap(err, "delete current roles")
 	}
@@ -1159,15 +1227,21 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo) error {
 	if len(exclude.Users) > 0 {
 		user = exclude.Users[0].DB + "." + exclude.Users[0].User
 	}
+	filterUsers := bson.M{
+		"_id": bson.M{"$ne": user},
+	}
+	if len(dbs) > 0 {
+		filterUsers["db"] = bson.M{"$in": dbs}
+	}
 	cur, err := r.nodeConn.Database(defs.DB).Collection(defs.TmpUsersCollection).
-		Find(ctx, bson.M{"_id": bson.M{"$ne": user}})
+		Find(ctx, filterUsers)
 	if err != nil {
 		return errors.Wrap(err, "create cursor for tmpUsers")
 	}
 	defer cur.Close(ctx)
 
 	usersC := r.nodeConn.Database("admin").Collection("system.users")
-	_, err = usersC.DeleteMany(ctx, bson.M{"_id": bson.M{"$ne": user}})
+	_, err = usersC.DeleteMany(ctx, filterUsers)
 	if err != nil {
 		return errors.Wrap(err, "delete current users")
 	}

--- a/pbm/restore/logical_test.go
+++ b/pbm/restore/logical_test.go
@@ -1,0 +1,160 @@
+package restore
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveNamespace(t *testing.T) {
+	checkNS := func(t testing.TB, got, want []string) {
+		t.Helper()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got=%v, want=%v", got, want)
+		}
+	}
+
+	t.Run("without users&roles", func(t *testing.T) {
+		testCases := []struct {
+			desc       string
+			nssBackup  []string
+			nssRestore []string
+			want       []string
+		}{
+			{
+				desc:       "full backup -> full restore",
+				nssBackup:  []string{},
+				nssRestore: []string{},
+				want:       []string{},
+			},
+			{
+				desc:       "full backup -> selective restore",
+				nssBackup:  []string{},
+				nssRestore: []string{"d.c"},
+				want:       []string{"d.c"},
+			},
+			{
+				desc:       "selective backup -> full restore",
+				nssBackup:  []string{"d.c"},
+				nssRestore: []string{},
+				want:       []string{"d.c"},
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				got := resolveNamespace(tC.nssBackup, tC.nssRestore, false)
+				checkNS(t, got, tC.want)
+			})
+		}
+	})
+
+	t.Run("with users&roles", func(t *testing.T) {
+		testCases := []struct {
+			desc       string
+			nssBackup  []string
+			nssRestore []string
+			want       []string
+		}{
+			{
+				desc:       "full backup -> full restore",
+				nssBackup:  []string{},
+				nssRestore: []string{},
+				want:       []string{},
+			},
+			{
+				desc:       "full backup -> selective restore",
+				nssBackup:  []string{},
+				nssRestore: []string{"d.c"},
+				want:       []string{"d.c", "admin.pbmRUsers", "admin.pbmRRoles"},
+			},
+			{
+				desc:       "selective backup -> full restore",
+				nssBackup:  []string{"d.c"},
+				nssRestore: []string{},
+				want:       []string{"d.c"},
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				got := resolveNamespace(tC.nssBackup, tC.nssRestore, true)
+				checkNS(t, got, tC.want)
+			})
+		}
+	})
+}
+
+func TestShouldRestoreUsersAndRoles(t *testing.T) {
+	checkOpt := func(t testing.TB, got, want restoreUsersAndRolesOption) {
+		t.Helper()
+		if got != want {
+			t.Errorf("invalid restoreUsersAndRolesOption got=%t, want=%t", got, want)
+		}
+	}
+
+	t.Run("without users&roles", func(t *testing.T) {
+		testCases := []struct {
+			desc       string
+			nssBackup  []string
+			nssRestore []string
+			wantOpt    restoreUsersAndRolesOption
+		}{
+			{
+				desc:       "full backup -> full restore",
+				nssBackup:  []string{},
+				nssRestore: []string{},
+				wantOpt:    true,
+			},
+			{
+				desc:       "full backup -> selective restore",
+				nssBackup:  []string{},
+				nssRestore: []string{"d.c"},
+				wantOpt:    false,
+			},
+			{
+				desc:       "selective backup -> full restore",
+				nssBackup:  []string{"d.c"},
+				nssRestore: []string{},
+				wantOpt:    false,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				gotOpt := shouldRestoreUsersAndRoles(tC.nssBackup, tC.nssRestore, false)
+				checkOpt(t, gotOpt, tC.wantOpt)
+			})
+		}
+	})
+
+	t.Run("with users&roles", func(t *testing.T) {
+		testCases := []struct {
+			desc       string
+			nssBackup  []string
+			nssRestore []string
+			wantOpt    restoreUsersAndRolesOption
+		}{
+			{
+				desc:       "full backup -> full restore",
+				nssBackup:  []string{},
+				nssRestore: []string{},
+				wantOpt:    true,
+			},
+			{
+				desc:       "full backup -> selective restore",
+				nssBackup:  []string{},
+				nssRestore: []string{"d.c"},
+				wantOpt:    true,
+			},
+			{
+				desc:       "selective backup -> full restore",
+				nssBackup:  []string{"d.c"},
+				nssRestore: []string{},
+				wantOpt:    false,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				gotOpt := shouldRestoreUsersAndRoles(tC.nssBackup, tC.nssRestore, true)
+				checkOpt(t, gotOpt, tC.wantOpt)
+			})
+		}
+	})
+}

--- a/pbm/restore/logical_test.go
+++ b/pbm/restore/logical_test.go
@@ -38,6 +38,12 @@ func TestResolveNamespace(t *testing.T) {
 				nssRestore: []string{},
 				want:       []string{"d.c"},
 			},
+			{
+				desc:       "selective backup -> selective restore",
+				nssBackup:  []string{"d.*"},
+				nssRestore: []string{"d.c"},
+				want:       []string{"d.c"},
+			},
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -34,7 +34,7 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
-// CollExists ispects if collection is explicitely specified by name
+// CollExists ispects if collection is explicitly specified by name
 // within the namespace
 func CollExists(ns string) bool {
 	_, c := ParseNS(ns)

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -20,6 +20,20 @@ func IsSelective(ids []string) bool {
 	return false
 }
 
+// ParseNS breaks namespace into database and collection parts
+func ParseNS(ns string) (string, string) {
+	db, coll, _ := strings.Cut(ns, ".")
+
+	if db == "*" {
+		db = ""
+	}
+	if coll == "*" {
+		coll = ""
+	}
+
+	return db, coll
+}
+
 func MakeSelectedPred(nss []string) archive.NSFilterFn {
 	if len(nss) == 0 {
 		return func(string) bool { return true }

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -23,6 +23,8 @@ func IsSelective(ids []string) bool {
 // ParseNS breaks namespace into database and collection parts
 func ParseNS(ns string) (string, string) {
 	db, coll, _ := strings.Cut(ns, ".")
+	db = strings.TrimSpace(db)
+	coll = strings.TrimSpace(coll)
 
 	if db == "*" {
 		db = ""

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -34,6 +34,28 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
+// CollExists ispects if collection is explicitely specified by name
+// within the namespace
+func CollExists(ns string) bool {
+	_, c := ParseNS(ns)
+	if c != "" {
+		return true
+	}
+
+	return false
+}
+
+// AnyCollExists inspects if any collection exists for multi-ns
+func AnyCollExists(nss []string) bool {
+	for _, ns := range nss {
+		if CollExists(ns) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func MakeSelectedPred(nss []string) archive.NSFilterFn {
 	if len(nss) == 0 {
 		return func(string) bool { return true }

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/hex"
+	"slices"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,8 +24,6 @@ func IsSelective(ids []string) bool {
 // ParseNS breaks namespace into database and collection parts
 func ParseNS(ns string) (string, string) {
 	db, coll, _ := strings.Cut(ns, ".")
-	db = strings.TrimSpace(db)
-	coll = strings.TrimSpace(coll)
 
 	if db == "*" {
 		db = ""
@@ -36,26 +35,18 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
-// CollExists inspects if collection is explicitly specified by name
+// ContainsColl inspects if collection is explicitly specified by name
 // within the namespace
-func CollExists(ns string) bool {
+func ContainsColl(ns string) bool {
 	_, c := ParseNS(ns)
-	if c != "" {
-		return true
-	}
-
-	return false
+	return c != ""
 }
 
-// AnyCollExists inspects if any collection exists for multi-ns
-func AnyCollExists(nss []string) bool {
-	for _, ns := range nss {
-		if CollExists(ns) {
-			return true
-		}
-	}
-
-	return false
+// ContainsSpecifiedColl inspects if any collection exists for multi-ns
+func ContainsSpecifiedColl(nss []string) bool {
+	return slices.ContainsFunc(nss, func(ns string) bool {
+		return ContainsColl(ns)
+	})
 }
 
 func MakeSelectedPred(nss []string) archive.NSFilterFn {

--- a/pbm/util/sel.go
+++ b/pbm/util/sel.go
@@ -36,7 +36,7 @@ func ParseNS(ns string) (string, string) {
 	return db, coll
 }
 
-// CollExists ispects if collection is explicitly specified by name
+// CollExists inspects if collection is explicitly specified by name
 // within the namespace
 func CollExists(ns string) bool {
 	_, c := ParseNS(ns)

--- a/pbm/util/sel_test.go
+++ b/pbm/util/sel_test.go
@@ -87,8 +87,8 @@ func TestCollExists(t *testing.T) {
 	}{
 		{desc: "collection is defined", ns: "d.c", res: true},
 		{desc: "collection is wild-carded", ns: "d.*", res: false},
-		{desc: "namespace is wild-carded", ns: "d.*", res: false},
-		{desc: "namespace is empty", ns: "d.*", res: false},
+		{desc: "namespace is wild-carded", ns: "*.*", res: false},
+		{desc: "namespace is empty", ns: "", res: false},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {

--- a/pbm/util/sel_test.go
+++ b/pbm/util/sel_test.go
@@ -45,3 +45,75 @@ func TestSelectedPred(t *testing.T) {
 		}
 	}
 }
+
+func TestParseNS(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		ns      string
+		resDB   string
+		resColl string
+	}{
+		{desc: "wild-card namespace", ns: "*.*", resDB: "", resColl: ""},
+		{desc: "explicit db & explicit collection namespace", ns: "D.C", resDB: "D", resColl: "C"},
+		{desc: "only db specified", ns: "D", resDB: "D", resColl: ""},
+		{desc: "only db specified, collection with wild-card", ns: "D.*", resDB: "D", resColl: ""},
+		{desc: "only db specified, collection is empty", ns: "D.", resDB: "D", resColl: ""},
+		{desc: "only db specified, collection is whitespace", ns: "D.   ", resDB: "D", resColl: ""},
+		{desc: "only db with whitespaces specified, collection is whitespace", ns: " D    ", resDB: "D", resColl: ""},
+		{desc: "only collection specified", ns: ".C", resDB: "", resColl: "C"},
+		{desc: "only collection specified, database with wild-card", ns: "*.C", resDB: "", resColl: "C"},
+		{desc: "only collection specified, collection is empty", ns: ".C", resDB: "", resColl: "C"},
+		{desc: "only collection specified, db is whitespace", ns: "  .C", resDB: "", resColl: "C"},
+		{desc: "only collection with whitespaces specified, database is whitespace", ns: " . C    ", resDB: "", resColl: "C"},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			resDB, resColl := util.ParseNS(tC.ns)
+			if resDB != tC.resDB {
+				t.Errorf("expected database: %q, got: %q", tC.resDB, resDB)
+			}
+			if resColl != tC.resColl {
+				t.Errorf("expected collection: %q, got: %q", tC.resColl, resColl)
+			}
+		})
+	}
+}
+
+func TestCollExists(t *testing.T) {
+	testCases := []struct {
+		desc string
+		ns   string
+		res  bool
+	}{
+		{desc: "collection is defined", ns: "d.c", res: true},
+		{desc: "collection is wild-carded", ns: "d.*", res: false},
+		{desc: "namespace is wild-carded", ns: "d.*", res: false},
+		{desc: "namespace is empty", ns: "d.*", res: false},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			if res := util.CollExists(tC.ns); res != tC.res {
+				t.Errorf("expected: %t, got: %t", tC.res, res)
+			}
+		})
+	}
+}
+
+func TestAnyCollExists(t *testing.T) {
+	testCases := []struct {
+		desc string
+		ns   []string
+		res  bool
+	}{
+		{desc: "collection is defined once", ns: []string{"d.*", "d.c"}, res: true},
+		{desc: "all collections are wild-carded", ns: []string{"d1.*", "d2.*", "d3.*"}, res: false},
+		{desc: "all collections are not specified", ns: []string{"d1.*", "d2", "d3."}, res: false},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			if res := util.AnyCollExists(tC.ns); res != tC.res {
+				t.Errorf("expected: %t, got: %t", tC.res, res)
+			}
+		})
+	}
+}

--- a/pbm/util/sel_test.go
+++ b/pbm/util/sel_test.go
@@ -58,13 +58,13 @@ func TestParseNS(t *testing.T) {
 		{desc: "only db specified", ns: "D", resDB: "D", resColl: ""},
 		{desc: "only db specified, collection with wild-card", ns: "D.*", resDB: "D", resColl: ""},
 		{desc: "only db specified, collection is empty", ns: "D.", resDB: "D", resColl: ""},
-		{desc: "only db specified, collection is whitespace", ns: "D.   ", resDB: "D", resColl: ""},
-		{desc: "only db with whitespaces specified, collection is whitespace", ns: " D    ", resDB: "D", resColl: ""},
+		{desc: "only db specified, collection is whitespace", ns: "D. ", resDB: "D", resColl: " "},
+		{desc: "only db with whitespaces specified, collection is whitespace", ns: " D ", resDB: " D ", resColl: ""},
 		{desc: "only collection specified", ns: ".C", resDB: "", resColl: "C"},
 		{desc: "only collection specified, database with wild-card", ns: "*.C", resDB: "", resColl: "C"},
 		{desc: "only collection specified, collection is empty", ns: ".C", resDB: "", resColl: "C"},
-		{desc: "only collection specified, db is whitespace", ns: "  .C", resDB: "", resColl: "C"},
-		{desc: "only collection with whitespaces specified, database is whitespace", ns: " . C    ", resDB: "", resColl: "C"},
+		{desc: "only collection specified, db is whitespace", ns: " .C", resDB: " ", resColl: "C"},
+		{desc: "only collection with whitespaces specified, database is whitespace", ns: " . C ", resDB: " ", resColl: " C "},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestParseNS(t *testing.T) {
 	}
 }
 
-func TestCollExists(t *testing.T) {
+func TestContainsColl(t *testing.T) {
 	testCases := []struct {
 		desc string
 		ns   string
@@ -92,14 +92,14 @@ func TestCollExists(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			if res := util.CollExists(tC.ns); res != tC.res {
+			if res := util.ContainsColl(tC.ns); res != tC.res {
 				t.Errorf("expected: %t, got: %t", tC.res, res)
 			}
 		})
 	}
 }
 
-func TestAnyCollExists(t *testing.T) {
+func TestContainsSpecifiedColl(t *testing.T) {
 	testCases := []struct {
 		desc string
 		ns   []string
@@ -111,7 +111,7 @@ func TestAnyCollExists(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			if res := util.AnyCollExists(tC.ns); res != tC.res {
+			if res := util.ContainsSpecifiedColl(tC.ns); res != tC.res {
 				t.Errorf("expected: %t, got: %t", tC.res, res)
 			}
 		})


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1213

The feature expands logical restore command with the possibility to include database specific users and roles. 

When restoring specific database(s) from the full backup, it is possible to specify new `--with-users-and-roles` flag, and in that case database specific users&roles will be restored together with db related data.

Selective restore from full backup example:
```
$ pbm backup
Starting backup '2024-03-27T16:48:21Z'.......

$ pbm restore --ns="mydb1.*, mydb2.*" --with-users-and-roles 
```
