### PR TITLE
PBM-557: PITR slicing could end up on primary node

### DIFF
--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -338,12 +338,15 @@ func (a *Agent) pitr(ctx context.Context) error {
 			}
 		}()
 
-		streamErr := s.Stream(ctx,
+		streamErr := s.Stream(
+			ctx,
+			nodeInfo,
 			stopC,
 			w,
 			cfg.PITR.Compression,
 			cfg.PITR.CompressionLevel,
-			cfg.Backup.Timeouts)
+			cfg.Backup.Timeouts,
+		)
 		if streamErr != nil {
 			l.Error("streaming oplog: %v", streamErr)
 			retErr := errors.Wrap(streamErr, "streaming oplog")

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -338,6 +338,9 @@ func (a *Agent) pitr(ctx context.Context) error {
 			}
 		}()
 
+		// monitor implicit priority changes (secondary->primary)
+		monitorPrio := cfg.PITR.Priority == nil
+
 		streamErr := s.Stream(
 			ctx,
 			nodeInfo,
@@ -346,6 +349,7 @@ func (a *Agent) pitr(ctx context.Context) error {
 			cfg.PITR.Compression,
 			cfg.PITR.CompressionLevel,
 			cfg.Backup.Timeouts,
+			monitorPrio,
 		)
 		if streamErr != nil {
 			l.Error("streaming oplog: %v", streamErr)

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -277,7 +277,8 @@ func (a *Agent) pitr(ctx context.Context) error {
 		if err := lck.Release(); err != nil {
 			l.Error("release lock: %v", err)
 		}
-		return errors.Wrap(err, "unable to get storage configuration")
+		err = errors.Wrap(err, "unable to get storage configuration")
+		return err
 	}
 
 	s := slicer.NewSlicer(a.brief.SetName, a.leadConn, a.nodeConn, stg, cfg, log.FromContext(ctx))
@@ -292,7 +293,8 @@ func (a *Agent) pitr(ctx context.Context) error {
 		if err := lck.Release(); err != nil {
 			l.Error("release lock: %v", err)
 		}
-		return errors.Wrap(err, "catchup")
+		err = errors.Wrap(err, "catchup")
+		return err
 	}
 
 	go func() {

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -345,15 +345,11 @@ func (a *Agent) pitr(ctx context.Context) error {
 			cfg.PITR.CompressionLevel,
 			cfg.Backup.Timeouts)
 		if streamErr != nil {
-			out := l.Error
-			if errors.Is(streamErr, slicer.OpMovedError{}) {
-				out = l.Info
-			}
-			retErr := errors.Wrap(streamErr, "streaming oplog: %v")
+			l.Error("streaming oplog: %v", streamErr)
+			retErr := errors.Wrap(streamErr, "streaming oplog")
 			if err := oplog.SetErrorRSStatus(ctx, a.leadConn, nodeInfo.SetName, nodeInfo.Me, retErr.Error()); err != nil {
-				l.Error("setting RS status to status error, err = %v", err)
+				l.Error("setting RS status to StatusError: %v", err)
 			}
-			out(retErr.Error())
 		}
 
 		if err := lck.Release(); err != nil {

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -203,7 +203,6 @@ func (a *Agent) pitr(ctx context.Context) error {
 		return errors.Wrap(err, "check if already run")
 	}
 	if !moveOn {
-		l.Debug("pitr running on another RS member")
 		return nil
 	}
 

--- a/pbm/prio/priority.go
+++ b/pbm/prio/priority.go
@@ -8,7 +8,12 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
 
-const defaultScore = 1.0
+const (
+	defaultScore      = 1.0
+	scoreForPrimary   = defaultScore / 2
+	scoreForSecondary = defaultScore * 1
+	scoreForHidden    = defaultScore * 2
+)
 
 // NodesPriority groups nodes by priority according to
 // provided scores. Basically nodes are grouped and sorted by
@@ -106,9 +111,9 @@ func implicitPrioCalc(a topo.AgentStat, rule map[string]float64) float64 {
 	if coeff, ok := rule[a.Node]; ok && rule != nil {
 		return defaultScore * coeff
 	} else if a.State == defs.NodeStatePrimary {
-		return defaultScore / 2
+		return scoreForPrimary
 	} else if a.Hidden {
-		return defaultScore * 2
+		return scoreForHidden
 	}
 	return defaultScore
 }

--- a/pbm/prio/priority.go
+++ b/pbm/prio/priority.go
@@ -104,6 +104,18 @@ func CalcPriorityForAgent(
 	return implicitPrioCalc(agent, coeffRules)
 }
 
+// CalcPriorityForNode returns implicit priority based on node info.
+func CalcPriorityForNode(node *topo.NodeInfo) float64 {
+	if node.IsPrimary {
+		return scoreForPrimary
+	} else if node.Secondary {
+		return scoreForSecondary
+	} else if node.Hidden {
+		return scoreForHidden
+	}
+	return defaultScore
+}
+
 // implicitPrioCalc provides priority calculation based on topology rules.
 // Instead of using explicitly specified priority numbers, topology rules are
 // applied for primary, secondary and hidden member.


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-557

PBM monitors if RS member that is doing PITR slicing has decreased priority.
This is only applied when PITR priority is based on cluster topology (hidden, secondary, primary rules).
In such a case, PBM restarts election process and elects new PITR slicing members, according to new priority configuration. 