### PR TITLE
PBM-1308: Improve read/write concern validation

### DIFF
--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -103,6 +103,9 @@ func (a *Agent) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	logger.Printf("pbm-agent:\n%s", version.Current().All(""))
 	logger.Printf("node: %s/%s", a.brief.SetName, a.brief.Me)
+	logger.Printf("conn level ReadConcern: %v; WriteConcern: %v",
+		a.leadConn.MongoOptions().ReadConcern.Level,
+		a.leadConn.MongoOptions().WriteConcern.W)
 
 	c, cerr := ctrl.ListenCmd(ctx, a.leadConn, a.closeCMD)
 


### PR DESCRIPTION
Fix for https://perconadev.atlassian.net/browse/PBM-1308 .

Following validation are added:

```
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=majority
-----
Exit: connect to PBM: create mongo connection: invalid connection string option: ReadConcern majority and WriteConcern 1 is not allowed
```

```
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=available
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=snapshot
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=linearizable
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=abc
-----
Exit: connect to PBM: create mongo connection: invalid connection string option: ReadConcern level is not allowed
```

In addition read/write concern info is added in pbm-agent startup log info:
```
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin
-----
...
GoVersion: go1.22.1
2024-05-15T10:23:15.000+0200 I starting PITR routine
2024-05-15T10:23:15.000+0200 I node: rs0/rs01:30001
2024-05-15T10:23:15.000+0200 I conn level ReadConcern: majority; WriteConcern: majority
2024-05-15T10:23:15.000+0200 I listening for the commands
...
```

```
mongodb://pbmuser:test1234@0.0.0.0:30001/?authSource=admin&w=1&readConcernLevel=local
-----
...
GoVersion: go1.22.1
2024-05-15T10:21:36.000+0200 I starting PITR routine
2024-05-15T10:21:36.000+0200 I node: rs0/rs01:30001
2024-05-15T10:21:36.000+0200 I conn level ReadConcern: local; WriteConcern: 1
2024-05-15T10:21:36.000+0200 I listening for the commands
...
```
