### PR TITLE
PBM-886: sync channel set/unset/close ops

### DIFF
--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -214,7 +214,7 @@ func Upload(
 
 		err := r.Close()
 		if err != nil {
-			return 0, errors.Wrap(err, "cancel backup: close reader")
+			return 0, errors.Wrap(err, "cancel upload: close reader")
 		}
 		return 0, ErrCancelled
 	case <-saveDone:


### PR DESCRIPTION
`storage.Upload()` with already canceled context can trigger data race warning (https://github.com/percona/percona-backup-mongodb/blob/v2.6.0/pbm/storage/storage.go#L179)