### PR TITLE
PBM-1394: fix tests according to PBM-1316

### DIFF
--- a/e2e-tests/cmd/pbm-test/run.go
+++ b/e2e-tests/cmd/pbm-test/run.go
@@ -70,8 +70,8 @@ func run(t *sharded.Cluster, typ testTyp) {
 
 	t.SetBallastData(1e5)
 
-	runTest("Check the Running Backup can't be deleted",
-		t.BackupNotDeleteRunning)
+	runTest("Check the Cannot Run Delete During Backup",
+		t.CannotRunDeleteDuringBackup)
 
 	runTest("Check Backup Cancellation",
 		func() { t.BackupCancellation(storage) })

--- a/e2e-tests/pkg/tests/sharded/backuper.go
+++ b/e2e-tests/pkg/tests/sharded/backuper.go
@@ -66,9 +66,9 @@ func NewPitr(c *Cluster) *Pitr {
 }
 
 func (p *Pitr) Backup() {
+	p.c.pitrOn()
 	bcpName := p.c.LogicalBackup()
 	p.started <- struct{}{}
-	p.c.pitrOn()
 	p.c.BackupWaitDone(context.TODO(), bcpName)
 	p.sdone <- struct{}{}
 

--- a/e2e-tests/pkg/tests/sharded/test_delete_backup.go
+++ b/e2e-tests/pkg/tests/sharded/test_delete_backup.go
@@ -191,12 +191,12 @@ func checkArtefacts(conf string, shouldStay map[string]struct{}) {
 	}
 }
 
-func (c *Cluster) BackupNotDeleteRunning() {
+func (c *Cluster) CannotRunDeleteDuringBackup() {
 	bcpName := c.LogicalBackup()
 	c.printBcpList()
 	log.Println("deleting backup", bcpName)
 	o, err := c.pbm.RunCmd("pbm", "delete-backup", "-y", bcpName)
-	if err == nil || !strings.Contains(err.Error(), "backup is in progress") {
+	if err == nil || !strings.Contains(err.Error(), "another operation in progress, Snapshot backup") {
 		list, lerr := c.pbm.RunCmd("pbm", "list")
 		log.Fatalf("ERROR: running backup '%s' shouldn't be deleted.\n"+
 			"Output: %s\nStderr:%v\nBackups list:\n%v\n%v",

--- a/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
+++ b/e2e-tests/pkg/tests/sharded/test_oplog_replay.go
@@ -12,11 +12,11 @@ import (
 )
 
 func (c *Cluster) OplogReplay() {
-	bcpName := c.LogicalBackup()
-
 	c.pitrOn()
 	log.Println("turn on PITR")
 	defer c.pitrOff()
+
+	bcpName := c.LogicalBackup()
 
 	counters := make(map[string]shardCounter)
 	for name, cn := range c.shards {

--- a/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
+++ b/e2e-tests/pkg/tests/sharded/test_pitr_basic.go
@@ -15,11 +15,11 @@ import (
 )
 
 func (c *Cluster) PITRbasic() {
-	bcpName := c.LogicalBackup()
-
 	c.pitrOn()
 	log.Println("turn on PITR")
 	defer c.pitrOff()
+
+	bcpName := c.LogicalBackup()
 
 	counters := make(map[string]shardCounter)
 	for name, cn := range c.shards {

--- a/e2e-tests/pkg/tests/sharded/test_timeseries.go
+++ b/e2e-tests/pkg/tests/sharded/test_timeseries.go
@@ -16,10 +16,10 @@ func (c *Cluster) Timeseries() {
 
 	ts1.gen()
 
-	bcpName := c.LogicalBackup()
-
 	c.pitrOn()
 	defer c.pitrOff()
+
+	bcpName := c.LogicalBackup()
 
 	c.BackupWaitDone(context.TODO(), bcpName)
 


### PR DESCRIPTION
https://github.com/percona/percona-backup-mongodb/pull/999 prevents running op when a lock has already been acquired. it is not possible to delete backups or change config (e.g. enable PITR) if there is another operation in progress