### PR TITLE
PBM-1211: Multi-endpoint feature

### DIFF
--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -456,7 +456,7 @@ func (a *Agent) storStatus(
 		return topo.SubsysStatus{OK: true}
 	}
 
-	stg, err := util.GetStorageFromNode(ctx, a.leadConn, a.brief.Me, log)
+	stg, err := util.GetStorage(ctx, a.leadConn, a.brief.Me, log)
 	if err != nil {
 		return topo.SubsysStatus{Err: fmt.Sprintf("unable to get storage: %v", err)}
 	}

--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -456,7 +456,7 @@ func (a *Agent) storStatus(
 		return topo.SubsysStatus{OK: true}
 	}
 
-	stg, err := util.GetStorage(ctx, a.leadConn, log)
+	stg, err := util.GetStorageFromNode(ctx, a.leadConn, a.brief.Me, log)
 	if err != nil {
 		return topo.SubsysStatus{Err: fmt.Sprintf("unable to get storage: %v", err)}
 	}

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -298,7 +298,7 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		l.Error(err.Error())
 	}
 
-	err = resync.Resync(ctx, a.leadConn, &cfg.Storage)
+	err = resync.Resync(ctx, a.leadConn, &cfg.Storage, a.brief.Me)
 	if err != nil {
 		l.Error("storage resync: " + err.Error())
 	}

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -97,7 +97,7 @@ func (a *Agent) Delete(ctx context.Context, d *ctrl.DeleteBackupCmd, opid ctrl.O
 		}
 
 		l.Info("deleting backups older than %v", t)
