### PR TITLE
PBM-1258: Fix for unnecessary resync operation when applied config's storage params are the same

### DIFF
--- a/cmd/pbm/config.go
+++ b/cmd/pbm/config.go
@@ -131,8 +131,6 @@ func runConfig(ctx context.Context, conn connect.Client, pbm sdk.Client, c *conf
 			return nil, errors.Wrap(err, "unable to set config: write to db")
 		}
 
-		// provider value may differ as it set automatically after config parsing
-		oldCfg.Storage.S3.Provider = newCfg.Storage.S3.Provider
 		// resync storage only if Storage options have changed
 		if !reflect.DeepEqual(newCfg.Storage, oldCfg.Storage) {
 			if _, err := pbm.SyncFromStorage(ctx); err != nil {

--- a/cmd/pbm/config.go
+++ b/cmd/pbm/config.go
@@ -127,7 +127,7 @@ func runConfig(ctx context.Context, conn connect.Client, pbm sdk.Client, c *conf
 			oldCfg = &config.Config{}
 		}
 
-		if err := config.SetConfig(ctx, conn, newCfg); err != nil {
+		if err := config.SetConfig(ctx, conn, &newCfg); err != nil {
 			return nil, errors.Wrap(err, "unable to set config: write to db")
 		}
 

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -263,7 +263,10 @@ func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {
 	return cfg, nil
 }
 
-func SetConfig(ctx context.Context, m connect.Client, cfg Config) error {
+// SetConfig stores config doc within the database.
+// It also applies default storage parameters depending on the type of storage
+// and assigns those possible default values to the cfg parameter.
+func SetConfig(ctx context.Context, m connect.Client, cfg *Config) error {
 	switch cfg.Storage.Type {
 	case storage.S3:
 		err := cfg.Storage.S3.Cast()
@@ -299,7 +302,7 @@ func SetConfig(ctx context.Context, m connect.Client, cfg Config) error {
 	_, err = m.ConfigCollection().UpdateOne(
 		ctx,
 		bson.D{},
-		bson.M{"$set": cfg},
+		bson.M{"$set": *cfg},
 		options.Update().SetUpsert(true),
 	)
 	return errors.Wrap(err, "mongo defs.ConfigCollection UpdateOne")

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -79,7 +79,7 @@ func (c *clientImpl) GetConfig(ctx context.Context) (*Config, error) {
 }
 
 func (c *clientImpl) SetConfig(ctx context.Context, cfg Config) (CommandID, error) {
-	return NoOpID, config.SetConfig(ctx, c.conn, cfg)
+	return NoOpID, config.SetConfig(ctx, c.conn, &cfg)
 }
 
 func (c *clientImpl) GetAllBackups(ctx context.Context) ([]BackupMetadata, error) {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1258 