### PR TITLE
Migrate e2e-tests to Docker Compose V2

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -28,9 +28,9 @@ $ MONGODB_VERSION=4.4 ./start-cluster
 
 You need to set up PBM though:
 ```
-$ docker-compose -f ./docker/docker-compose.yaml exec agent-rs101 pbm config --file=/etc/pbm/minio.yaml
+$ docker compose -f ./docker/docker-compose.yaml exec agent-rs101 pbm config --file=/etc/pbm/minio.yaml
 ```
 Run pbm commands:
 ```
-$ docker-compose -f ./docker/docker-compose.yaml exec agent-rs101 pbm list
+$ docker compose -f ./docker/docker-compose.yaml exec agent-rs101 pbm list
 ```

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -29,22 +29,22 @@ run() {
         ;;
     esac
 
-    docker-compose -f $compose up -d docker-host
+    docker compose -f $compose up -d docker-host
     desc 'Run tests'
-    docker-compose -f $compose run tests
+    docker compose -f $compose run tests
     EXIT_CODE=$?
 
     if [ "$EXIT_CODE" != 0 ]; then
-        docker-compose -f $compose logs --no-color --tail=100
+        docker compose -f $compose logs --no-color --tail=100
         desc 'PBM logs'
-        docker-compose -f $compose exec -T agent-rs101 pbm logs -t 0 -s D -x || true
+        docker compose -f $compose exec -T agent-rs101 pbm logs -t 0 -s D -x || true
         if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
-            docker-compose -f $compose exec -T agent-rs201 pbm logs -t 0 -s D -x || true
+            docker compose -f $compose exec -T agent-rs201 pbm logs -t 0 -s D -x || true
         fi
         desc 'PBM status'
-        docker-compose -f $compose exec -T agent-rs101 pbm status || true
+        docker compose -f $compose exec -T agent-rs101 pbm status || true
         if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
-            docker-compose -f $compose exec -T agent-rs201 pbm status || true
+            docker compose -f $compose exec -T agent-rs201 pbm status || true
         fi
     fi
 
@@ -59,7 +59,7 @@ run() {
 pbm_run() {
     local cmd="$@"
 
-    docker-compose -f $COMPOSE_PATH exec -T agent-rs101 pbm $cmd
+    docker compose -f $COMPOSE_PATH exec -T agent-rs101 pbm $cmd
 }
 
 mongo_run() {
@@ -71,7 +71,7 @@ mongo_run() {
         mongo="mongosh"
     fi
 
-    docker-compose -f $COMPOSE_PATH exec -T "${rs}01" $mongo "mongodb://${BACKUP_USER}:${MONGO_PASS}@localhost/?replicaSet=${rs}" --quiet --eval="${cmd}"
+    docker compose -f $COMPOSE_PATH exec -T "${rs}01" $mongo "mongodb://${BACKUP_USER}:${MONGO_PASS}@localhost/?replicaSet=${rs}" --quiet --eval="${cmd}"
 }
 
 wait_backup() {
@@ -158,7 +158,7 @@ start_cluster() {
     genMongoKey
 
     echo 'Build agents and tests'
-    docker-compose -f $COMPOSE_PATH build --no-cache --pull
+    docker compose -f $COMPOSE_PATH build --no-cache --pull
 
     mongo="mongo"
     if [ "${mongo_version:0:1}" -ge 6 ]; then
@@ -171,18 +171,18 @@ start_cluster() {
     fi
     export MONGODB_VERSION=${mongo_version:-"4.4"}
     export MONGODB_IMAGE=${MONGODB_IMAGE:-"percona/percona-server-mongodb"}
-    docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d \
+    docker compose -f $COMPOSE_PATH up --quiet-pull --no-color -d \
         cfg01 cfg02 cfg03 rs101 rs102 rs103 rs201 rs202 rs203 mongos minio createbucket
     sleep 25
-    docker-compose -f $COMPOSE_PATH ps
+    docker compose -f $COMPOSE_PATH ps
     export COMPOSE_INTERACTIVE_NO_CLI=1
-    docker-compose -f $COMPOSE_PATH exec -T cfg01 /opt/start.sh
-    docker-compose -f $COMPOSE_PATH exec -T rs101 /opt/start.sh
-    docker-compose -f $COMPOSE_PATH exec -T rs201 /opt/start.sh
+    docker compose -f $COMPOSE_PATH exec -T cfg01 /opt/start.sh
+    docker compose -f $COMPOSE_PATH exec -T rs101 /opt/start.sh
+    docker compose -f $COMPOSE_PATH exec -T rs201 /opt/start.sh
     sleep 15
-    docker-compose -f $COMPOSE_PATH exec -T mongos $mongo mongodb://${BACKUP_USER}:${MONGO_PASS}@localhost /opt/mongos_init.js
+    docker compose -f $COMPOSE_PATH exec -T mongos $mongo mongodb://${BACKUP_USER}:${MONGO_PASS}@localhost /opt/mongos_init.js
 
-    docker-compose -f $COMPOSE_PATH up --quiet-pull --no-color -d \
+    docker compose -f $COMPOSE_PATH up --quiet-pull --no-color -d \
         agent-cfg01 agent-cfg02 agent-cfg03 agent-rs101 agent-rs102 agent-rs103 agent-rs201 agent-rs202 agent-rs203
 }
 
@@ -203,7 +203,7 @@ start_replset() {
     genMongoKey
 
     echo 'Build agents and tests'
-    docker-compose -f $compose build --no-cache --pull
+    docker compose -f $compose build --no-cache --pull
 
     if [ ! -d "${test_dir}/docker/backups" ]; then
         mkdir "${test_dir}/docker/backups"
@@ -212,19 +212,19 @@ start_replset() {
 
     export MONGODB_VERSION=${mongo_version:-"4.4"}
     export MONGODB_IMAGE=${MONGODB_IMAGE:-"percona/percona-server-mongodb"}
-    docker-compose -f $compose up --quiet-pull --no-color -d \
+    docker compose -f $compose up --quiet-pull --no-color -d \
         $nodes
 
     sleep 25
-    docker-compose -f $compose ps
+    docker compose -f $compose ps
     export COMPOSE_INTERACTIVE_NO_CLI=1
-    docker-compose -f $compose exec -T rs101 /opt/start.sh
+    docker compose -f $compose exec -T rs101 /opt/start.sh
     if [ $compose == $COMPOSE_REMAPPING_PATH ]; then
-        docker-compose -f $compose exec -T rs201 /opt/start.sh
+        docker compose -f $compose exec -T rs201 /opt/start.sh
     fi
     sleep 15
 
-    docker-compose -f $compose up -d $agents
+    docker compose -f $compose up -d $agents
 }
 
 genMongoKey() {
@@ -239,6 +239,6 @@ genMongoKey() {
 destroy_cluster() {
     local compose=$1
 
-    docker-compose -f $compose ps
-    docker-compose -f $compose down -v -t 2
+    docker compose -f $compose ps
+    docker compose -f $compose down -v -t 2
 }

--- a/e2e-tests/run-new-cluster
+++ b/e2e-tests/run-new-cluster
@@ -47,7 +47,7 @@ users_og=$(mongo_run 'db.getSiblingDB("admin").system.users.find({}, {_id: 1}).s
 
 date
 desc 'Destroy cluster'
-docker-compose -f ${test_dir}/docker/docker-compose.yaml down
+docker compose -f ${test_dir}/docker/docker-compose.yaml down
 desc 'Removing PSMDB volumes'
 docker volume rm $(docker volume ls --filter name=data -q)
 


### PR DESCRIPTION
After upgrade of Docker I had following issue:
https://docs.docker.com/desktop/release-notes/#known-issues
so I decided to upgrade to Compose V2