### PR TITLE
PBM-1391: Enabling PITR after physical restore causes PSMDB to crash

### DIFF
--- a/cmd/pbm-agent/setup.go
+++ b/cmd/pbm-agent/setup.go
@@ -110,6 +110,14 @@ func setupNewDB(ctx context.Context, conn connect.Client) error {
 		return errors.Wrap(err, "ensure pitr chunks index")
 	}
 
+	err = conn.AdminCommand(
+		ctx,
+		bson.D{{"create", defs.PITRCollection}},
+	).Err()
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return errors.Wrap(err, "ensure pitr collection")
+	}
+
 	_, err = conn.BcpCollection().Indexes().CreateMany(
 		ctx,
 		[]mongo.IndexModel{
@@ -124,6 +132,25 @@ func setupNewDB(ctx context.Context, conn connect.Client) error {
 			},
 		},
 	)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return errors.Wrap(err, "ensure backup collection index")
+	}
 
-	return err
+	err = conn.AdminCommand(
+		ctx,
+		bson.D{{"create", defs.RestoresCollection}},
+	).Err()
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return errors.Wrap(err, "ensure restore collection")
+	}
+
+	err = conn.AdminCommand(
+		ctx,
+		bson.D{{"create", defs.AgentsStatusCollection}},
+	).Err()
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return errors.Wrap(err, "ensure agent status collection")
+	}
+
+	return nil
 }

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1524,13 +1524,13 @@ func (r *PhysRestore) resetRS() error {
 			return errors.Wrap(err, "turn off pitr")
 		}
 
-		r.dropPBMCollections(ctx, c)
+		r.cleanUpPBMCollections(ctx, c)
 	}
 
 	return r.shutdown(c)
 }
 
-func (r *PhysRestore) dropPBMCollections(ctx context.Context, c *mongo.Client) {
+func (r *PhysRestore) cleanUpPBMCollections(ctx context.Context, c *mongo.Client) {
 	pbmCollections := []string{
 		defs.LockCollection,
 		defs.LogCollection,
@@ -1554,9 +1554,9 @@ func (r *PhysRestore) dropPBMCollections(ctx context.Context, c *mongo.Client) {
 			defer wg.Done()
 
 			r.log.Debug("dropping 'admin.%s'", coll)
-			err := c.Database(defs.DB).Collection(coll).Drop(ctx)
+			_, err := c.Database(defs.DB).Collection(coll).DeleteMany(ctx, bson.M{})
 			if err != nil {
-				r.log.Warning("failed to drop 'admin.%s': %v", coll, err)
+				r.log.Warning("failed to delete all from 'admin.%s': %v", coll, err)
 			}
 		}()
 	}

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1554,7 +1554,7 @@ func (r *PhysRestore) cleanUpPBMCollections(ctx context.Context, c *mongo.Client
 			defer wg.Done()
 
 			r.log.Debug("dropping 'admin.%s'", coll)
-			_, err := c.Database(defs.DB).Collection(coll).DeleteMany(ctx, bson.M{})
+			_, err := c.Database(defs.DB).Collection(coll).DeleteMany(ctx, bson.D{})
 			if err != nil {
 				r.log.Warning("failed to delete all from 'admin.%s': %v", coll, err)
 			}


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1391

After physical restore with PITR, all PSMDB secondary nodes fail with the fatal error:
```
{"t":{"$date":"2024-09-12T06:12:55.515+00:00"},"s":"F",  "c":"ASSERT",   "id":23081,   "ctx":"ReplWriterWorker-6","msg":"Invariant failure","attr":{"expr":"!needsRenaming || allowRenameOutOfTheWay","msg":"Current collection name: (None), UUID: 0ea5a363-872c-4380-87c6-ff426f0b0a85. Future collection name: admin.pbmPITR","file":"src/mongo/db/catalog/create_collection.cpp","line":835}}
{"t":{"$date":"2024-09-12T06:12:55.515+00:00"},"s":"F",  "c":"ASSERT",   "id":23082,   "ctx":"ReplWriterWorker-6","msg":"\n\n***aborting after invariant() failure\n\n"}
{"t":{"$date":"2024-09-12T06:12:55.515+00:00"},"s":"F",  "c":"CONTROL",  "id":6384300, "ctx":"ReplWriterWorker-6","msg":"Writing fatal message","attr":{"message":"\n"}}
{"t":{"$date":"2024-09-12T06:12:55.515+00:00"},"s":"F",  "c":"CONTROL",  "id":6384300, "ctx":"ReplWriterWorker-6","msg":"Writing fatal message","attr":{"message":"Got signal: 6 (Aborted).\n"}}
```
due to the fact that Primary and Secondary have DDL operations executed in different order:
- Primary: PITR apply -> dropping PBM collections
- Secondary: dropping PBM collections -> applying PITR (during sync from Primary)

This PR fixes the problem by omitting DDL operation (primary drop) on PBM's collection during the physical restore phase and replacing it with `delete all` operation.
PR also creates all remaining PBM system collections at the first start of the PBM Agent to reduce the DDL operation within PITR.