### PR TITLE
PBM-1309: PBM can't be started if RS doesn't have a majority

### DIFF
--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -909,7 +909,7 @@ func (r *Restore) updateRouterConfig(ctx context.Context) error {
 		}
 	}
 
-	res := r.leadConn.AdminCommand(ctx, primitive.M{"flushRouterConfig": 1})
+	res := r.leadConn.AdminCommand(ctx, bson.D{{"flushRouterConfig", 1}})
 	return errors.Wrap(res.Err(), "flushRouterConfig")
 }
 


### PR DESCRIPTION
Fix for https://perconadev.atlassian.net/browse/PBM-1309

In this bug, pbm-agent wan't able to create (try to create) pbm related collections after restart of the agent in case when cluster doesn't have majority of data members.
Root cause is that Database.RunCommand api call doesn't apply read/write concerns specified in connection string (see documentation [here](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo@v1.15.0#Database.RunCommandCursor:~:text=This%20function%20does%20not%20obey%20the%20Database%27s%20readConcern%20or%20writeConcern.%20A%20user%20must%20supply%20these%20values%20manually%20in%20the%20user%2Dprovided%20runCommand%20parameter.)). This PR applies read/write concern from connection string to particular command (only 'create' command for now).