-		err = backup.DeleteBackupBefore(ctx, a.leadConn, t, bcpType)
+		err = backup.DeleteBackupBefore(ctx, a.leadConn, t, bcpType, nodeInfo.Me)
 		if err != nil {
 			l.Error("deleting: %v", err)
 			return
@@ -107,7 +107,7 @@ func (a *Agent) Delete(ctx context.Context, d *ctrl.DeleteBackupCmd, opid ctrl.O
 		ctx := log.SetLogEventToContext(ctx, l)
 
 		l.Info("deleting backup")
-		err := backup.DeleteBackup(ctx, a.leadConn, d.Backup)
+		err := backup.DeleteBackup(ctx, a.leadConn, d.Backup, nodeInfo.Me)
 		if err != nil {
 			l.Error("deleting: %v", err)
 			return

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -259,7 +259,7 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		l.Error("get config: %v", err)
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, a.brief.Me, l)
+	stg, err := util.StorageFromConfig(&cfg.Storage, a.brief.Me, l)
 	if err != nil {
 		l.Error("get storage: " + err.Error())
 	}
@@ -315,7 +315,7 @@ func (a *Agent) deletePITRImpl(ctx context.Context, ts primitive.Timestamp) erro
 		return nil
 	}
 
-	stg, err := util.GetStorageFromNode(ctx, a.leadConn, a.brief.Me, l)
+	stg, err := util.GetStorage(ctx, a.leadConn, a.brief.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/config"
-	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
@@ -188,7 +187,7 @@ func (a *Agent) DeletePITR(ctx context.Context, d *ctrl.DeletePITRCmd, opid ctrl
 
 	ts := primitive.Timestamp{T: uint32(t.Unix())}
 	l.Info("deleting pitr chunks older than %v", t)
-	err = deletePITRImpl(ctx, a.leadConn, ts)
+	err = a.deletePITRImpl(ctx, ts)
 	if err != nil {
 		l.Error("deleting: %v", err)
 		return
@@ -304,10 +303,10 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 	}
 }
 
-func deletePITRImpl(ctx context.Context, conn connect.Client, ts primitive.Timestamp) error {
+func (a *Agent) deletePITRImpl(ctx context.Context, ts primitive.Timestamp) error {
 	l := log.LogEventFromContext(ctx)
 
-	r, err := backup.MakeCleanupInfo(ctx, conn, ts)
+	r, err := backup.MakeCleanupInfo(ctx, a.leadConn, ts)
 	if err != nil {
 		return errors.Wrap(err, "get pitr chunks")
 	}
@@ -316,15 +315,15 @@ func deletePITRImpl(ctx context.Context, conn connect.Client, ts primitive.Times
 		return nil
 	}
 
-	stg, err := util.GetStorage(ctx, conn, l)
+	stg, err := util.GetStorageFromNode(ctx, a.leadConn, a.brief.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
 
-	return deleteChunks(ctx, conn, stg, r.Chunks)
+	return a.deleteChunks(ctx, stg, r.Chunks)
 }
 
-func deleteChunks(ctx context.Context, m connect.Client, stg storage.Storage, chunks []oplog.OplogChunk) error {
+func (a *Agent) deleteChunks(ctx context.Context, stg storage.Storage, chunks []oplog.OplogChunk) error {
 	l := log.LogEventFromContext(ctx)
 
 	for _, chnk := range chunks {
@@ -333,7 +332,7 @@ func deleteChunks(ctx context.Context, m connect.Client, stg storage.Storage, ch
 			return errors.Wrapf(err, "delete pitr chunk '%s' (%v) from storage", chnk.FName, chnk)
 		}
 
-		_, err = m.PITRChunksCollection().DeleteOne(
+		_, err = a.leadConn.PITRChunksCollection().DeleteOne(
 			ctx,
 			bson.D{
 				{"rs", chnk.RS},

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -260,7 +260,7 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		l.Error("get config: %v", err)
 	}
 
-	stg, err := util.StorageFromConfig(&cfg.Storage, l)
+	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, a.brief.Me, l)
 	if err != nil {
 		l.Error("get storage: " + err.Error())
 	}

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -284,7 +284,7 @@ func (a *Agent) pitr(ctx context.Context) error {
 		}
 	}()
 
-	stg, err := util.StorageFromConfig(&cfg.Storage, l)
+	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, a.brief.Me, l)
 	if err != nil {
 		if err := lck.Release(); err != nil {
 			l.Error("release lock: %v", err)

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -284,7 +284,7 @@ func (a *Agent) pitr(ctx context.Context) error {
 		}
 	}()
 
-	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, a.brief.Me, l)
+	stg, err := util.StorageFromConfig(&cfg.Storage, a.brief.Me, l)
 	if err != nil {
 		if err := lck.Release(); err != nil {
 			l.Error("release lock: %v", err)

--- a/cmd/pbm-agent/profile.go
+++ b/cmd/pbm-agent/profile.go
@@ -86,7 +86,7 @@ func (a *Agent) handleAddConfigProfile(
 		return
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&cmd.Storage, a.brief.Me, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfig(&cmd.Storage, a.brief.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		err = errors.Wrap(err, "storage from config")
 		return

--- a/cmd/pbm-agent/profile.go
+++ b/cmd/pbm-agent/profile.go
@@ -86,7 +86,7 @@ func (a *Agent) handleAddConfigProfile(
 		return
 	}
 
-	stg, err := util.StorageFromConfig(&cmd.Storage, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfigAndNode(&cmd.Storage, a.brief.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		err = errors.Wrap(err, "storage from config")
 		return

--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -91,7 +91,7 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		l.Info("backup: %s", r.BackupName)
 
 		// XXX: why is backup searched on storage?
-		bcp, err = restore.LookupBackupMeta(ctx, a.leadConn, r.BackupName)
+		bcp, err = restore.LookupBackupMeta(ctx, a.leadConn, r.BackupName, a.brief.Me)
 		if err != nil {
 			l.Error("define base backup: %v", err)
 			return

--- a/cmd/pbm-agent/resync.go
+++ b/cmd/pbm-agent/resync.go
@@ -81,14 +81,14 @@ func (a *Agent) Resync(ctx context.Context, cmd *ctrl.ResyncCmd, opid ctrl.OPID,
 	l.Info("succeed")
 }
 
-func (a *Agent) handleSyncAllProfiles(ctx context.Context, clear bool) error {
+func (a *Agent) handleSyncAllProfiles(ctx context.Context, clearProfile bool) error {
 	profiles, err := config.ListProfiles(ctx, a.leadConn)
 	if err != nil {
 		return errors.Wrap(err, "get config profiles")
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
-	if clear {
+	if clearProfile {
 		for i := range profiles {
 			eg.Go(func() error {
 				return a.helpClearProfileBackups(ctx, profiles[i].Name)
@@ -105,7 +105,7 @@ func (a *Agent) handleSyncAllProfiles(ctx context.Context, clear bool) error {
 	return eg.Wait()
 }
 
-func (a *Agent) handleSyncProfile(ctx context.Context, name string, clear bool) error {
+func (a *Agent) handleSyncProfile(ctx context.Context, name string, clearProfile bool) error {
 	profile, err := config.GetProfile(ctx, a.leadConn, name)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -115,7 +115,7 @@ func (a *Agent) handleSyncProfile(ctx context.Context, name string, clear bool) 
 		return errors.Wrap(err, "get config profile")
 	}
 
-	if clear {
+	if clearProfile {
 		err = a.helpClearProfileBackups(ctx, profile.Name)
 	} else {
 		err = a.helpSyncProfileBackups(ctx, profile)

--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -120,7 +120,7 @@ func testStorage(mURL string, compression compress.CompressionType, level *int, 
 	}
 	defer client.Disconnect(context.Background()) //nolint:errcheck
 
-	stg, err := util.GetStorageFromNode(context.Background(), client, "", log.DiscardEvent)
+	stg, err := util.GetStorage(context.Background(), client, "", log.DiscardEvent)
 	if err != nil {
 		stdlog.Fatalln("Error: get storage:", err)
 	}

--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -120,7 +120,7 @@ func testStorage(mURL string, compression compress.CompressionType, level *int, 
 	}
 	defer client.Disconnect(context.Background()) //nolint:errcheck
 
-	stg, err := util.GetStorage(context.Background(), client, log.DiscardEvent)
+	stg, err := util.GetStorageFromNode(context.Background(), client, "", log.DiscardEvent)
 	if err != nil {
 		stdlog.Fatalln("Error: get storage:", err)
 	}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -378,7 +378,12 @@ func byteCountIEC(b int64) string {
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
-func describeBackup(ctx context.Context, pbm *sdk.Client, b *descBcp) (fmt.Stringer, error) {
+func describeBackup(
+	ctx context.Context,
+	pbm *sdk.Client,
+	b *descBcp,
+	node string,
+) (fmt.Stringer, error) {
 	bcp, err := pbm.GetBackupByName(ctx, b.name, sdk.GetBackupByNameOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "get backup meta")
@@ -388,7 +393,7 @@ func describeBackup(ctx context.Context, pbm *sdk.Client, b *descBcp) (fmt.Strin
 	if b.coll || bcp.Size == 0 {
 		// to read backed up collection names
 		// or calculate size of files for legacy backups
-		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -393,7 +393,7 @@ func describeBackup(
 	if b.coll || bcp.Size == 0 {
 		// to read backed up collection names
 		// or calculate size of files for legacy backups
-		stg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -526,9 +526,9 @@ func main() {
 	case descBcpCmd.FullCommand():
 		out, err = describeBackup(ctx, pbm, &descBcp, node)
 	case restoreCmd.FullCommand():
-		out, err = runRestore(ctx, conn, pbm, &restore, pbmOutF)
+		out, err = runRestore(ctx, conn, pbm, &restore, node, pbmOutF)
 	case replayCmd.FullCommand():
-		out, err = replayOplog(ctx, conn, pbm, replayOpts, pbmOutF)
+		out, err = replayOplog(ctx, conn, pbm, replayOpts, node, pbmOutF)
 	case listCmd.FullCommand():
 		out, err = runList(ctx, conn, pbm, &list)
 	case deleteBcpCmd.FullCommand():

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -496,7 +496,7 @@ func main() {
 
 		inf, err := topo.GetNodeInfo(ctx, conn.MongoClient())
 		if err != nil {
-			//todo
+			exitErr(errors.Wrap(err, "unable to obtain node info"), pbmOutF)
 		}
 		node = inf.Me
 	}

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
+	"github.com/percona/percona-backup-mongodb/pbm/topo"
 	"github.com/percona/percona-backup-mongodb/pbm/version"
 	"github.com/percona/percona-backup-mongodb/sdk"
 )
@@ -468,6 +469,7 @@ func main() {
 
 	var conn connect.Client
 	var pbm *sdk.Client
+	var node string
 	// we don't need pbm connection if it is `pbm describe-restore -c ...`
 	// or `pbm restore-finish `
 	if describeRestoreOpts.cfg == "" && finishRestore.cfg == "" {
@@ -491,6 +493,12 @@ func main() {
 			exitErr(errors.Wrap(err, "init sdk"), pbmOutF)
 		}
 		defer pbm.Close(context.Background())
+
+		inf, err := topo.GetNodeInfo(ctx, conn.MongoClient())
+		if err != nil {
+			//todo
+		}
+		node = inf.Me
 	}
 
 	switch cmd {
@@ -514,9 +522,9 @@ func main() {
 	case backupFinishCmd.FullCommand():
 		out, err = runFinishBcp(ctx, conn, finishBackupName)
 	case restoreFinishCmd.FullCommand():
-		out, err = runFinishRestore(finishRestore)
+		out, err = runFinishRestore(finishRestore, node)
 	case descBcpCmd.FullCommand():
-		out, err = describeBackup(ctx, pbm, &descBcp)
+		out, err = describeBackup(ctx, pbm, &descBcp, node)
 	case restoreCmd.FullCommand():
 		out, err = runRestore(ctx, conn, pbm, &restore, pbmOutF)
 	case replayCmd.FullCommand():
@@ -534,7 +542,7 @@ func main() {
 	case statusCmd.FullCommand():
 		out, err = status(ctx, conn, pbm, *mURL, statusOpts, pbmOutF == outJSONpretty)
 	case describeRestoreCmd.FullCommand():
-		out, err = describeRestore(ctx, conn, describeRestoreOpts)
+		out, err = describeRestore(ctx, conn, describeRestoreOpts, node)
 	}
 
 	if err != nil {

--- a/cmd/pbm/oplog.go
+++ b/cmd/pbm/oplog.go
@@ -46,6 +46,7 @@ func replayOplog(
 	conn connect.Client,
 	pbm *sdk.Client,
 	o replayOptions,
+	node string,
 	outf outFormat,
 ) (fmt.Stringer, error) {
 	rsMap, err := parseRSNamesMapping(o.rsMap)
@@ -105,7 +106,7 @@ func replayOplog(
 	}
 
 	fmt.Print("Started.\nWaiting to finish")
-	err = waitRestore(ctx, conn, m, defs.StatusDone, 0)
+	err = waitRestore(ctx, conn, m, node, defs.StatusDone, 0)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = errWaitTimeout

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -586,7 +586,7 @@ func (r describeRestoreResult) String() string {
 	return string(b)
 }
 
-func getRestoreMetaStg(cfgPath string, node string) (storage.Storage, error) {
+func getRestoreMetaStg(cfgPath, node string) (storage.Storage, error) {
 	buf, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read config file")

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -204,7 +204,7 @@ func waitRestore(
 	ep, _ := config.GetEpoch(ctx, conn)
 	l := log.FromContext(ctx).
 		NewEvent(string(ctrl.CmdRestore), m.Backup, m.OPID, ep.TS())
-	stg, err := util.GetStorageFromNode(ctx, conn, node, l)
+	stg, err := util.GetStorage(ctx, conn, node, l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -424,7 +424,7 @@ func doRestore(
 		ep, _ := config.GetEpoch(ctx, conn)
 		l := log.FromContext(ctx).NewEvent(string(ctrl.CmdRestore), bcp, "", ep.TS())
 
-		stg, err := util.GetStorageFromNode(ctx, conn, node, l)
+		stg, err := util.GetStorage(ctx, conn, node, l)
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}
@@ -599,7 +599,7 @@ func getRestoreMetaStg(cfgPath string, node string) (storage.Storage, error) {
 	}
 
 	l := log.New(nil, "cli", "").NewEvent("", "", "", primitive.Timestamp{})
-	return util.StorageFromConfigAndNode(&cfg.Storage, node, l)
+	return util.StorageFromConfig(&cfg.Storage, node, l)
 }
 
 func describeRestore(

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -436,8 +436,8 @@ func doRestore(
 	return waitForRestoreStatus(startCtx, conn, name, fn)
 }
 
-func runFinishRestore(o descrRestoreOpts) (fmt.Stringer, error) {
-	stg, err := getRestoreMetaStg(o.cfg)
+func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {
+	stg, err := getRestoreMetaStg(o.cfg, node)
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
@@ -583,7 +583,7 @@ func (r describeRestoreResult) String() string {
 	return string(b)
 }
 
-func getRestoreMetaStg(cfgPath string) (storage.Storage, error) {
+func getRestoreMetaStg(cfgPath string, node string) (storage.Storage, error) {
 	buf, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read config file")
@@ -596,17 +596,22 @@ func getRestoreMetaStg(cfgPath string) (storage.Storage, error) {
 	}
 
 	l := log.New(nil, "cli", "").NewEvent("", "", "", primitive.Timestamp{})
-	return util.StorageFromConfig(&cfg.Storage, l)
+	return util.StorageFromConfigAndNode(&cfg.Storage, node, l)
 }
 
-func describeRestore(ctx context.Context, conn connect.Client, o descrRestoreOpts) (fmt.Stringer, error) {
+func describeRestore(
+	ctx context.Context,
+	conn connect.Client,
+	o descrRestoreOpts,
+	node string,
+) (fmt.Stringer, error) {
 	var (
 		meta *restore.RestoreMeta
 		err  error
 		res  describeRestoreResult
 	)
 	if o.cfg != "" {
-		stg, err := getRestoreMetaStg(o.cfg)
+		stg, err := getRestoreMetaStg(o.cfg, node)
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -573,7 +573,7 @@ func getStorageStat(
 	// which the `confsrv` param in `bcpMatchCluster` is all about
 	bcpsMatchCluster(bcps, ver.VersionString, fcv, shards, inf.SetName, rsMap)
 
-	stg, err := util.GetStorageFromNode(ctx, conn, inf.Me,
+	stg, err := util.GetStorage(ctx, conn, inf.Me,
 		log.FromContext(ctx).NewEvent("", "", "", primitive.Timestamp{}))
 	if err != nil {
 		return s, errors.Wrap(err, "get storage")

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -573,9 +573,8 @@ func getStorageStat(
 	// which the `confsrv` param in `bcpMatchCluster` is all about
 	bcpsMatchCluster(bcps, ver.VersionString, fcv, shards, inf.SetName, rsMap)
 
-	stg, err := util.GetStorage(ctx, conn,
-		log.FromContext(ctx).
-			NewEvent("", "", "", primitive.Timestamp{}))
+	stg, err := util.GetStorageFromNode(ctx, conn, inf.Me,
+		log.FromContext(ctx).NewEvent("", "", "", primitive.Timestamp{}))
 	if err != nil {
 		return s, errors.Wrap(err, "get storage")
 	}

--- a/e2e-tests/cmd/ensure-oplog/main.go
+++ b/e2e-tests/cmd/ensure-oplog/main.go
@@ -251,7 +251,7 @@ func ensureReplsetOplog(ctx context.Context, uri string, from, till primitive.Ti
 		return errors.Wrap(err, "get config")
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, "", log.FromContext(ctx).NewDefaultEvent())
+	stg, err := util.StorageFromConfig(&cfg.Storage, "", log.FromContext(ctx).NewDefaultEvent())
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}

--- a/e2e-tests/cmd/ensure-oplog/main.go
+++ b/e2e-tests/cmd/ensure-oplog/main.go
@@ -251,7 +251,7 @@ func ensureReplsetOplog(ctx context.Context, uri string, from, till primitive.Ti
 		return errors.Wrap(err, "get config")
 	}
 
-	stg, err := util.StorageFromConfig(&cfg.Storage, log.FromContext(ctx).NewDefaultEvent())
+	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, "", log.FromContext(ctx).NewDefaultEvent())
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -58,7 +58,7 @@ func (m *MongoPBM) DeleteBackup(ctx context.Context, bcpName string) error {
 func (m *MongoPBM) Storage(ctx context.Context) (storage.Storage, error) {
 	l := log.FromContext(ctx).
 		NewEvent("", "", "", primitive.Timestamp{})
-	return util.GetStorageFromNode(ctx, m.conn, "", l)
+	return util.GetStorage(ctx, m.conn, "", l)
 }
 
 func (m *MongoPBM) StoreResync(ctx context.Context) error {

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -52,13 +52,13 @@ func (m *MongoPBM) DeleteBackup(ctx context.Context, bcpName string) error {
 	l := log.FromContext(ctx).
 		NewEvent(string(ctrl.CmdDeleteBackup), "", "", primitive.Timestamp{})
 	ctx = log.SetLogEventToContext(ctx, l)
-	return backup.DeleteBackup(ctx, m.conn, bcpName)
+	return backup.DeleteBackup(ctx, m.conn, bcpName, "")
 }
 
 func (m *MongoPBM) Storage(ctx context.Context) (storage.Storage, error) {
 	l := log.FromContext(ctx).
 		NewEvent("", "", "", primitive.Timestamp{})
-	return util.GetStorage(ctx, m.conn, l)
+	return util.GetStorageFromNode(ctx, m.conn, "", l)
 }
 
 func (m *MongoPBM) StoreResync(ctx context.Context) error {

--- a/e2e-tests/pkg/pbm/mongo_pbm.go
+++ b/e2e-tests/pkg/pbm/mongo_pbm.go
@@ -71,7 +71,7 @@ func (m *MongoPBM) StoreResync(ctx context.Context) error {
 		return errors.Wrap(err, "get config")
 	}
 
-	return resync.Resync(ctx, m.conn, &cfg.Storage)
+	return resync.Resync(ctx, m.conn, &cfg.Storage, "")
 }
 
 func (m *MongoPBM) Conn() connect.Client {

--- a/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
+++ b/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
@@ -73,7 +73,7 @@ func listAllFiles(confFilepath string) ([]storage.FileInfo, error) {
 		return nil, errors.Wrap(err, "parse config")
 	}
 
-	stg, err := util.StorageFromConfig(&cfg.Storage, nil)
+	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "storage from config")
 	}

--- a/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
+++ b/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
@@ -73,7 +73,7 @@ func listAllFiles(confFilepath string) ([]storage.FileInfo, error) {
 		return nil, errors.Wrap(err, "parse config")
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&cfg.Storage, "", nil)
+	stg, err := util.StorageFromConfig(&cfg.Storage, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "storage from config")
 	}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -201,7 +201,7 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 		rsMeta.IsConfigSvr = &v
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&b.config.Storage, inf.Me, l)
+	stg, err := util.StorageFromConfig(&b.config.Storage, inf.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "unable to get PBM storage configuration settings")
 	}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -201,7 +201,7 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 		rsMeta.IsConfigSvr = &v
 	}
 
-	stg, err := util.StorageFromConfig(&b.config.Storage, l)
+	stg, err := util.StorageFromConfigAndNode(&b.config.Storage, inf.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "unable to get PBM storage configuration settings")
 	}

--- a/pbm/backup/delete.go
+++ b/pbm/backup/delete.go
@@ -79,7 +79,7 @@ func deleteBackupImpl(
 		return err
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -113,7 +113,7 @@ func deleteIncremetalChainImpl(ctx context.Context, conn connect.Client, bcp *Ba
 		all = append(all, bcps...)
 	}
 
-	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -331,7 +331,7 @@ func DeleteBackupBefore(
 		return nil
 	}
 
-	stg, err := util.GetStorageFromNode(ctx, conn, node, log.LogEventFromContext(ctx))
+	stg, err := util.GetStorage(ctx, conn, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}

--- a/pbm/backup/delete.go
+++ b/pbm/backup/delete.go
@@ -55,26 +55,31 @@ type CleanupInfo struct {
 
 // DeleteBackup deletes backup with the given name from the current storage
 // and pbm database
-func DeleteBackup(ctx context.Context, conn connect.Client, name string) error {
+func DeleteBackup(ctx context.Context, conn connect.Client, name, node string) error {
 	bcp, err := NewDBManager(conn).GetBackupByName(ctx, name)
 	if err != nil {
 		return errors.Wrap(err, "get backup meta")
 	}
 
 	if bcp.Type == defs.IncrementalBackup {
-		return deleteIncremetalChainImpl(ctx, conn, bcp)
+		return deleteIncremetalChainImpl(ctx, conn, bcp, node)
 	}
 
-	return deleteBackupImpl(ctx, conn, bcp)
+	return deleteBackupImpl(ctx, conn, bcp, node)
 }
 
-func deleteBackupImpl(ctx context.Context, conn connect.Client, bcp *BackupMeta) error {
+func deleteBackupImpl(
+	ctx context.Context,
+	conn connect.Client,
+	bcp *BackupMeta,
+	node string,
+) error {
 	err := CanDeleteBackup(ctx, conn, bcp)
 	if err != nil {
 		return err
 	}
 
-	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -92,7 +97,7 @@ func deleteBackupImpl(ctx context.Context, conn connect.Client, bcp *BackupMeta)
 	return nil
 }
 
-func deleteIncremetalChainImpl(ctx context.Context, conn connect.Client, bcp *BackupMeta) error {
+func deleteIncremetalChainImpl(ctx context.Context, conn connect.Client, bcp *BackupMeta, node string) error {
 	increments, err := FetchAllIncrements(ctx, conn, bcp)
 	if err != nil {
 		return err
@@ -108,7 +113,7 @@ func deleteIncremetalChainImpl(ctx context.Context, conn connect.Client, bcp *Ba
 		all = append(all, bcps...)
 	}
 
-	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -316,6 +321,7 @@ func DeleteBackupBefore(
 	conn connect.Client,
 	t time.Time,
 	bcpType defs.BackupType,
+	node string,
 ) error {
 	backups, err := ListDeleteBackupBefore(ctx, conn, primitive.Timestamp{T: uint32(t.Unix())}, bcpType)
 	if err != nil {
@@ -325,7 +331,7 @@ func DeleteBackupBefore(
 		return nil
 	}
 
-	stg, err := util.GetStorage(ctx, conn, log.LogEventFromContext(ctx))
+	stg, err := util.GetStorageFromNode(ctx, conn, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -170,11 +170,6 @@ func (b *Backup) doLogical(
 	snapshotSize, err := snapshot.UploadDump(ctx,
 		dump,
 		func(ns, ext string, r io.Reader) error {
-			stg, err := util.StorageFromConfig(&b.config.Storage, l)
-			if err != nil {
-				return errors.Wrap(err, "get storage")
-			}
-
 			filepath := path.Join(bcp.Name, rsMeta.Name, ns+ext)
 			return stg.Save(filepath, r, nssSize[ns])
 		},

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -170,6 +170,10 @@ func (b *Backup) doLogical(
 	snapshotSize, err := snapshot.UploadDump(ctx,
 		dump,
 		func(ns, ext string, r io.Reader) error {
+			stg, err := util.StorageFromConfig(&b.config.Storage, b.brief.Me, l)
+			if err != nil {
+				return errors.Wrap(err, "get storage")
+			}
 			filepath := path.Join(bcp.Name, rsMeta.Name, ns+ext)
 			return stg.Save(filepath, r, nssSize[ns])
 		},

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -178,7 +178,7 @@ func (r *Restore) Snapshot(
 		return err
 	}
 
-	r.bcpStg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, r.brief.Me, r.log)
+	r.bcpStg, err = util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
 	if err != nil {
 		return errors.Wrap(err, "get backup storage")
 	}
@@ -296,11 +296,11 @@ func (r *Restore) PITR(
 			"Try to set an earlier snapshot. Or leave the snapshot empty so PBM will choose one.")
 	}
 
-	r.bcpStg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, r.brief.Me, r.log)
+	r.bcpStg, err = util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
 	if err != nil {
 		return errors.Wrap(err, "get backup storage")
 	}
-	r.oplogStg, err = util.GetStorageFromNode(ctx, r.leadConn, r.nodeInfo.Me, log.LogEventFromContext(ctx))
+	r.oplogStg, err = util.GetStorage(ctx, r.leadConn, r.nodeInfo.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get oplog storage")
 	}
@@ -432,7 +432,7 @@ func (r *Restore) ReplayOplog(ctx context.Context, cmd *ctrl.ReplayCmd, opid ctr
 		return r.Done(ctx) // skip. no oplog for current rs
 	}
 
-	r.oplogStg, err = util.GetStorageFromNode(ctx, r.leadConn, r.nodeInfo.Me, log.LogEventFromContext(ctx))
+	r.oplogStg, err = util.GetStorage(ctx, r.leadConn, r.nodeInfo.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrapf(err, "get oplog storage")
 	}
@@ -589,7 +589,7 @@ func LookupBackupMeta(
 	}
 
 	var stg storage.Storage
-	stg, err = util.GetStorageFromNode(ctx, conn, node, log.LogEventFromContext(ctx))
+	stg, err = util.GetStorage(ctx, conn, node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
@@ -802,7 +802,7 @@ func (r *Restore) RunSnapshot(
 
 		rdr, err = snapshot.DownloadDump(
 			func(ns string) (io.ReadCloser, error) {
-				stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, r.brief.Me, r.log)
+				stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
 				if err != nil {
 					return nil, errors.Wrap(err, "get storage")
 				}

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1797,7 +1797,7 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 		return errors.Wrap(err, "get pbm config")
 	}
 
-	r.stg, err = util.StorageFromConfig(&cfg.Storage, l)
+	r.stg, err = util.StorageFromConfigAndNode(&cfg.Storage, r.nodeInfo.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -2156,7 +2156,7 @@ func (r *PhysRestore) prepareBackup(ctx context.Context, backupName string) erro
 		return errors.Wrap(err, "get backup metadata")
 	}
 
-	r.bcpStg, err = util.StorageFromConfig(&r.bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+	r.bcpStg, err = util.StorageFromConfigAndNode(&r.bcp.Store.StorageConf, r.nodeInfo.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get backup storage")
 	}

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1797,7 +1797,7 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 		return errors.Wrap(err, "get pbm config")
 	}
 
-	r.stg, err = util.StorageFromConfigAndNode(&cfg.Storage, r.nodeInfo.Me, l)
+	r.stg, err = util.StorageFromConfig(&cfg.Storage, r.nodeInfo.Me, l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -2156,7 +2156,7 @@ func (r *PhysRestore) prepareBackup(ctx context.Context, backupName string) erro
 		return errors.Wrap(err, "get backup metadata")
 	}
 
-	r.bcpStg, err = util.StorageFromConfigAndNode(&r.bcp.Store.StorageConf, r.nodeInfo.Me, log.LogEventFromContext(ctx))
+	r.bcpStg, err = util.StorageFromConfig(&r.bcp.Store.StorageConf, r.nodeInfo.Me, log.LogEventFromContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "get backup storage")
 	}

--- a/pbm/resync/rsync.go
+++ b/pbm/resync/rsync.go
@@ -29,7 +29,7 @@ import (
 func Resync(ctx context.Context, conn connect.Client, cfg *config.StorageConf, node string) error {
 	l := log.LogEventFromContext(ctx)
 
-	stg, err := util.StorageFromConfigAndNode(cfg, node, l)
+	stg, err := util.StorageFromConfig(cfg, node, l)
 	if err != nil {
 		return errors.Wrap(err, "unable to get backup store")
 	}
@@ -101,7 +101,7 @@ func SyncBackupList(
 ) error {
 	l := log.LogEventFromContext(ctx)
 
-	stg, err := util.StorageFromConfigAndNode(cfg, node, l)
+	stg, err := util.StorageFromConfig(cfg, node, l)
 	if err != nil {
 		return errors.Wrap(err, "storage from config")
 	}

--- a/pbm/resync/rsync.go
+++ b/pbm/resync/rsync.go
@@ -26,10 +26,10 @@ import (
 //
 // It checks for read and write permissions, drops all meta from the database
 // and populate it again by reading meta from the storage.
-func Resync(ctx context.Context, conn connect.Client, cfg *config.StorageConf) error {
+func Resync(ctx context.Context, conn connect.Client, cfg *config.StorageConf, node string) error {
 	l := log.LogEventFromContext(ctx)
 
-	stg, err := util.StorageFromConfig(cfg, l)
+	stg, err := util.StorageFromConfigAndNode(cfg, node, l)
 	if err != nil {
 		return errors.Wrap(err, "unable to get backup store")
 	}
@@ -52,7 +52,7 @@ func Resync(ctx context.Context, conn connect.Client, cfg *config.StorageConf) e
 		}
 	}
 
-	err = SyncBackupList(ctx, conn, cfg, "")
+	err = SyncBackupList(ctx, conn, cfg, "", node)
 	if err != nil {
 		l.Error("failed sync backup metadata: %v", err)
 	}
@@ -97,10 +97,11 @@ func SyncBackupList(
 	conn connect.Client,
 	cfg *config.StorageConf,
 	profile string,
+	node string,
 ) error {
 	l := log.LogEventFromContext(ctx)
 
-	stg, err := util.StorageFromConfig(cfg, l)
+	stg, err := util.StorageFromConfigAndNode(cfg, node, l)
 	if err != nil {
 		return errors.Wrap(err, "storage from config")
 	}

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -32,6 +32,7 @@ const (
 	maxBlocks = 50_000
 )
 
+//nolint:lll
 type Config struct {
 	Account        string            `bson:"account" json:"account,omitempty" yaml:"account,omitempty"`
 	Container      string            `bson:"container" json:"container,omitempty" yaml:"container,omitempty"`

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"path"
 	"runtime"
@@ -32,11 +33,12 @@ const (
 )
 
 type Config struct {
-	Account     string      `bson:"account" json:"account,omitempty" yaml:"account,omitempty"`
-	Container   string      `bson:"container" json:"container,omitempty" yaml:"container,omitempty"`
-	EndpointURL string      `bson:"endpointUrl" json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
-	Prefix      string      `bson:"prefix" json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Credentials Credentials `bson:"credentials" json:"-" yaml:"credentials"`
+	Account        string            `bson:"account" json:"account,omitempty" yaml:"account,omitempty"`
+	Container      string            `bson:"container" json:"container,omitempty" yaml:"container,omitempty"`
+	EndpointURL    string            `bson:"endpointUrl" json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
+	EndpointURLMap map[string]string `bson:"endpointUrlMap,omitempty" json:"endpointUrlMap,omitempty" yaml:"endpointUrlMap,omitempty"`
+	Prefix         string            `bson:"prefix" json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Credentials    Credentials       `bson:"credentials" json:"-" yaml:"credentials"`
 }
 
 func (cfg *Config) Clone() *Config {
@@ -45,6 +47,7 @@ func (cfg *Config) Clone() *Config {
 	}
 
 	rv := *cfg
+	rv.EndpointURLMap = maps.Clone(cfg.EndpointURLMap)
 	return &rv
 }
 
@@ -62,6 +65,9 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.EndpointURL != other.EndpointURL {
 		return false
 	}
+	if !maps.Equal(cfg.EndpointURLMap, other.EndpointURLMap) {
+		return false
+	}
 	if cfg.Prefix != other.Prefix {
 		return false
 	}
@@ -72,23 +78,39 @@ func (cfg *Config) Equal(other *Config) bool {
 	return true
 }
 
+// resolveEndpointURL returns endpoint url based on provided
+// EndpointURL or associated EndpointURLMap configuration fields.
+// If specified EndpointURLMap overrides EndpointURL field.
+func (cfg *Config) resolveEndpointURL(node string) string {
+	ep := cfg.EndpointURL
+	if epm, ok := cfg.EndpointURLMap[node]; ok {
+		ep = epm
+	}
+	if ep == "" {
+		ep = fmt.Sprintf(BlobURL, cfg.Account)
+	}
+	return ep
+}
+
 type Credentials struct {
 	Key string `bson:"key" json:"key,omitempty" yaml:"key,omitempty"`
 }
 
 type Blob struct {
 	opts *Config
+	node string
 	log  log.LogEvent
 	// url  *url.URL
 	c *azblob.Client
 }
 
-func New(opts *Config, l log.LogEvent) (*Blob, error) {
+func New(opts *Config, node string, l log.LogEvent) (*Blob, error) {
 	if l == nil {
 		l = log.DiscardEvent
 	}
 	b := &Blob{
 		opts: opts,
+		node: node,
 		log:  l,
 	}
 
@@ -295,10 +317,7 @@ func (b *Blob) client() (*azblob.Client, error) {
 	opts.Retry = policy.RetryOptions{
 		MaxRetries: defaultRetries,
 	}
-	epURL := b.opts.EndpointURL
-	if epURL == "" {
-		epURL = fmt.Sprintf(BlobURL, b.opts.Account)
-	}
+	epURL := b.opts.resolveEndpointURL(b.node)
 	return azblob.NewClientWithSharedKeyCredential(epURL, cred, opts)
 }
 

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -40,17 +40,18 @@ const (
 
 //nolint:lll
 type Config struct {
-	Provider             string      `bson:"provider,omitempty" json:"provider,omitempty" yaml:"provider,omitempty"`
-	Region               string      `bson:"region" json:"region" yaml:"region"`
-	EndpointURL          string      `bson:"endpointUrl,omitempty" json:"endpointUrl" yaml:"endpointUrl,omitempty"`
-	ForcePathStyle       *bool       `bson:"forcePathStyle,omitempty" json:"forcePathStyle,omitempty" yaml:"forcePathStyle,omitempty"`
-	Bucket               string      `bson:"bucket" json:"bucket" yaml:"bucket"`
-	Prefix               string      `bson:"prefix,omitempty" json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Credentials          Credentials `bson:"credentials" json:"-" yaml:"credentials"`
-	ServerSideEncryption *AWSsse     `bson:"serverSideEncryption,omitempty" json:"serverSideEncryption,omitempty" yaml:"serverSideEncryption,omitempty"`
-	UploadPartSize       int         `bson:"uploadPartSize,omitempty" json:"uploadPartSize,omitempty" yaml:"uploadPartSize,omitempty"`
-	MaxUploadParts       int         `bson:"maxUploadParts,omitempty" json:"maxUploadParts,omitempty" yaml:"maxUploadParts,omitempty"`
-	StorageClass         string      `bson:"storageClass,omitempty" json:"storageClass,omitempty" yaml:"storageClass,omitempty"`
+	Provider             string            `bson:"provider,omitempty" json:"provider,omitempty" yaml:"provider,omitempty"`
+	Region               string            `bson:"region" json:"region" yaml:"region"`
+	EndpointURL          string            `bson:"endpointUrl,omitempty" json:"endpointUrl" yaml:"endpointUrl,omitempty"`
+	EndpointURLMap       map[string]string `bson:"endpointUrlMap,omitempty" json:"endpointUrlMap,omitempty" yaml:"endpointUrlMap,omitempty"`
+	ForcePathStyle       *bool             `bson:"forcePathStyle,omitempty" json:"forcePathStyle,omitempty" yaml:"forcePathStyle,omitempty"`
+	Bucket               string            `bson:"bucket" json:"bucket" yaml:"bucket"`
+	Prefix               string            `bson:"prefix,omitempty" json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Credentials          Credentials       `bson:"credentials" json:"-" yaml:"credentials"`
+	ServerSideEncryption *AWSsse           `bson:"serverSideEncryption,omitempty" json:"serverSideEncryption,omitempty" yaml:"serverSideEncryption,omitempty"`
+	UploadPartSize       int               `bson:"uploadPartSize,omitempty" json:"uploadPartSize,omitempty" yaml:"uploadPartSize,omitempty"`
+	MaxUploadParts       int               `bson:"maxUploadParts,omitempty" json:"maxUploadParts,omitempty" yaml:"maxUploadParts,omitempty"`
+	StorageClass         string            `bson:"storageClass,omitempty" json:"storageClass,omitempty" yaml:"storageClass,omitempty"`
 
 	// InsecureSkipTLSVerify disables client verification of the server's
 	// certificate chain and host name

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path"
@@ -133,6 +134,7 @@ func (cfg *Config) Clone() *Config {
 	}
 
 	rv := *cfg
+	rv.EndpointURLMap = maps.Clone(cfg.EndpointURLMap)
 	if cfg.ForcePathStyle != nil {
 		a := *cfg.ForcePathStyle
 		rv.ForcePathStyle = &a
@@ -158,6 +160,9 @@ func (cfg *Config) Equal(other *Config) bool {
 		return false
 	}
 	if cfg.EndpointURL != other.EndpointURL {
+		return false
+	}
+	if !maps.Equal(cfg.EndpointURLMap, other.EndpointURLMap) {
 		return false
 	}
 	if cfg.Bucket != other.Bucket {

--- a/pbm/util/storage.go
+++ b/pbm/util/storage.go
@@ -45,12 +45,16 @@ func StorageFromConfigAndNode(cfg *config.StorageConf, node string, l log.LogEve
 // GetStorage reads current storage config and creates and
 // returns respective storage.Storage object
 func GetStorage(ctx context.Context, m connect.Client, l log.LogEvent) (storage.Storage, error) {
+	return GetStorageFromNode(ctx, m, "", l)
+}
+
+func GetStorageFromNode(ctx context.Context, m connect.Client, node string, l log.LogEvent) (storage.Storage, error) {
 	c, err := config.GetConfig(ctx, m)
 	if err != nil {
 		return nil, errors.Wrap(err, "get config")
 	}
 
-	return StorageFromConfig(&c.Storage, l)
+	return StorageFromConfigAndNode(&c.Storage, node, l)
 }
 
 // Initialize write current PBM version to PBM init file.

--- a/pbm/util/storage.go
+++ b/pbm/util/storage.go
@@ -20,12 +20,9 @@ import (
 // ErrStorageUndefined is an error for undefined storage
 var ErrStorageUndefined = errors.New("storage undefined")
 
-// StorageFromConfig creates and returns a storage object based on a given config
-func StorageFromConfig(cfg *config.StorageConf, l log.LogEvent) (storage.Storage, error) {
-	return StorageFromConfigAndNode(cfg, "", l)
-}
-
-func StorageFromConfigAndNode(cfg *config.StorageConf, node string, l log.LogEvent) (storage.Storage, error) {
+// StorageFromConfig creates and returns a storage object based on a given config and node name.
+// Node name is used for fetching endpoint url from config for specific cluster member (node).
+func StorageFromConfig(cfg *config.StorageConf, node string, l log.LogEvent) (storage.Storage, error) {
 	switch cfg.Type {
 	case storage.S3:
 		return s3.New(cfg.S3, node, l)
@@ -43,18 +40,14 @@ func StorageFromConfigAndNode(cfg *config.StorageConf, node string, l log.LogEve
 }
 
 // GetStorage reads current storage config and creates and
-// returns respective storage.Storage object
-func GetStorage(ctx context.Context, m connect.Client, l log.LogEvent) (storage.Storage, error) {
-	return GetStorageFromNode(ctx, m, "", l)
-}
-
-func GetStorageFromNode(ctx context.Context, m connect.Client, node string, l log.LogEvent) (storage.Storage, error) {
+// returns respective storage.Storage object.
+func GetStorage(ctx context.Context, m connect.Client, node string, l log.LogEvent) (storage.Storage, error) {
 	c, err := config.GetConfig(ctx, m)
 	if err != nil {
 		return nil, errors.Wrap(err, "get config")
 	}
 
-	return StorageFromConfigAndNode(&c.Storage, node, l)
+	return StorageFromConfig(&c.Storage, node, l)
 }
 
 // Initialize write current PBM version to PBM init file.

--- a/pbm/util/storage.go
+++ b/pbm/util/storage.go
@@ -22,9 +22,13 @@ var ErrStorageUndefined = errors.New("storage undefined")
 
 // StorageFromConfig creates and returns a storage object based on a given config
 func StorageFromConfig(cfg *config.StorageConf, l log.LogEvent) (storage.Storage, error) {
+	return StorageFromConfigAndNode(cfg, "", l)
+}
+
+func StorageFromConfigAndNode(cfg *config.StorageConf, node string, l log.LogEvent) (storage.Storage, error) {
 	switch cfg.Type {
 	case storage.S3:
-		return s3.New(cfg.S3, l)
+		return s3.New(cfg.S3, node, l)
 	case storage.Azure:
 		return azure.New(cfg.Azure, l)
 	case storage.Filesystem:

--- a/pbm/util/storage.go
+++ b/pbm/util/storage.go
@@ -27,7 +27,7 @@ func StorageFromConfig(cfg *config.StorageConf, node string, l log.LogEvent) (st
 	case storage.S3:
 		return s3.New(cfg.S3, node, l)
 	case storage.Azure:
-		return azure.New(cfg.Azure, l)
+		return azure.New(cfg.Azure, node, l)
 	case storage.Filesystem:
 		return fs.New(cfg.Filesystem)
 	case storage.Blackhole:

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -183,7 +183,7 @@ func (c *Client) fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata)
 	eg.SetLimit(runtime.NumCPU())
 
 	if version.HasFilelistFile(bcp.PBMVersion) {
-		stg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
 		if err != nil {
 			return errors.Wrap(err, "get storage")
 		}
@@ -242,7 +242,7 @@ func (c *Client) fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata)
 }
 
 func (c *Client) getStorageForRead(ctx context.Context, bcp *backup.BackupMeta) (storage.Storage, error) {
-	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
+	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -36,6 +36,7 @@ var (
 
 type Client struct {
 	conn connect.Client
+	node string
 }
 
 func (c *Client) Close(ctx context.Context) error {
@@ -165,7 +166,7 @@ func (c *Client) getBackupHelper(
 	}
 
 	if options.FetchFilelist {
-		err := fillFilelistForBackup(ctx, bcp)
+		err := c.fillFilelistForBackup(ctx, bcp)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetch filelist")
 		}
@@ -174,7 +175,7 @@ func (c *Client) getBackupHelper(
 	return bcp, nil
 }
 
-func fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
+func (c *Client) fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
 	var err error
 	var stg storage.Storage
 
@@ -182,7 +183,7 @@ func fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
 	eg.SetLimit(runtime.NumCPU())
 
 	if version.HasFilelistFile(bcp.PBMVersion) {
-		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfigAndNode(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
 		if err != nil {
 			return errors.Wrap(err, "get storage")
 		}
@@ -215,7 +216,7 @@ func fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
 
 			if stg == nil {
 				// in case if it is the first backup made with filelist file
-				stg, err = getStorageForRead(ctx, bcp)
+				stg, err = c.getStorageForRead(ctx, bcp)
 				if err != nil {
 					return errors.Wrap(err, "get storage")
 				}
@@ -240,8 +241,8 @@ func fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
 	return eg.Wait()
 }
 
-func getStorageForRead(ctx context.Context, bcp *backup.BackupMeta) (storage.Storage, error) {
-	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, log.LogEventFromContext(ctx))
+func (c *Client) getStorageForRead(ctx context.Context, bcp *backup.BackupMeta) (storage.Storage, error) {
+	stg, err := util.StorageFromConfigAndNode(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -13,10 +12,12 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
 	"github.com/percona/percona-backup-mongodb/pbm/restore"
+	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
 
 var (
@@ -137,7 +138,12 @@ func NewClient(ctx context.Context, uri string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{conn: conn}, nil
+	inf, err := topo.GetNodeInfo(ctx, conn.MongoClient())
+	if err != nil {
+		return nil, errors.Wrap(err, "get node info")
+	}
+
+	return &Client{conn: conn, node: inf.Me}, nil
 }
 
 func WaitForAddProfile(ctx context.Context, client *Client, cid CommandID) error {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1211

PBM's multiple endpoint feature enables possibility to specify different endpoint urls for the different cluster members, but all of them should point to the same cloud storage. 
Supported storage types are: S3 and Azure.

Example for possible configuration:
```
storage:
    type: s3
    s3:
      endpointUrl: http://S3:9000
      endpointUrlMap:
        "node01:27017": "did.socf.s3.com"
        "node03:27017": "123.12.1.202"
      ...
```