### PR TITLE
PBM-1382: Fix priority status for Delayed member

### DIFF
--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -179,7 +179,8 @@ func (n node) String() string {
 	}
 
 	var s string
-	if len(n.PrioBcp) == 0 || len(n.PrioPITR) == 0 {
+	if len(n.PrioBcp) == 0 || len(n.PrioPITR) == 0 ||
+		n.Role == cli.RoleDelayed {
 		s = fmt.Sprintf("%s [%s]: pbm-agent [%s]", n.Host, role, ver)
 	} else {
 		s = fmt.Sprintf("%s [%s], Bkp Prio: [%s], PITR Prio: [%s]: pbm-agent [%s]",


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1382

```
$ pbm status --priority --sections=cluster

Cluster:
========
rs1:
  - rs101:27017 [P], Bkp Prio: [0.5], PITR Prio: [0.5]: pbm-agent [v2.6.0] OK
  - rs102:27017 [S], Bkp Prio: [1.0], PITR Prio: [1.0]: pbm-agent [v2.6.0] OK
  - rs103:27017 [D]: pbm-agent [v2.6.0] OK
```