### PR TITLE
PBM-1343: Release the lock when failed to read the storage config

### DIFF
--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -221,6 +221,9 @@ func (a *Agent) pitr(ctx context.Context) error {
 
 	stg, err := util.StorageFromConfig(cfg.Storage, l)
 	if err != nil {
+		if err := lck.Release(); err != nil {
+			l.Error("release lock: %v", err)
+		}
 		return errors.Wrap(err, "unable to get storage configuration")
 	}
 


### PR DESCRIPTION
When the `pbm-agent` (during the pitr procedure) fails on reading the storage config it may get locked out of starting the slicer (which results in missing pitr data for a given replicaset in sharded cluster).

Each node is blocked at: https://github.com/percona/percona-backup-mongodb/blob/v2.5.0/cmd/pbm-agent/restore.go#L183-L185

Release the lock before exiting the function to allow another node to continue the slicing.