### PR TITLE
PBM-1369: Fix never ending backup after agent is lost

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -741,7 +741,7 @@ func setClusterLastWriteImpl(
 			}
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(10 * time.Second)
 	}
 
 	lw := bcp.Replsets[0].LastWriteTS


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1369

In the case of the lost `pbm-agent`, [setClusterLastWriteImpl](https://github.com/percona/percona-backup-mongodb/blob/5bb76dacbaf1856074415230d7964c428141795e/pbm/backup/backup.go#L664-L679) might have an endless loop, it the case when `last_write_ts` is not written on RS level.

This fix solves the problem by checking if `pbm-agent` is lost within the same loop.