### PR TITLE
PBM-1114: check backup files before mark it as done

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -337,9 +337,15 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 	}
 
 	if inf.IsLeader() {
-		err = b.reconcileStatus(ctx, bcp.Name, opid.String(), defs.StatusDone, nil)
+		shards, err := topo.ClusterMembers(ctx, b.leadConn.MongoClient())
 		if err != nil {
-			return errors.Wrap(err, "check cluster for backup done")
+			return errors.Wrap(err, "check cluster for backup done: get cluster members")
+		}
+
+		err = b.convergeCluster(ctx, bcp.Name, opid.String(), shards, defs.StatusDone)
+		err = errors.Wrap(err, "check cluster for backup done: convergeCluster")
+		if err != nil {
+			return err
 		}
 
 		bcpm, err = NewDBManager(b.leadConn).GetBackupByName(ctx, bcp.Name)
@@ -347,8 +353,23 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 			return errors.Wrap(err, "get backup metadata")
 		}
 
+		// PBM-1114: update file metadata with the same values as in database
+		unix := time.Now().Unix()
+		bcpm.Status = defs.StatusDone
+		bcpm.LastTransitionTS = unix
+		bcpm.Conditions = append(bcpm.Conditions, Condition{
+			Timestamp: unix,
+			Status:    defs.StatusDone,
+		})
+
 		err = writeMeta(stg, bcpm)
-		return errors.Wrap(err, "dump metadata")
+		if err != nil {
+			return errors.Wrap(err, "dump metadata")
+		}
+
+		err = ChangeBackupStateWithUnix(b.leadConn, bcp.Name, defs.StatusDone, unix, "")
+		return errors.Wrapf(err, "check cluster for backup done: update backup meta with %s",
+			defs.StatusDone)
 	} else {
 		// to be sure the locks released only after the "done" status had written
 		err = b.waitForStatus(ctx, bcp.Name, defs.StatusDone, nil)
@@ -432,14 +453,18 @@ func (b *Backup) reconcileStatus(
 	}
 
 	if timeout != nil {
-		return errors.Wrap(
-			b.convergeClusterWithTimeout(ctx, bcpName, opid, shards, status, *timeout),
-			"convergeClusterWithTimeout")
+		err = b.convergeClusterWithTimeout(ctx, bcpName, opid, shards, status, *timeout)
+		err = errors.Wrap(err, "convergeClusterWithTimeout")
+	} else {
+		err = b.convergeCluster(ctx, bcpName, opid, shards, status)
+		err = errors.Wrap(err, "convergeCluster")
+	}
+	if err != nil {
+		return err
 	}
 
-	return errors.Wrap(
-		b.convergeCluster(ctx, bcpName, opid, shards, status),
-		"convergeCluster")
+	err = ChangeBackupState(b.leadConn, bcpName, status, "")
+	return errors.Wrapf(err, "update backup meta with %s", status)
 }
 
 // convergeCluster waits until all given shards reached `status` and updates a cluster status
