### PR TITLE
PBM-1311: PBM fails to do PITR slicing when RS doesn't have a majority

### DIFF
--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -89,6 +89,7 @@ func (b *Backup) doLogical(
 
 	stopOplogSlicer := startOplogSlicer(ctx,
 		b.nodeConn,
+		b.leadConn.MongoOptions().WriteConcern,
 		b.SlicerInterval(),
 		rsMeta.FirstWriteTS,
 		func(ctx context.Context, w io.WriterTo, from, till primitive.Timestamp) (int64, error) {

--- a/pbm/slicer/slicer.go
+++ b/pbm/slicer/slicer.go
@@ -392,7 +392,11 @@ func (s *Slicer) Stream(
 			return OpMovedError{ld.Node}
 		}
 		if sliceTo.IsZero() {
-			sliceTo, err = topo.GetLastWrite(ctx, s.node, true)
+			majority, err := topo.IsWriteMajorityRequested(ctx, s.node, s.leadClient.MongoOptions().WriteConcern)
+			if err != nil {
+				return errors.Wrap(err, "define requested majority")
+			}
+			sliceTo, err = topo.GetLastWrite(ctx, s.node, majority)
 			if err != nil {
 				return errors.Wrap(err, "define last write timestamp")
 			}

--- a/pbm/topo/status.go
+++ b/pbm/topo/status.go
@@ -54,6 +54,7 @@ type ReplsetStatus struct {
 	ClusterTime             *ClusterTime         `bson:"$clusterTime,omitempty" json:"$clusterTime,omitempty"`
 	ConfigServerState       *ConfigServerState   `bson:"$configServerState,omitempty" json:"$configServerState,omitempty"`
 	OperationTime           *primitive.Timestamp `bson:"operationTime,omitempty" json:"operationTime,omitempty"`
+	WriteMajorityCount      int                  `bson:"writeMajorityCount,omitempty" json:"writeMajorityCount,omitempty"`
 }
 
 func CurrentUser(ctx context.Context, m *mongo.Client) (*AuthInfo, error) {


### PR DESCRIPTION
Fix for https://perconadev.atlassian.net/browse/PBM-1311

When doing PITR slicing PBM relies on `majorityOpTime` to define slicing intervals:
```
db.isMaster()
{
  ...
  lastWrite: {
    opTime: { ts: Timestamp({ t: 1715079500, i: 1 }), t: Long('1') },
    lastWriteDate: ISODate('2024-05-07T10:58:20.000Z'),
    majorityOpTime: { ts: Timestamp({ t: 1715079500, i: 1 }), t: Long('1') },
    majorityWriteDate: ISODate('2024-05-07T10:58:20.000Z')
  },
 ...
```
When cluster doesn't have majority `majorityOpTime` is stale,  so it contains last value when majority was present.

This PR fixes that using approach: when write concern is below majority, PBM uses `opTime` instead of `majorityOpTime`.
