### PR TITLE
PBM-887: add diagnostic command

### DIFF
--- a/cmd/pbm/diagnostic.go
+++ b/cmd/pbm/diagnostic.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/sdk"
+)
+
+type diagnosticOptions struct {
+	path string
+	opid string
+	name string
+}
+
+func handleDiagnostic(
+	ctx context.Context,
+	pbm *sdk.Client,
+	opts diagnosticOptions,
+) (fmt.Stringer, error) {
+	if opts.opid == "" && opts.name == "" {
+		return nil, errors.New("--opid or --name must be provided")
+	}
+
+	if opts.opid == "" {
+		cid, err := sdk.FindCommandIDByName(ctx, pbm, opts.name)
+		if err != nil {
+			return nil, errors.Wrap(err, "find opid by name")
+		}
+		opts.opid = string(cid)
+	}
+
+	report, err := sdk.Diagnostic(ctx, pbm, sdk.CommandID(opts.opid))
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo, err := os.Stat(opts.path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "stat")
+		}
+		err = os.MkdirAll(opts.path, 0o777)
+		if err != nil {
+			return nil, errors.Wrap(err, "create path")
+		}
+	} else if !fileInfo.IsDir() {
+		return nil, errors.Errorf("%s is not a dir", opts.path)
+	}
+
+	err = writeToFile(opts.path, opts.opid+".report.json", report)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to save %s", filepath.Join(opts.path, opts.opid+".report.json"))
+	}
+
+	switch report.Command.Cmd {
+	case sdk.CmdBackup:
+		meta, err := pbm.GetBackupByOpID(ctx, opts.opid, sdk.GetBackupByNameOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "get backup meta")
+		}
+		err = writeToFile(opts.path, opts.opid+".backup.json", meta)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to save %s", filepath.Join(opts.path, opts.opid+".backup.json"))
+		}
+	case sdk.CmdRestore:
+		meta, err := pbm.GetRestoreByOpID(ctx, opts.opid)
+		if err != nil {
+			return nil, errors.Wrap(err, "get restore meta")
+		}
+		err = writeToFile(opts.path, opts.opid+".restore.json", meta)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to save %s", filepath.Join(opts.path, opts.opid+".restore.json"))
+		}
+	}
+
+	err = writeLogToFile(ctx, pbm, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to save command log")
+	}
+
+	return outMsg{""}, nil
+}
+
+//nolint:nonamedreturns
+func writeLogToFile(ctx context.Context, pbm *sdk.Client, opts diagnosticOptions) (err error) {
+	filename := filepath.Join(opts.path, opts.opid+".log")
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			file.Close()
+			os.Remove(filename)
+		}
+	}()
+
+	cur, err := sdk.CommandLogCursor(ctx, pbm, sdk.CommandID(opts.opid))
+	if err != nil {
+		return errors.Wrap(err, "open log cursor")
+	}
+	defer cur.Close(ctx)
+
+	eol := []byte("\n")
+	for cur.Next(ctx) {
+		rec, err := cur.Record()
+		if err != nil {
+			return errors.Wrap(err, "log: decode")
+		}
+
+		data, err := bson.MarshalExtJSON(rec, true, true)
+		if err != nil {
+			return errors.Wrap(err, "log: encode")
+		}
+
+		n, err := file.Write(data)
+		if err != nil {
+			return errors.Wrap(err, "log: write")
+		}
+		if n != len(data) {
+			return errors.Wrap(io.ErrShortWrite, "log")
+		}
+
+		n, err = file.Write(eol)
+		if err != nil {
+			return errors.Wrap(err, "log: write")
+		}
+		if n != len(eol) {
+			return errors.Wrap(io.ErrShortWrite, "log")
+		}
+	}
+
+	err = cur.Err()
+	if err != nil {
+		return errors.Wrap(err, "log cursor")
+	}
+
+	err = file.Close()
+	if err != nil {
+		return errors.Wrap(err, "failed to save file command.log")
+	}
+
+	return nil
+}
+
+func writeToFile(dirname, name string, val any) error {
+	data, err := bson.MarshalExtJSONIndent(val, true, true, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "marshal")
+	}
+
+	file, err := os.Create(filepath.Join(dirname, name))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	n, err := file.Write(data)
+	if err != nil {
+		return errors.Wrap(err, "write")
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	err = file.Close()
+	if err != nil {
+		return errors.Wrap(err, "close file")
+	}
+
+	return nil
+}

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -442,12 +442,13 @@ func main() {
 
 	diagnosticCmd := pbmCmd.Command("diagnostic", "Create diagnostic report")
 	diagnosticOpts := diagnosticOptions{}
-	diagnosticCmd.Flag("opid", "OPID of command").
-		Required().
-		StringVar(&diagnosticOpts.opid)
-	diagnosticCmd.Flag("path", "Path to dir where files will be saved").
+	diagnosticCmd.Flag("path", "Path where files will be saved").
 		Required().
 		StringVar(&diagnosticOpts.path)
+	diagnosticCmd.Flag("opid", "OPID/Command ID").
+		StringVar(&diagnosticOpts.opid)
+	diagnosticCmd.Flag("name", "Backup or Restore name").
+		StringVar(&diagnosticOpts.name)
 
 	cmd, err := pbmCmd.DefaultEnvars().Parse(os.Args[1:])
 	if err != nil {

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -440,6 +440,15 @@ func main() {
 		Short('c').
 		StringVar(&describeRestoreOpts.cfg)
 
+	diagnosticCmd := pbmCmd.Command("diagnostic", "Create diagnostic report")
+	diagnosticOpts := diagnosticOptions{}
+	diagnosticCmd.Flag("opid", "OPID of command").
+		Required().
+		StringVar(&diagnosticOpts.opid)
+	diagnosticCmd.Flag("path", "Path to dir where files will be saved").
+		Required().
+		StringVar(&diagnosticOpts.path)
+
 	cmd, err := pbmCmd.DefaultEnvars().Parse(os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error: parse command line parameters:", err)
@@ -549,6 +558,8 @@ func main() {
 		out, err = status(ctx, conn, pbm, *mURL, statusOpts, pbmOutF == outJSONpretty)
 	case describeRestoreCmd.FullCommand():
 		out, err = describeRestore(ctx, conn, describeRestoreOpts, node)
+	case diagnosticCmd.FullCommand():
+		out, err = handleDiagnostic(ctx, pbm, diagnosticOpts)
 	}
 
 	if err != nil {

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -4,15 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	stdlog "log"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
@@ -31,172 +27,6 @@ import (
 	"github.com/percona/percona-backup-mongodb/sdk"
 	"github.com/percona/percona-backup-mongodb/sdk/cli"
 )
-
-type diagnosticOptions struct {
-	path string
-	opid string
-	name string
-}
-
-func handleDiagnostic(
-	ctx context.Context,
-	pbm *sdk.Client,
-	opts diagnosticOptions,
-) (fmt.Stringer, error) {
-	if opts.opid == "" && opts.name == "" {
-		return nil, errors.New("--opid or --name must be provided")
-	}
-
-	if opts.opid == "" {
-		cid, err := sdk.FindCommandIDByName(ctx, pbm, opts.name)
-		if err != nil {
-			return nil, errors.Wrap(err, "find opid by name")
-		}
-		opts.opid = string(cid)
-	}
-
-	report, err := sdk.Diagnostic(ctx, pbm, sdk.CommandID(opts.opid))
-	if err != nil {
-		return nil, err
-	}
-
-	if fileInfo, err := os.Stat(opts.path); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, errors.Wrap(err, "stat")
-		}
-		err = os.MkdirAll(opts.path, 0o777)
-		if err != nil {
-			return nil, errors.Wrap(err, "create path")
-		}
-	} else if !fileInfo.IsDir() {
-		return nil, errors.Errorf("%s is not a dir", opts.path)
-	}
-
-	err = writeToFile(opts.path, opts.opid+".report.json", report)
-	if err != nil {
-		return nil, errors.Wrapf(err,
-			"failed to save %s", filepath.Join(opts.path, opts.opid+".report.json"))
-	}
-
-	switch report.Command.Cmd {
-	case sdk.CmdBackup:
-		meta, err := pbm.GetBackupByOpID(ctx, opts.opid, sdk.GetBackupByNameOptions{})
-		if err != nil {
-			return nil, errors.Wrap(err, "get backup meta")
-		}
-		err = writeToFile(opts.path, opts.opid+".backup.json", meta)
-		if err != nil {
-			return nil, errors.Wrapf(err,
-				"failed to save %s", filepath.Join(opts.path, opts.opid+".backup.json"))
-		}
-	case sdk.CmdRestore:
-		meta, err := pbm.GetRestoreByOpID(ctx, opts.opid)
-		if err != nil {
-			return nil, errors.Wrap(err, "get restore meta")
-		}
-		err = writeToFile(opts.path, opts.opid+".restore.json", meta)
-		if err != nil {
-			return nil, errors.Wrapf(err,
-				"failed to save %s", filepath.Join(opts.path, opts.opid+".restore.json"))
-		}
-	}
-
-	err = writeLogToFile(ctx, pbm, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to save command log")
-	}
-
-	return outMsg{""}, nil
-}
-
-//nolint:nonamedreturns
-func writeLogToFile(ctx context.Context, pbm *sdk.Client, opts diagnosticOptions) (err error) {
-	filename := filepath.Join(opts.path, opts.opid+".log")
-	file, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil {
-			file.Close()
-			os.Remove(filename)
-		}
-	}()
-
-	cur, err := sdk.CommandLogCursor(ctx, pbm, sdk.CommandID(opts.opid))
-	if err != nil {
-		return errors.Wrap(err, "open log cursor")
-	}
-	defer cur.Close(ctx)
-
-	eol := []byte("\n")
-	for cur.Next(ctx) {
-		rec, err := cur.Record()
-		if err != nil {
-			return errors.Wrap(err, "log: decode")
-		}
-
-		data, err := bson.MarshalExtJSON(rec, true, true)
-		if err != nil {
-			return errors.Wrap(err, "log: encode")
-		}
-
-		n, err := file.Write(data)
-		if err != nil {
-			return errors.Wrap(err, "log: write")
-		}
-		if n != len(data) {
-			return errors.Wrap(io.ErrShortWrite, "log")
-		}
-
-		n, err = file.Write(eol)
-		if err != nil {
-			return errors.Wrap(err, "log: write")
-		}
-		if n != len(eol) {
-			return errors.Wrap(io.ErrShortWrite, "log")
-		}
-	}
-
-	err = cur.Err()
-	if err != nil {
-		return errors.Wrap(err, "log cursor")
-	}
-
-	err = file.Close()
-	if err != nil {
-		return errors.Wrap(err, "failed to save file command.log")
-	}
-
-	return nil
-}
-
-func writeToFile(dirname, name string, val any) error {
-	data, err := bson.MarshalExtJSONIndent(val, true, true, "", "  ")
-	if err != nil {
-		return errors.Wrap(err, "marshal")
-	}
-
-	file, err := os.Create(filepath.Join(dirname, name))
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	n, err := file.Write(data)
-	if err != nil {
-		return errors.Wrap(err, "write")
-	}
-	if n != len(data) {
-		return io.ErrShortWrite
-	}
-	err = file.Close()
-	if err != nil {
-		return errors.Wrap(err, "close file")
-	}
-
-	return nil
-}
 
 type statusOptions struct {
 	rsMap    string

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -39,7 +39,7 @@ func handleDiagnostic(
 	opts diagnosticOptions,
 ) (fmt.Stringer, error) {
 	err := sdk.Diagnostic(ctx, pbm, opts.opid, opts.path)
-	return outMsg{}, err
+	return outMsg{""}, err
 }
 
 type statusOptions struct {

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -28,6 +28,20 @@ import (
 	"github.com/percona/percona-backup-mongodb/sdk/cli"
 )
 
+type diagnosticOptions struct {
+	opid string
+	path string
+}
+
+func handleDiagnostic(
+	ctx context.Context,
+	pbm *sdk.Client,
+	opts diagnosticOptions,
+) (fmt.Stringer, error) {
+	err := sdk.Diagnostic(ctx, pbm, opts.opid, opts.path)
+	return outMsg{}, err
+}
+
 type statusOptions struct {
 	rsMap    string
 	sections []string

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	stdlog "log"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
@@ -29,8 +33,9 @@ import (
 )
 
 type diagnosticOptions struct {
-	opid string
 	path string
+	opid string
+	name string
 }
 
 func handleDiagnostic(
@@ -38,8 +43,159 @@ func handleDiagnostic(
 	pbm *sdk.Client,
 	opts diagnosticOptions,
 ) (fmt.Stringer, error) {
-	err := sdk.Diagnostic(ctx, pbm, opts.opid, opts.path)
-	return outMsg{""}, err
+	if opts.opid == "" && opts.name == "" {
+		return nil, errors.New("--opid or --name must be provided")
+	}
+
+	if opts.opid == "" {
+		cid, err := sdk.FindCommandIDByName(ctx, pbm, opts.name)
+		if err != nil {
+			return nil, errors.Wrap(err, "find opid by name")
+		}
+		opts.opid = string(cid)
+	}
+
+	report, err := sdk.Diagnostic(ctx, pbm, sdk.CommandID(opts.opid))
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo, err := os.Stat(opts.path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "stat")
+		}
+		err = os.MkdirAll(opts.path, 0o777)
+		if err != nil {
+			return nil, errors.Wrap(err, "create path")
+		}
+	} else if !fileInfo.IsDir() {
+		return nil, errors.Errorf("%s is not a dir", opts.path)
+	}
+
+	err = writeToFile(opts.path, opts.opid+".report.json", report)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"failed to save %s", filepath.Join(opts.path, opts.opid+".report.json"))
+	}
+
+	switch report.Command.Cmd {
+	case sdk.CmdBackup:
+		meta, err := pbm.GetBackupByOpID(ctx, opts.opid, sdk.GetBackupByNameOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "get backup meta")
+		}
+		err = writeToFile(opts.path, opts.opid+".backup.json", meta)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to save %s", filepath.Join(opts.path, opts.opid+".backup.json"))
+		}
+	case sdk.CmdRestore:
+		meta, err := pbm.GetRestoreByOpID(ctx, opts.opid)
+		if err != nil {
+			return nil, errors.Wrap(err, "get restore meta")
+		}
+		err = writeToFile(opts.path, opts.opid+".restore.json", meta)
+		if err != nil {
+			return nil, errors.Wrapf(err,
+				"failed to save %s", filepath.Join(opts.path, opts.opid+".restore.json"))
+		}
+	}
+
+	err = writeLogToFile(ctx, pbm, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to save command log")
+	}
+
+	return outMsg{""}, nil
+}
+
+//nolint:nonamedreturns
+func writeLogToFile(ctx context.Context, pbm *sdk.Client, opts diagnosticOptions) (err error) {
+	filename := filepath.Join(opts.path, opts.opid+".log")
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			file.Close()
+			os.Remove(filename)
+		}
+	}()
+
+	cur, err := sdk.CommandLogCursor(ctx, pbm, sdk.CommandID(opts.opid))
+	if err != nil {
+		return errors.Wrap(err, "open log cursor")
+	}
+	defer cur.Close(ctx)
+
+	eol := []byte("\n")
+	for cur.Next(ctx) {
+		rec, err := cur.Record()
+		if err != nil {
+			return errors.Wrap(err, "log: decode")
+		}
+
+		data, err := bson.MarshalExtJSON(rec, true, true)
+		if err != nil {
+			return errors.Wrap(err, "log: encode")
+		}
+
+		n, err := file.Write(data)
+		if err != nil {
+			return errors.Wrap(err, "log: write")
+		}
+		if n != len(data) {
+			return errors.Wrap(io.ErrShortWrite, "log")
+		}
+
+		n, err = file.Write(eol)
+		if err != nil {
+			return errors.Wrap(err, "log: write")
+		}
+		if n != len(eol) {
+			return errors.Wrap(io.ErrShortWrite, "log")
+		}
+	}
+
+	err = cur.Err()
+	if err != nil {
+		return errors.Wrap(err, "log cursor")
+	}
+
+	err = file.Close()
+	if err != nil {
+		return errors.Wrap(err, "failed to save file command.log")
+	}
+
+	return nil
+}
+
+func writeToFile(dirname, name string, val any) error {
+	data, err := bson.MarshalExtJSONIndent(val, true, true, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "marshal")
+	}
+
+	file, err := os.Create(filepath.Join(dirname, name))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	n, err := file.Write(data)
+	if err != nil {
+		return errors.Wrap(err, "write")
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	err = file.Close()
+	if err != nil {
+		return errors.Wrap(err, "close file")
+	}
+
+	return nil
 }
 
 type statusOptions struct {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -146,6 +146,10 @@ func NewClient(ctx context.Context, uri string) (*Client, error) {
 	return &Client{conn: conn, node: inf.Me}, nil
 }
 
+func CommandLogCursor(ctx context.Context, c *Client, cid CommandID) (*log.Cursor, error) {
+	return log.CommandLogCursor(ctx, c.conn, string(cid))
+}
+
 func WaitForAddProfile(ctx context.Context, client *Client, cid CommandID) error {
 	lck := &lock.LockHeader{Type: ctrl.CmdAddConfigProfile, OPID: string(cid)}
 	return waitOp(ctx, client.conn, lck)

--- a/sdk/util.go
+++ b/sdk/util.go
@@ -93,7 +93,7 @@ func WaitForResync(ctx context.Context, c *Client, cid CommandID) error {
 	}
 }
 
-func Diagnostic(ctx context.Context, c *Client, cid string, dirname string) error {
+func Diagnostic(ctx context.Context, c *Client, cid, dirname string) error {
 	if fileInfo, err := os.Stat(dirname); err != nil {
 		if !os.IsNotExist(err) {
 			return errors.Wrap(err, "stat")

--- a/sdk/util.go
+++ b/sdk/util.go
@@ -2,13 +2,18 @@ package sdk
 
 import (
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
@@ -86,4 +91,143 @@ func WaitForResync(ctx context.Context, c *Client, cid CommandID) error {
 			return err
 		}
 	}
+}
+
+func Diagnostic(ctx context.Context, c *Client, cid string, dirname string) error {
+	if fileInfo, err := os.Stat(dirname); err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Wrap(err, "stat")
+		}
+		err = os.MkdirAll(dirname, 0o777)
+		if err != nil {
+			return errors.Wrap(err, "create path")
+		}
+	} else if !fileInfo.IsDir() {
+		return errors.Errorf("%s is not a dir", dirname)
+	}
+
+	opid, err := ctrl.ParseOPID(cid)
+	if err != nil {
+		return ErrInvalidCommandID
+	}
+
+	topology := struct {
+		ClusterTime primitive.Timestamp `json:"cluster_time"`
+		Members     []topo.Shard        `json:"replsets"`
+		Agents      []AgentStatus       `json:"agents"`
+	}{}
+
+	topology.ClusterTime, err = topo.GetClusterTime(ctx, c.conn)
+	if err != nil {
+		return errors.Wrap(err, "get cluster time")
+	}
+	topology.Members, err = topo.ClusterMembers(ctx, c.conn.MongoClient())
+	if err != nil {
+		return errors.Wrap(err, "get members")
+	}
+	topology.Agents, err = topo.ListAgents(ctx, c.conn)
+	if err != nil {
+		return errors.Wrap(err, "get agents")
+	}
+	if err = writeToFile(dirname, "topo.json", topology); err != nil {
+		return errors.Wrap(err, "add topo.json")
+	}
+
+	locks := struct {
+		Locks   []lock.LockData `json:"locks"`
+		OpLocks []lock.LockData `json:"op_locks"`
+	}{}
+
+	locks.Locks, err = lock.GetLocks(ctx, c.conn, &lock.LockHeader{})
+	if err != nil {
+		return errors.Wrap(err, "get locks")
+	}
+	locks.OpLocks, err = lock.GetOpLocks(ctx, c.conn, &lock.LockHeader{})
+	if err != nil {
+		return errors.Wrap(err, "get op locks")
+	}
+	if err = writeToFile(dirname, "locks.json", locks); err != nil {
+		return errors.Wrap(err, "add locks.json")
+	}
+
+	cmd, err := c.CommandInfo(ctx, CommandID(opid.String()))
+	if err != nil {
+		return errors.Wrap(err, "get command info")
+	}
+	if err = writeToFile(dirname, "cmd.json", cmd); err != nil {
+		return errors.Wrap(err, "add command.json")
+	}
+
+	from, err := log.GetFirstTSForOPID(ctx, c.conn, opid.String())
+	if err != nil {
+		return errors.Wrap(err, "get first opid ts")
+	}
+	till, err := log.GetLastTSForOPID(ctx, c.conn, opid.String())
+	if err != nil {
+		return errors.Wrap(err, "get last opid ts")
+	}
+
+	logCursor, err := c.conn.LogCollection().Find(ctx,
+		bson.D{{"ts", bson.M{"$gte": from, "$lte": till}}})
+	if err != nil {
+		return errors.Wrap(err, "log: create cursor")
+	}
+
+	logs := struct {
+		Logs []log.Entry `bson:"logs"`
+	}{}
+	if err := logCursor.All(ctx, &logs.Logs); err != nil {
+		return errors.Wrap(err, "log: cursor %v")
+	}
+	if err = writeToFile(dirname, "logs.json", logs); err != nil {
+		return errors.Wrap(err, "add backup.json")
+	}
+
+	switch cmd.Cmd {
+	case CmdBackup:
+		meta, err := c.GetBackupByOpID(ctx, opid.String(), GetBackupByNameOptions{})
+		if err != nil {
+			return errors.Wrap(err, "get backup meta")
+		}
+		if err = writeToFile(dirname, "backup.json", meta); err != nil {
+			return errors.Wrap(err, "add backup.json")
+		}
+	case CmdRestore:
+		meta, err := c.GetRestoreByOpID(ctx, opid.String())
+		if err != nil {
+			return errors.Wrap(err, "get restore meta")
+		}
+		if err = writeToFile(dirname, "restore.json", meta); err != nil {
+			return errors.Wrap(err, "add restore.json")
+		}
+	}
+
+	return nil
+}
+
+func writeToFile(dirname, name string, val any) error {
+	data, err := bson.MarshalExtJSON(val, true, true)
+	if err != nil {
+		return errors.Wrap(err, "marshal")
+	}
+
+	file, err := os.Create(filepath.Join(dirname, name))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	n, err := file.Write(data)
+	if err != nil {
+		return errors.Wrap(err, "write")
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	err = file.Close()
+	if err != nil {
+		return errors.Wrap(err, "close file")
+	}
+
+	return nil
 }


### PR DESCRIPTION
```bash
> pbm help diagnostic
usage: pbm diagnostic --path=PATH [<flags>]

Create diagnostic report

Flags:
      --path=PATH                Path where files will be saved
      --opid=OPID                OPID/Command ID
      --name=NAME                Backup or Restore name
```

`--name` or `--opid` must be provided. it writes files inside `--path`. if `--path` does not exit, create it (like `mkdir -p`).

files:
- $(OPID).report.json (describes cluster)
- $(OPID).log (log (JSON) between command/operation start and end)
- $(OPID).backup.json (backup meta)
- $(OPID).restore.json (restore meta)

example of `672a0d4e2a59c1f46f628873.report.json`:
```jsonc
{
  "cluster_time": {
    "$timestamp": {
      "t": 1730813162,
      "i": 1
    }
  },
  "command": {
    "cmd": "backup",
    "backup": {
      "type": "logical",
      "base": false,
      "name": "2024-11-05T12:19:26Z",
      "compression": "none"
    },
    "ts": {
      "$numberLong": "1730809166"
    }
  },
  "replsets": [
    {
      "_id": "rs0",
      "host": "rs0/rs00:27017"
    }
  ],
  "agents": [{...}],
  "locks": [{...}],     // field is present if there is any lock in the admin.pbmLock
  "op_locks": [{...}],  // field is present if there is any lock in the admin.pbmOpLock
}
```