### PR TITLE
PBM-1226: `logpath` option for pbm-agent

### DIFF
--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -60,7 +60,7 @@ func main() {
 				"log-level",
 				"Minimal log level based on severity level: D, I, W, E or F, low to high. Choosing one includes higher levels too.").
 				Default("D").
-				Enum("D", "I", "W", "E", "F"),
+				Enum(log.D, log.I, log.W, log.E, log.F),
 		}
 	)
 

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -22,12 +22,6 @@ import (
 
 const mongoConnFlag = "mongodb-uri"
 
-type LogOpts struct {
-	logPath  string
-	logJSON  bool
-	logLevel string
-}
-
 func main() {
 	var (
 		pbmCmd      = kingpin.New("pbm-agent", "Percona Backup for MongoDB")
@@ -56,12 +50,12 @@ func main() {
 				Default("").
 				String()
 
-		logOpts = LogOpts{
-			logPath: *pbmCmd.Flag("log-path", "Path to file").
+		logOpts = log.Opts{
+			LogPath: *pbmCmd.Flag("log-path", "Path to file").
 				Default("/dev/stderr").
 				String(),
-			logJSON: *pbmCmd.Flag("log-json", "Enable JSON output").Bool(),
-			logLevel: *pbmCmd.Flag(
+			LogJSON: *pbmCmd.Flag("log-json", "Enable JSON output").Bool(),
+			LogLevel: *pbmCmd.Flag(
 				"log-level",
 				"Minimal log level based on severity level: D, I, W, E or F, low to high. Choosing one includes higher levels too.").
 				Default("D").
@@ -104,7 +98,7 @@ func main() {
 func runAgent(
 	mongoURI string,
 	dumpConns int,
-	logOpts *LogOpts,
+	logOpts *log.Opts,
 ) error {
 	mtLog.SetDateFormat(log.LogTimeFormat)
 	mtLog.SetVerbosity(&options.Verbosity{VLevel: mtLog.DebugLow})

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -493,7 +493,7 @@ func main() {
 		if err != nil {
 			exitErr(errors.Wrap(err, "connect to mongodb"), pbmOutF)
 		}
-		ctx = log.SetLoggerToContext(ctx, log.New(conn.LogCollection(), "", ""))
+		ctx = log.SetLoggerToContext(ctx, log.New(conn, "", ""))
 
 		ver, err := version.GetMongoVersion(ctx, conn.MongoClient())
 		if err != nil {

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -412,10 +412,6 @@ type Logging struct {
 	JSON  *bool  `json:"json,omitempty" bson:"json,omitempty" yaml:"json,omitempty"`
 }
 
-func (l *Logging) Equal(other *Logging) bool {
-	return reflect.DeepEqual(l, other)
-}
-
 func (l *Logging) Clone() *Logging {
 	if l == nil {
 		return nil

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	PITR    *PITRConf    `bson:"pitr,omitempty" json:"pitr,omitempty" yaml:"pitr,omitempty"`
 	Backup  *BackupConf  `bson:"backup,omitempty" json:"backup,omitempty" yaml:"backup,omitempty"`
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
+	Logging *Logging     `bson:"log,omitempty" json:"log,omitempty" yaml:"log,omitempty"`
 
 	Epoch primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
 }
@@ -110,6 +111,7 @@ func (c *Config) Clone() *Config {
 		PITR:      c.PITR.Clone(),
 		Restore:   c.Restore.Clone(),
 		Backup:    c.Backup.Clone(),
+		Logging:   c.Logging.Clone(),
 		Epoch:     c.Epoch,
 	}
 
@@ -402,6 +404,33 @@ func (t *BackupTimeouts) StartingStatus() time.Duration {
 	}
 
 	return time.Duration(*t.Starting) * time.Second
+}
+
+type Logging struct {
+	Path  string `json:"path,omitempty" bson:"path,omitempty" yaml:"path,omitempty"`
+	Level string `json:"level,omitempty" bson:"level,omitempty" yaml:"level,omitempty"`
+	JSON  *bool  `json:"json,omitempty" bson:"json,omitempty" yaml:"json,omitempty"`
+}
+
+func (l *Logging) Equal(other *Logging) bool {
+	return reflect.DeepEqual(l, other)
+}
+
+func (l *Logging) Clone() *Logging {
+	if l == nil {
+		return nil
+	}
+
+	var clonedJSON = new(bool)
+	if l.JSON != nil {
+		*clonedJSON = *l.JSON
+	}
+
+	return &Logging{
+		Path:  l.Path,
+		Level: l.Level,
+		JSON:  clonedJSON,
+	}
 }
 
 func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {

--- a/pbm/log/config.go
+++ b/pbm/log/config.go
@@ -1,0 +1,74 @@
+package log
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/percona/percona-backup-mongodb/pbm/connect"
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+)
+
+const (
+	cfgChangePollingCycle = 5 * time.Second
+)
+
+func (l *loggerImpl) cfgChangeMonitor(ctx context.Context, initialCfg *cfg) {
+	l.Printf("start cfg change monitor for logger")
+	defer l.Printf("stop cfg change monitor for logger")
+
+	tk := time.NewTicker(cfgChangePollingCycle)
+	defer tk.Stop()
+
+	currentCfg := initialCfg
+
+	for {
+		select {
+		case <-tk.C:
+			lastCfg, err := getConfig(ctx, l.conn)
+			if err != nil {
+				if !errors.Is(err, mongo.ErrNoDocuments) {
+					l.Printf("error while monitoring for pitr conf change: %v", err)
+				}
+				continue
+			}
+			if lastCfg.Epoch.Equal(currentCfg.Epoch) || lastCfg.Epoch.Before(currentCfg.Epoch) {
+				continue
+			}
+
+			l.applyConfigChange(lastCfg.Logging)
+			currentCfg = lastCfg
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func getConfig(ctx context.Context, m connect.Client) (*cfg, error) {
+	res := m.ConfigCollection().FindOne(ctx, bson.D{{"profile", nil}})
+	if err := res.Err(); err != nil {
+		return nil, errors.Wrap(err, "get")
+	}
+
+	cfg := &cfg{}
+	if err := res.Decode(&cfg); err != nil {
+		return nil, errors.Wrap(err, "decode")
+	}
+
+	return cfg, nil
+}
+
+type cfg struct {
+	Logging *loggingCfg         `bson:"log,omitempty" json:"log,omitempty" yaml:"log,omitempty"`
+	Epoch   primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
+}
+
+type loggingCfg struct {
+	Path  string `json:"path,omitempty" bson:"path,omitempty" yaml:"path,omitempty"`
+	Level string `json:"level,omitempty" bson:"level,omitempty" yaml:"level,omitempty"`
+	JSON  *bool  `json:"json,omitempty" bson:"json,omitempty" yaml:"json,omitempty"`
+}

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -76,3 +76,20 @@ func (s Severity) String() string {
 		return ""
 	}
 }
+
+func strToSeverity(s string) Severity {
+	switch s {
+	case "F":
+		return Fatal
+	case "E":
+		return Error
+	case "W":
+		return Warning
+	case "I":
+		return Info
+	case "D":
+		return Debug
+	default:
+		return Debug
+	}
+}

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -60,18 +60,26 @@ const (
 	Debug
 )
 
+const (
+	F = "F"
+	E = "E"
+	W = "W"
+	I = "I"
+	D = "D"
+)
+
 func (s Severity) String() string {
 	switch s {
 	case Fatal:
-		return "F"
+		return F
 	case Error:
-		return "E"
+		return E
 	case Warning:
-		return "W"
+		return W
 	case Info:
-		return "I"
+		return I
 	case Debug:
-		return "D"
+		return D
 	default:
 		return ""
 	}
@@ -79,15 +87,15 @@ func (s Severity) String() string {
 
 func strToSeverity(s string) Severity {
 	switch s {
-	case "F":
+	case F:
 		return Fatal
-	case "E":
+	case E:
 		return Error
-	case "W":
+	case W:
 		return Warning
-	case "I":
+	case I:
 		return Info
-	case "D":
+	case D:
 		return Debug
 	default:
 		return Debug

--- a/pbm/log/logger.go
+++ b/pbm/log/logger.go
@@ -250,9 +250,15 @@ func (l *loggerImpl) Output(ctx context.Context, e *Entry) error {
 	}
 
 	if l.logger != nil && l.logLevel >= e.Severity {
-		_, err := l.logger.out.Write(append([]byte(e.String()), '\n'))
+		var err error
+		if l.logJSON {
+			err = json.NewEncoder(l.logger.out).Encode(e)
+			err = errors.Wrap(err, "io json")
+		} else {
+			_, err = l.logger.out.Write(append([]byte(e.String()), '\n'))
+			err = errors.Wrap(err, "io text")
+		}
 
-		err = errors.Wrap(err, "io")
 		if rerr != nil {
 			rerr = errors.Errorf("%v, %v", rerr, err)
 		} else {

--- a/pbm/log/logger.go
+++ b/pbm/log/logger.go
@@ -32,17 +32,18 @@ type loggerImpl struct {
 
 	pauseMgo int32
 
-	logLevel string
+	logLevel Severity
 	logJSON  bool
 }
 
 // New creates default logger which outputs to stderr.
 func New(cn *mongo.Collection, rs, node string) Logger {
 	return &loggerImpl{
-		cn:     cn,
-		logger: newStdLogger(),
-		rs:     rs,
-		node:   node,
+		cn:       cn,
+		logger:   newStdLogger(),
+		rs:       rs,
+		node:     node,
+		logLevel: Debug,
 	}
 }
 
@@ -52,7 +53,7 @@ func NewWithOpts(cn *mongo.Collection, rs, node string, opts *Opts) Logger {
 		cn:       cn,
 		rs:       rs,
 		node:     node,
-		logLevel: opts.LogLevel,
+		logLevel: strToSeverity(opts.LogLevel),
 		logJSON:  opts.LogJSON,
 	}
 
@@ -248,7 +249,7 @@ func (l *loggerImpl) Output(ctx context.Context, e *Entry) error {
 		}
 	}
 
-	if l.logger != nil {
+	if l.logger != nil && l.logLevel >= e.Severity {
 		_, err := l.logger.out.Write(append([]byte(e.String()), '\n'))
 
 		err = errors.Wrap(err, "io")


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1226

In the current version, PBM supports sending diagnostic logging information to:
- database collection `admin.pbmLogs`: PBM's central logging which includes logs from all pbm-agents,
- `stderr` for every pbm-agent.  

This PR allows sending logging information into an arbitrary log file instead of `stderr`. Each pbm-agent creates the log file at the specified path for that purpose based on provided CLI options or PBM's configuration.

#### pbm-agent's options for logger:
```
$ pbm-agent help                                                                                                                                                 
Flags:
 ...
  --log-path="/dev/stderr"  Path to file
  --log-json                Enable JSON output
  --log-level=D             Minimal log level based on severity level: D, I, W, E or F, low to high. Choosing one includes higher levels too.
```
#### PBM's configuration for logger:
```
log:
    path: ./logdir/pbm-log
    level: D
    json: false
storage:
...
```
#### Explanation of the parameters:
- `log-path` or `log.path` - path to the file or stderr. For `stderr` it should be empty/unspecified or "/dev/stderr".
- `log-level` or `log.level` - see option description for `log-level`.
- `log-json` or `log.json` - if `true` will produce json output, otherwise it will be text output

#### Other behavior:
- If PBM's configuration parameter is provided, it overrides pbm-agent's option.
- When `log` section within PBM's config is updated and changed, every pbm-agent will reload the configuration and set new logging settings.
- When logging into a provided file is impossible due to the error, PBM will fallback to `stderr` instead.