@@ -480,10 +505,11 @@ func (b *Backup) convergeClusterWithTimeout(
 	status defs.Status,
 	t time.Duration,
 ) error {
-	tk := time.NewTicker(time.Second * 1)
+	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
 
-	tout := time.After(t)
+	tout := time.NewTimer(t)
+	defer tout.Stop()
 
 	for {
 		select {
@@ -495,7 +521,7 @@ func (b *Backup) convergeClusterWithTimeout(
 			if ok {
 				return nil
 			}
-		case <-tout:
+		case <-tout.C:
 			return errors.Wrap(errConvergeTimeOut, t.String())
 		case <-ctx.Done():
 			return ctx.Err()
@@ -554,15 +580,7 @@ func (b *Backup) converged(
 		}
 	}
 
-	if shardsToFinish == 0 {
-		err := ChangeBackupState(b.leadConn, bcpName, status, "")
-		if err != nil {
-			return false, errors.Wrapf(err, "update backup meta with %s", status)
-		}
-		return true, nil
-	}
-
-	return false, nil
+	return shardsToFinish == 0, nil
 }
 
 func (b *Backup) waitForStatus(

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -372,7 +372,7 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 			return errors.Wrap(err, "check backup files")
 		}
 
-		err = ChangeBackupStateWithUnix(b.leadConn, bcp.Name, defs.StatusDone, unix, "")
+		err = ChangeBackupStateWithUnixTime(ctx, b.leadConn, bcp.Name, defs.StatusDone, unix, "")
 		return errors.Wrapf(err, "check cluster for backup done: update backup meta with %s",
 			defs.StatusDone)
 	} else {

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -367,6 +367,11 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 			return errors.Wrap(err, "dump metadata")
 		}
 
+		err = CheckBackupFiles(ctx, stg, bcp.Name)
+		if err != nil {
+			return errors.Wrap(err, "check backup files")
+		}
+
 		err = ChangeBackupStateWithUnix(b.leadConn, bcp.Name, defs.StatusDone, unix, "")
 		return errors.Wrapf(err, "check cluster for backup done: update backup meta with %s",
 			defs.StatusDone)

--- a/pbm/backup/query.go
+++ b/pbm/backup/query.go
@@ -81,15 +81,34 @@ func getBackupMeta(ctx context.Context, conn connect.Client, clause bson.D) (*Ba
 }
 
 func ChangeBackupStateOPID(conn connect.Client, opid string, s defs.Status, msg string) error {
-	return changeBackupState(context.Background(), conn, bson.D{{"opid", opid}}, s, msg)
+	return changeBackupState(context.TODO(),
+		conn, bson.D{{"opid", opid}}, time.Now().UTC().Unix(), s, msg)
 }
 
 func ChangeBackupState(conn connect.Client, bcpName string, s defs.Status, msg string) error {
-	return changeBackupState(context.Background(), conn, bson.D{{"name", bcpName}}, s, msg)
+	return changeBackupState(context.TODO(),
+		conn, bson.D{{"name", bcpName}}, time.Now().UTC().Unix(), s, msg)
 }
 
-func changeBackupState(ctx context.Context, conn connect.Client, clause bson.D, s defs.Status, msg string) error {
-	ts := time.Now().UTC().Unix()
+func ChangeBackupStateWithUnix(
+	conn connect.Client,
+	bcpName string,
+	s defs.Status,
+	unix int64,
+	msg string,
+) error {
+	return changeBackupState(context.TODO(),
+		conn, bson.D{{"name", bcpName}}, time.Now().UTC().Unix(), s, msg)
+}
+
+func changeBackupState(
+	ctx context.Context,
+	conn connect.Client,
+	clause bson.D,
+	ts int64,
+	s defs.Status,
+	msg string,
+) error {
 	_, err := conn.BcpCollection().UpdateOne(
 		ctx,
 		clause,

--- a/pbm/backup/query.go
+++ b/pbm/backup/query.go
@@ -90,15 +90,15 @@ func ChangeBackupState(conn connect.Client, bcpName string, s defs.Status, msg s
 		conn, bson.D{{"name", bcpName}}, time.Now().UTC().Unix(), s, msg)
 }
 
-func ChangeBackupStateWithUnix(
+func ChangeBackupStateWithUnixTime(
+	ctx context.Context,
 	conn connect.Client,
 	bcpName string,
 	s defs.Status,
 	unix int64,
 	msg string,
 ) error {
-	return changeBackupState(context.TODO(),
-		conn, bson.D{{"name", bcpName}}, time.Now().UTC().Unix(), s, msg)
+	return changeBackupState(ctx, conn, bson.D{{"name", bcpName}}, time.Now().UTC().Unix(), s, msg)
 }
 
 func changeBackupState(

--- a/pbm/backup/storage.go
+++ b/pbm/backup/storage.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"encoding/json"
 	"path"
 	"runtime"
 	"sync"
@@ -10,100 +9,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/percona/percona-backup-mongodb/pbm/archive"
-	"github.com/percona/percona-backup-mongodb/pbm/config"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	sfs "github.com/percona/percona-backup-mongodb/pbm/storage/fs"
-	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"github.com/percona/percona-backup-mongodb/pbm/version"
 )
-
-type StorageManager interface {
-	GetAllBackups(ctx context.Context) ([]BackupMeta, error)
-	GetBackupByName(ctx context.Context, name string) (*BackupMeta, error)
-}
-
-type storageManagerImpl struct {
-	cfg *config.StorageConf
-	stg storage.Storage
-}
-
-func NewStorageManager(ctx context.Context, cfg *config.StorageConf) (*storageManagerImpl, error) {
-	stg, err := util.StorageFromConfig(cfg, log.LogEventFromContext(ctx))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get backup store")
-	}
-
-	_, err = stg.FileStat(defs.StorInitFile)
-	if !errors.Is(err, storage.ErrNotExist) {
-		return nil, err
-	}
-
-	return &storageManagerImpl{cfg: cfg, stg: stg}, nil
-}
-
-func (m *storageManagerImpl) GetAllBackups(ctx context.Context) ([]BackupMeta, error) {
-	l := log.LogEventFromContext(ctx)
-
-	bcpList, err := m.stg.List("", defs.MetadataFileSuffix)
-	if err != nil {
-		return nil, errors.Wrap(err, "get a backups list from the storage")
-	}
-	l.Debug("got backups list: %v", len(bcpList))
-
-	var rv []BackupMeta
-	for _, b := range bcpList {
-		l.Debug("bcp: %v", b.Name)
-
-		d, err := m.stg.SourceReader(b.Name)
-		if err != nil {
-			return nil, errors.Wrapf(err, "read meta for %v", b.Name)
-		}
-
-		v := BackupMeta{}
-		err = json.NewDecoder(d).Decode(&v)
-		d.Close()
-		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshal backup meta [%s]", b.Name)
-		}
-
-		err = CheckBackupFiles(ctx, &v, m.stg)
-		if err != nil {
-			l.Warning("skip snapshot %s: %v", v.Name, err)
-			v.Status = defs.StatusError
-			v.Err = err.Error()
-		}
-		rv = append(rv, v)
-	}
-
-	return rv, nil
-}
-
-func (m *storageManagerImpl) GetBackupByName(ctx context.Context, name string) (*BackupMeta, error) {
-	l := log.LogEventFromContext(ctx)
-	l.Debug("get backup by name: %v", name)
-
-	rdr, err := m.stg.SourceReader(name + defs.MetadataFileSuffix)
-	if err != nil {
-		return nil, errors.Wrapf(err, "read meta for %v", name)
-	}
-	defer rdr.Close()
-
-	v := &BackupMeta{}
-	if err := json.NewDecoder(rdr).Decode(&v); err != nil {
-		return nil, errors.Wrapf(err, "unmarshal backup meta [%s]", name)
-	}
-
-	if err := CheckBackupFiles(ctx, v, m.stg); err != nil {
-		l.Warning("no backup files %s: %v", v.Name, err)
-		v.Status = defs.StatusError
-		v.Err = err.Error()
-	}
-
-	return v, nil
-}
 
 func CheckBackupFiles(ctx context.Context, bcp *BackupMeta, stg storage.Storage) error {
 	// !!! TODO: Check physical files ?


### PR DESCRIPTION
backup status can be set to done in db meta before the meta is written to storage. if the write fails, no meta will be available on storage. storage resync will delete backup meta from db and won't see it on storage.