### PR TITLE
fix go1.22 download link in packaging

### DIFF
--- a/e2e-tests/docker/pbm.dockerfile
+++ b/e2e-tests/docker/pbm.dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /data/db
 COPY --from=mongo_image /bin/mongod /bin/
 RUN dnf install epel-release && dnf update && dnf install make gcc krb5-devel iproute-tc libfaketime
 
-RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz && \
+RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go1.22.2.linux-amd64.tar.gz && \
 rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/golang.tar.gz && rm /tmp/golang.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/e2e-tests/docker/tests.dockerfile
+++ b/e2e-tests/docker/tests.dockerfile
@@ -2,7 +2,7 @@ FROM oraclelinux:8 AS base-build
 WORKDIR /build
 RUN dnf update && dnf install make gcc krb5-devel
 
-RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz && \
+RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go1.22.2.linux-amd64.tar.gz && \
 rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/golang.tar.gz && rm /tmp/golang.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/packaging/scripts/mongodb-backup_builder.sh
+++ b/packaging/scripts/mongodb-backup_builder.sh
@@ -141,8 +141,8 @@ install_golang() {
     elif [ x"$ARCH" = "xaarch64" ]; then
         GO_ARCH="arm64"
     fi
-    wget https://golang.org/dl/go1.22.linux-${GO_ARCH}.tar.gz -O /tmp/golang1.22.tar.gz
-    tar --transform=s,go,go1.22, -zxf /tmp/golang1.22.tar.gz
+    wget https://go.dev/dl/go1.22.2.linux-${GO_ARCH}.tar.gz -O /tmp/go1.22.tar.gz
+    tar --transform=s,go,go1.22, -zxf /tmp/go1.22.tar.gz
     rm -rf /usr/local/go*
     mv go1.22 /usr/local/
     ln -s /usr/local/go1.22 /usr/local/go


### PR DESCRIPTION
Since golang 1.20, the exact version should be used in the download link (go1.20.0 instead of go1.20)