### PR TITLE
PBM-1422: Adjust Oplog and PITR to support cloned collection

### DIFF
--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -798,10 +798,6 @@ func validateNSFromNSTo(o *restoreOpts) error {
 	if o.nsFrom != "" && o.nsTo != "" && o.usersAndRoles {
 		return ErrCloningWithUAndR
 	}
-	// if o.nsFrom != "" && o.nsTo != "" && o.pitr != "" {
-	// 	// this check will be removed with: PBM-1422
-	// 	return ErrCloningWithPITR
-	// }
 	if strings.Contains(o.nsTo, "*") || strings.Contains(o.nsFrom, "*") {
 		return ErrCloningWithWildCards
 	}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -798,10 +798,10 @@ func validateNSFromNSTo(o *restoreOpts) error {
 	if o.nsFrom != "" && o.nsTo != "" && o.usersAndRoles {
 		return ErrCloningWithUAndR
 	}
-	if o.nsFrom != "" && o.nsTo != "" && o.pitr != "" {
-		// this check will be removed with: PBM-1422
-		return ErrCloningWithPITR
-	}
+	// if o.nsFrom != "" && o.nsTo != "" && o.pitr != "" {
+	// 	// this check will be removed with: PBM-1422
+	// 	return ErrCloningWithPITR
+	// }
 	if strings.Contains(o.nsTo, "*") || strings.Contains(o.nsFrom, "*") {
 		return ErrCloningWithWildCards
 	}

--- a/cmd/pbm/restore_test.go
+++ b/cmd/pbm/restore_test.go
@@ -43,15 +43,15 @@ func TestCloningValidation(t *testing.T) {
 			},
 			wantErr: ErrCloningWithUAndR,
 		},
-		{
-			desc: "cloning with PITR is not allowed",
-			opts: restoreOpts{
-				nsFrom: "d.c1",
-				nsTo:   "d.c2",
-				pitr:   "2024-10-27T11:23:30",
-			},
-			wantErr: ErrCloningWithPITR,
-		},
+		// {
+		// 	desc: "cloning with PITR is not allowed",
+		// 	opts: restoreOpts{
+		// 		nsFrom: "d.c1",
+		// 		nsTo:   "d.c2",
+		// 		pitr:   "2024-10-27T11:23:30",
+		// 	},
+		// 	wantErr: ErrCloningWithPITR,
+		// },
 		{
 			desc: "cloning with wild cards within nsFrom",
 			opts: restoreOpts{

--- a/cmd/pbm/restore_test.go
+++ b/cmd/pbm/restore_test.go
@@ -43,15 +43,6 @@ func TestCloningValidation(t *testing.T) {
 			},
 			wantErr: ErrCloningWithUAndR,
 		},
-		// {
-		// 	desc: "cloning with PITR is not allowed",
-		// 	opts: restoreOpts{
-		// 		nsFrom: "d.c1",
-		// 		nsTo:   "d.c2",
-		// 		pitr:   "2024-10-27T11:23:30",
-		// 	},
-		// 	wantErr: ErrCloningWithPITR,
-		// },
 		{
 			desc: "cloning with wild cards within nsFrom",
 			opts: restoreOpts{

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -372,9 +372,7 @@ func (o *OplogRestore) isOpForCloning(oe *db.Oplog) bool {
 	}
 
 	db, coll, _ := strings.Cut(oe.Namespace, ".")
-	cloneFromDB, cloneFromColl, _ := strings.Cut(o.cloneNS.FromNS, ".")
-	if coll != "$cmd" || db != cloneFromDB {
-		// entry not a command or it's command not relevant for db to clone from
+	if coll != "$cmd" {
 		return false
 	}
 
@@ -382,6 +380,13 @@ func (o *OplogRestore) isOpForCloning(oe *db.Oplog) bool {
 	if cmd == "applyOps" {
 		return true // internal ops of applyOps are checked one by one later
 	}
+
+	cloneFromDB, cloneFromColl, _ := strings.Cut(o.cloneNS.FromNS, ".")
+	if db != cloneFromDB {
+		// it's command not relevant for db to clone from
+		return false
+	}
+
 	if _, ok := cloningNSSupportedCommands[cmd]; ok {
 		// check if command targets collection
 		collForCmd, _ := oe.Object[0].Value.(string)

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -154,7 +154,6 @@ func NewOplogRestore(
 	ctxn chan phys.RestoreTxn,
 	txnErr chan error,
 ) (*OplogRestore, error) {
-
 	m, err := ns.NewMatcher(append(snapshot.ExcludeFromRestore, excludeFromOplog...))
 	if err != nil {
 		return nil, errors.Wrap(err, "create matcher for the collections exclude")
@@ -279,7 +278,7 @@ func (o *OplogRestore) SetIncludeNS(nss []string) {
 }
 
 // SetCloneNS sets all needed data for cloning namespace:
-// collection names and namespace UUIDs
+// collection names and target namespace UUID
 func (o *OplogRestore) SetCloneNS(ctx context.Context, ns snapshot.CloneNS) error {
 	if !ns.IsSpecified() {
 		return nil
@@ -367,8 +366,8 @@ func (o *OplogRestore) isOpForCloning(oe *db.Oplog) bool {
 	}
 
 	db, coll, _ := strings.Cut(oe.Namespace, ".")
-	cloneFromDb, cloneFromColl, _ := strings.Cut(o.cloneNS.FromNS, ".")
-	if coll != "$cmd" || db != cloneFromDb {
+	cloneFromDB, cloneFromColl, _ := strings.Cut(o.cloneNS.FromNS, ".")
+	if coll != "$cmd" || db != cloneFromDB {
 		// entry not a command or it's command not relevant for db to clone from
 		return false
 	}
@@ -1219,8 +1218,8 @@ func isFalsy(val interface{}) bool {
 }
 
 // getUUIDForNS ruturns UUID of existing collection.
-// When ns doesn't exist, it retuns zero value without an error.
-// In case of error, it returns zero value for UUID in addtion to error.
+// When ns doesn't exist, it returns zero value without an error.
+// In case of error, it returns zero value for UUID in addition to error.
 func getUUIDForNS(ctx context.Context, m *mongo.Client, ns string) (primitive.Binary, error) {
 	var uuid primitive.Binary
 

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -120,7 +120,14 @@ type OplogRestore struct {
 
 	unsafe bool
 
-	filter OpFilter
+	filter    OpFilter
+	cloneNS   snapshot.CloneNS
+	cloneUUID cloneUUID
+}
+
+type cloneUUID struct {
+	fromUUID primitive.Binary
+	toUUID   primitive.Binary
 }
 
 const saveLastDistTxns = 100
@@ -134,6 +141,7 @@ func NewOplogRestore(
 	preserveUUID bool,
 	ctxn chan phys.RestoreTxn,
 	txnErr chan error,
+	cloneNS snapshot.CloneNS,
 ) (*OplogRestore, error) {
 	m, err := ns.NewMatcher(append(snapshot.ExcludeFromRestore, excludeFromOplog...))
 	if err != nil {
@@ -169,6 +177,7 @@ func NewOplogRestore(
 		filter:            DefaultOpFilter,
 		txnData:           make(map[string]Txn),
 		txnCommit:         newCQueue(saveLastDistTxns),
+		cloneNS:           cloneNS,
 	}, nil
 }
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -261,15 +261,10 @@ func (r *Restore) Snapshot(
 		oplogOption.nss = []string{"config.databases"}
 		oplogOption.filter = newConfigsvrOpFilter(nss)
 	}
-	if cloneNS.IsSpecified() {
-		// oplog doesn't need to be applied when cloning ns
-		// this restriction will be removed during PBM-1422
-		l.Debug("applying oplog is skipped when cloning collection")
-	} else {
-		err = r.applyOplog(ctx, oplogRanges, oplogOption)
-		if err != nil {
-			return err
-		}
+
+	err = r.applyOplog(ctx, oplogRanges, oplogOption, cloneNS)
+	if err != nil {
+		return err
 	}
 
 	err = r.restoreIndexes(ctx, oplogOption.nss, cloneNS)

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -256,13 +256,17 @@ func (r *Restore) Snapshot(
 	oplogRanges := []oplogRange{
 		{chunks: chunks, storage: r.bcpStg},
 	}
-	oplogOption := &applyOplogOption{end: &bcp.LastWriteTS, nss: nss}
+	oplogOption := &applyOplogOption{
+		end:     &bcp.LastWriteTS,
+		nss:     nss,
+		cloudNS: cloneNS,
+	}
 	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 		oplogOption.nss = []string{"config.databases"}
 		oplogOption.filter = newConfigsvrOpFilter(nss)
 	}
 
-	err = r.applyOplog(ctx, oplogRanges, oplogOption, cloneNS)
+	err = r.applyOplog(ctx, oplogRanges, oplogOption)
 	if err != nil {
 		return err
 	}
@@ -419,7 +423,11 @@ func (r *Restore) PITR(
 		{chunks: bcpChunks, storage: r.bcpStg},
 		{chunks: chunks, storage: r.oplogStg},
 	}
-	oplogOption := applyOplogOption{end: &cmd.OplogTS, nss: nss}
+	oplogOption := applyOplogOption{
+		end:     &cmd.OplogTS,
+		nss:     nss,
+		cloudNS: cloneNS,
+	}
 	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 		oplogOption.nss = []string{"config.databases"}
 		oplogOption.filter = newConfigsvrOpFilter(nss)

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -367,7 +367,10 @@ func applyOplog(
 	oplogRestore.SetTimeframe(startTS, endTS)
 	oplogRestore.SetIncludeNS(options.nss)
 	err = oplogRestore.SetCloneNS(ctx, options.cloudNS)
-	if err != nil {
+	if errors.Is(err, oplog.ErrNoCloningNamespace) {
+		log.Info("cloning namespace doesn't exist so oplog will not be applied")
+		return partial, nil
+	} else if err != nil {
 		return nil, errors.Wrap(err, "set cloning ns")
 	}
 

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -343,7 +343,15 @@ func applyOplog(
 		txnSyncErr chan error
 	)
 
-	oplogRestore, err := oplog.NewOplogRestore(node, ic, mgoV, options.unsafe, true, ctxn, txnSyncErr)
+	oplogRestore, err := oplog.NewOplogRestore(
+		node,
+		ic,
+		mgoV,
+		options.unsafe,
+		true,
+		ctxn,
+		txnSyncErr,
+		options.cloudNS)
 	if err != nil {
 		return nil, errors.Wrap(err, "create oplog")
 	}

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
 	"github.com/percona/percona-backup-mongodb/pbm/restore/phys"
+	"github.com/percona/percona-backup-mongodb/pbm/snapshot"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
@@ -286,11 +287,12 @@ func chunks(
 }
 
 type applyOplogOption struct {
-	start  *primitive.Timestamp
-	end    *primitive.Timestamp
-	nss    []string
-	unsafe bool
-	filter oplog.OpFilter
+	start   *primitive.Timestamp
+	end     *primitive.Timestamp
+	nss     []string
+	cloudNS snapshot.CloneNS
+	unsafe  bool
+	filter  oplog.OpFilter
 }
 
 type (

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -350,8 +350,7 @@ func applyOplog(
 		options.unsafe,
 		true,
 		ctxn,
-		txnSyncErr,
-		options.cloudNS)
+		txnSyncErr)
 	if err != nil {
 		return nil, errors.Wrap(err, "create oplog")
 	}
@@ -367,6 +366,10 @@ func applyOplog(
 	}
 	oplogRestore.SetTimeframe(startTS, endTS)
 	oplogRestore.SetIncludeNS(options.nss)
+	err = oplogRestore.SetCloneNS(ctx, options.cloudNS)
+	if err != nil {
+		return nil, errors.Wrap(err, "set cloning ns")
+	}
 
 	var lts primitive.Timestamp
 	for _, oplogRange := range ranges {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1422

PR #1040 allows restore and cloning collection, but doesn't apply oplog entries that happened during the backup, neither it supports PITR feature. 
The PR expands the cloning feature with two additional use cases:
- applying oplog entries that happened during the backup 
- applying PITR entries that are stored within PITR chunks

In case of cloning, applying oplog entries means:
- selecting entries that are relevant for collection cloning source (`--ns-from`)
- applying selected entries but with the different namespace (`--ns-to`)
- following types of oplog operation are processed: `insert`, `update`, `delete` ops, and index related DDL ops
- all other DDL related ops are ignored