### PR TITLE
PBM-1057: Forbidden running Backup & PITR on non-suitable agents

### DIFF
--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -330,6 +330,13 @@ func (a *Agent) HbStatus(ctx context.Context) {
 			} else {
 				hb.State = n.State
 				hb.StateStr = n.StateStr
+
+				rLag, err := topo.ReplicationLag(ctx, a.nodeConn, a.brief.Me)
+				if err != nil {
+					l.Error("get replication lag: %v", err)
+					hb.Err += fmt.Sprintf("get replication lag: %v", err)
+				}
+				hb.ReplicationLag = rLag
 			}
 		}
 

--- a/cmd/pbm-agent/backup.go
+++ b/cmd/pbm-agent/backup.go
@@ -165,7 +165,7 @@ func (a *Agent) Backup(ctx context.Context, cmd *ctrl.BackupCmd, opid ctrl.OPID,
 			}
 		}
 
-		agents, err := topo.ListAgentStatuses(ctx, a.leadConn)
+		agents, err := topo.ListSteadyAgents(ctx, a.leadConn)
 		if err != nil {
 			l.Error("get agents list: %v", err)
 			return

--- a/cmd/pbm-agent/backup.go
+++ b/cmd/pbm-agent/backup.go
@@ -171,9 +171,9 @@ func (a *Agent) Backup(ctx context.Context, cmd *ctrl.BackupCmd, opid ctrl.OPID,
 			return
 		}
 
-		validCandidates := a.getValidCandidates(agents, cmd.Type)
+		candidates := a.getValidCandidates(agents, cmd.Type)
 
-		nodes := prio.CalcNodesPriority(c, cfg.Backup.Priority, validCandidates)
+		nodes := prio.CalcNodesPriority(c, cfg.Backup.Priority, candidates)
 
 		shards, err := topo.ClusterMembers(ctx, a.leadConn.MongoClient())
 		if err != nil {
@@ -254,12 +254,6 @@ func (a *Agent) getValidCandidates(agents []topo.AgentStat, backupType defs.Back
 	validCandidates := []topo.AgentStat{}
 	for _, agent := range agents {
 		if version.FeatureSupport(agent.MongoVersion()).BackupType(backupType) != nil {
-			continue
-		}
-		if agent.Arbiter || agent.DelaySecs > 0 {
-			continue
-		}
-		if agent.ReplicationLag >= defs.MaxReplicationLagTimeSec {
 			continue
 		}
 		validCandidates = append(validCandidates, agent)

--- a/cmd/pbm-agent/backup.go
+++ b/cmd/pbm-agent/backup.go
@@ -249,7 +249,7 @@ func (a *Agent) Backup(ctx context.Context, cmd *ctrl.BackupCmd, opid ctrl.OPID,
 	}
 }
 
-// getValidCandidates filter out all agents that are not suitable for the backup.
+// getValidCandidates filters out all agents that are not suitable for the backup.
 func (a *Agent) getValidCandidates(agents []topo.AgentStat, backupType defs.BackupType) []topo.AgentStat {
 	validCandidates := []topo.AgentStat{}
 	for _, a := range agents {

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -460,12 +460,16 @@ func (a *Agent) leadNomination(
 // getValidCandidatesForPITR filters out all agents that are not suitable for the PITR.
 func (a *Agent) getValidCandidatesForPITR(agents []topo.AgentStat) []topo.AgentStat {
 	validCandidates := []topo.AgentStat{}
-	for _, a := range agents {
-		if a.Arbiter || a.DelaySecs > 0 {
+	for _, agent := range agents {
+		if agent.Arbiter || agent.DelaySecs > 0 {
 			continue
 		}
-		validCandidates = append(validCandidates, a)
+		if agent.ReplicationLag >= defs.MaxReplicationLagTimeSec {
+			continue
+		}
+		validCandidates = append(validCandidates, agent)
 	}
+
 	return validCandidates
 }
 

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -412,13 +412,11 @@ func (a *Agent) leadNomination(
 		return
 	}
 
-	agents, err := topo.ListSteadyAgents(ctx, a.leadConn)
+	candidates, err := topo.ListSteadyAgents(ctx, a.leadConn)
 	if err != nil {
 		l.Error("get agents list: %v", err)
 		return
 	}
-
-	candidates := a.getValidCandidatesForPITR(agents)
 
 	nodes := prio.CalcNodesPriority(nil, cfgPrio, candidates)
 
@@ -455,22 +453,6 @@ func (a *Agent) leadNomination(
 			}
 		}(sh.RS)
 	}
-}
-
-// getValidCandidatesForPITR filters out all agents that are not suitable for the PITR.
-func (a *Agent) getValidCandidatesForPITR(agents []topo.AgentStat) []topo.AgentStat {
-	validCandidates := []topo.AgentStat{}
-	for _, agent := range agents {
-		if agent.Arbiter || agent.DelaySecs > 0 {
-			continue
-		}
-		if agent.ReplicationLag >= defs.MaxReplicationLagTimeSec {
-			continue
-		}
-		validCandidates = append(validCandidates, agent)
-	}
-
-	return validCandidates
 }
 
 func (a *Agent) nominateRSForPITR(ctx context.Context, rs string, nodes [][]string) error {

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -659,7 +659,7 @@ func (a *Agent) reconcileReadyStatus(ctx context.Context, agents []topo.AgentSta
 			if err := oplog.SetClusterStatus(ctx, a.leadConn, oplog.StatusUnset); err != nil {
 				l.Error("error while cleaning cluster status: %v", err)
 			}
-			return errors.New("timeout while roconciling ready status")
+			return errors.New("timeout while reconciling ready status")
 		}
 	}
 }

--- a/pbm/defs/defs.go
+++ b/pbm/defs/defs.go
@@ -136,6 +136,8 @@ const (
 
 const StaleFrameSec uint32 = 30
 
+const MaxReplicationLagTimeSec = 21
+
 const (
 	// MetadataFileSuffix is a suffix for the metadata file on a storage
 	MetadataFileSuffix = ".pbm.json"

--- a/pbm/topo/agent.go
+++ b/pbm/topo/agent.go
@@ -192,6 +192,23 @@ func ListAgentStatuses(ctx context.Context, m connect.Client) ([]AgentStat, erro
 	return ListAgents(ctx, m)
 }
 
+// ListSteadyAgents returns agents which are in steady state for backup or pitr.
+func ListSteadyAgents(ctx context.Context, m connect.Client) ([]AgentStat, error) {
+	agents, err := ListAgentStatuses(ctx, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "listing agents")
+	}
+	steadyAgents := []AgentStat{}
+	for _, a := range agents {
+		if a.State == defs.NodeStatePrimary ||
+			a.State == defs.NodeStateSecondary {
+			steadyAgents = append(steadyAgents, a)
+		}
+	}
+
+	return steadyAgents, nil
+}
+
 func ListAgents(ctx context.Context, m connect.Client) ([]AgentStat, error) {
 	cur, err := m.AgentsStatusCollection().Find(ctx, bson.D{})
 	if err != nil {

--- a/pbm/topo/agent.go
+++ b/pbm/topo/agent.go
@@ -45,6 +45,9 @@ type AgentStat struct {
 	// DelaySecs is the node configured replication delay (lag).
 	DelaySecs int32 `bson:"delay"`
 
+	// Replication lag for mongod.
+	ReplicationLag int `bson:"repl_lag"`
+
 	// AgentVer has the PBM Agent version (looks like `v2.3.4`)
 	AgentVer string `bson:"v"`
 

--- a/pbm/topo/topo.go
+++ b/pbm/topo/topo.go
@@ -148,8 +148,6 @@ func collectTopoCheckErrors(
 	return nil
 }
 
-const maxReplicationLagTimeSec = 21
-
 // NodeSuits checks if node can perform backup
 func NodeSuits(ctx context.Context, m *mongo.Client, inf *NodeInfo) (bool, error) {
 	status, err := GetNodeStatus(ctx, m, inf.Me)
@@ -165,7 +163,7 @@ func NodeSuits(ctx context.Context, m *mongo.Client, inf *NodeInfo) (bool, error
 		return false, errors.Wrap(err, "get node replication lag")
 	}
 
-	return replLag < maxReplicationLagTimeSec && status.Health == defs.NodeHealthUp &&
+	return replLag < defs.MaxReplicationLagTimeSec && status.Health == defs.NodeHealthUp &&
 			(status.State == defs.NodeStatePrimary || status.State == defs.NodeStateSecondary),
 		nil
 }


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1057

In the context of this PR, non-suitable agents for _Backup_ and _PITR_ are:
- agents with node status different than _PRIMARY_ or _SECONDARY_ (e.g. _STARTUP2_ for initial sync from the Jira ticket)
- agents with _Arbiter_ or _Delayed_ node
- agents with node's replication lag

This PR filters out non-suitable agents from:
- _Backup_ nomination process
- _PITR_ nomination process