### PR TITLE
PBM-1338: Restore Start/Finish time for `describe-restore` command

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -268,7 +268,7 @@ func main() {
 	replayCmd.Flag("start", fmt.Sprintf("Replay oplog from the time. Set in format %s", datetimeFormat)).
 		Required().
 		StringVar(&replayOpts.start)
-	replayCmd.Flag("end", "Replay oplog to the time. Set in format %s").
+	replayCmd.Flag("end", fmt.Sprintf("Replay oplog to the time. Set in format %s", datetimeFormat)).
 		Required().
 		StringVar(&replayOpts.end)
 	replayCmd.Flag("wait", "Wait for the restore to finish.").

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -620,7 +620,9 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 	res.LastTransitionTS = meta.LastTransitionTS
 	res.LastTransitionTime = time.Unix(res.LastTransitionTS, 0).UTC().Format(time.RFC3339)
 	res.StartTime = util.Ref(time.Unix(meta.StartTS, 0).UTC().Format(time.RFC3339))
-	res.FinishTime = util.Ref(time.Unix(meta.LastTransitionTS, 0).UTC().Format(time.RFC3339))
+	if meta.Status == defs.StatusDone {
+		res.FinishTime = util.Ref(time.Unix(meta.LastTransitionTS, 0).UTC().Format(time.RFC3339))
+	}
 	if meta.Status == defs.StatusError {
 		res.Error = &meta.Error
 	}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -532,6 +532,7 @@ type describeRestoreResult struct {
 	Namespaces         []string         `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
 	StartTS            *int64           `json:"start_ts,omitempty" yaml:"-"`
 	StartTime          *string          `json:"start,omitempty" yaml:"start,omitempty"`
+	FinishTime         *string          `json:"finish,omitempty" yaml:"finish,omitempty"`
 	PITR               *int64           `json:"ts_to_restore,omitempty" yaml:"-"`
 	PITRTime           *string          `json:"time_to_restore,omitempty" yaml:"time_to_restore,omitempty"`
 	LastTransitionTS   int64            `json:"last_transition_ts" yaml:"-"`
@@ -618,6 +619,8 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 	res.OPID = meta.OPID
 	res.LastTransitionTS = meta.LastTransitionTS
 	res.LastTransitionTime = time.Unix(res.LastTransitionTS, 0).UTC().Format(time.RFC3339)
+	res.StartTime = util.Ref(time.Unix(meta.StartTS, 0).UTC().Format(time.RFC3339))
+	res.FinishTime = util.Ref(time.Unix(meta.LastTransitionTS, 0).UTC().Format(time.RFC3339))
 	if meta.Status == defs.StatusError {
 		res.Error = &meta.Error
 	}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -624,15 +624,9 @@ func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpt
 	if meta.Status == defs.StatusError {
 		res.Error = &meta.Error
 	}
-	if meta.StartPITR != 0 {
-		res.StartTS = &meta.StartPITR
-		s := time.Unix(meta.StartPITR, 0).UTC().Format(time.RFC3339)
-		res.StartTime = &s
-	}
 	if meta.PITR != 0 {
 		res.PITR = &meta.PITR
-		s := time.Unix(meta.PITR, 0).UTC().Format(time.RFC3339)
-		res.PITRTime = &s
+		res.PITRTime = util.Ref(time.Unix(meta.PITR, 0).UTC().Format(time.RFC3339))
 	}
 
 	for _, rs := range meta.Replsets {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1338

`start` and `finish` fields display `restore` start and finish time. Field `finish` is displayed only in case of successfully finished restore (`status: done`).
```
$ pbm describe-restore 2024-09-03T07:48:59.389263417Z

name: "2024-09-03T07:48:59.389263417Z"
opid: 66d6bf6b4134f541bae6f571
backup: "2024-09-03T07:37:16Z"
type: logical
status: done
start: "2024-09-03T07:48:59Z"
finish: "2024-09-03T07:50:06Z"
last_transition_time: "2024-09-03T07:50:06Z"
replsets:
  - ...
```