### PR TITLE
PBM-1376. Add support for SSE-S3 for S3 providers

### DIFF
--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -355,9 +355,9 @@ func (s *S3) Save(name string, data io.Reader, sizeb int64) error {
 
 		sse := s.opts.ServerSideEncryption
 		if sse != nil {
-                       if sse.SseAlgorithm == s3.ServerSideEncryptionAes256 {
-                                uplInput.ServerSideEncryption = aws.String(sse.SseAlgorithm)
-                        } else if sse.SseAlgorithm == s3.ServerSideEncryptionAwsKms {
+			if sse.SseAlgorithm == s3.ServerSideEncryptionAes256 {
+				uplInput.ServerSideEncryption = aws.String(sse.SseAlgorithm)
+			} else if sse.SseAlgorithm == s3.ServerSideEncryptionAwsKms {
 				uplInput.ServerSideEncryption = aws.String(sse.SseAlgorithm)
 				uplInput.SSEKMSKeyId = aws.String(sse.KmsKeyID)
 			} else if sse.SseCustomerAlgorithm != "" {

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -355,7 +355,9 @@ func (s *S3) Save(name string, data io.Reader, sizeb int64) error {
 
 		sse := s.opts.ServerSideEncryption
 		if sse != nil {
-			if sse.SseAlgorithm == s3.ServerSideEncryptionAwsKms {
+                       if sse.SseAlgorithm == s3.ServerSideEncryptionAes256 {
+                                uplInput.ServerSideEncryption = aws.String(sse.SseAlgorithm)
+                        } else if sse.SseAlgorithm == s3.ServerSideEncryptionAwsKms {
 				uplInput.ServerSideEncryption = aws.String(sse.SseAlgorithm)
 				uplInput.SSEKMSKeyId = aws.String(sse.KmsKeyID)
 			} else if sse.SseCustomerAlgorithm != "" {


### PR DESCRIPTION
In order to be able to define server-side encryption with Amazon S3 managed keys (SSE-S3) user needs to set storage.s3.serverSideEncryption.sseAlgorithm to AES256 option.

https://github.com/aws/aws-sdk-go/blob/main/service/s3/api.go#L45783