### PR TITLE
PBM-1381: Log correlation between Backup Name and OPID

### DIFF
--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -167,7 +167,7 @@ func (a *Agent) Start(ctx context.Context) error {
 				return nil
 			}
 
-			logger.Printf("got command %s", cmd)
+			logger.Printf("got command %s, opid: %s", cmd, cmd.OPID)
 
 			ep, err := config.GetEpoch(ctx, a.leadConn)
 			if err != nil {


### PR DESCRIPTION
When analyzing PBM's logs, it is not possible to correlate the backup's name with the backup's OPID. That is typically needed when analyzing locks and PITR execution. This PR adds a line that correlates them, e.g:
```
2024-09-26T15:27:56Z I [rs2/rs202:27017] got command backup [name: 2024-09-26T15:27:55Z, compression: none (level: default)] <ts: 1727364475>, opid: 66f57d7b0940491a6d4aef8a
```