### PR TITLE
PBM-1226: `logpath` option for pbm-agent

### DIFF
--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -139,6 +139,8 @@ func runAgent(
 	mtLog.SetWriter(logger)
 
 	logger.Printf(perconaSquadNotice)
+	logger.Printf("log options: log-path=%s, log-level:%s, log-json:%t",
+		logOpts.LogPath, logOpts.LogLevel, logOpts.LogJSON)
 
 	canRunSlicer := true
 	if err := agent.CanStart(ctx); err != nil {

--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -49,6 +49,20 @@ func main() {
 		versionFormat = versionCmd.Flag("format", "Output format <json or \"\">").
 				Default("").
 				String()
+
+		logPath = pbmCmd.Flag("log-path", "Path to file").
+			Envar("LOG_PATH").
+			Default("/dev/stderr").
+			String()
+		logJSON = pbmCmd.Flag("log-json", "Enable JSON output").
+			Envar("LOG_JSON").
+			Bool()
+		logLevel = pbmCmd.Flag(
+			"log-level",
+			"Minimal log level based on severity level: D, I, W, E or F, low to high. Choosing one includes higher levels too.").
+			Envar("LOG_LEVEL").
+			Default(log.D).
+			Enum(log.D, log.I, log.W, log.E, log.F)
 	)
 
 	cmd, err := pbmCmd.DefaultEnvars().Parse(os.Args[1:])
@@ -75,6 +89,11 @@ func main() {
 	hidecreds()
 
 	fmt.Print(perconaSquadNotice)
+	logOpts := &log.Opts{
+		LogPath:  *logPath,
+		LogLevel: *logLevel,
+		LogJSON:  *logJSON,
+	}
 
 	err = runAgent(url, *dumpConns)
 	stdlog.Println("Exit:", err)

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -495,7 +495,7 @@ func main() {
 		if err != nil {
 			exitErr(errors.Wrap(err, "connect to mongodb"), pbmOutF)
 		}
-		ctx = log.SetLoggerToContext(ctx, log.New(conn.LogCollection(), "", ""))
+		ctx = log.SetLoggerToContext(ctx, log.New(conn, "", ""))
 
 		ver, err := version.GetMongoVersion(ctx, conn.MongoClient())
 		if err != nil {

--- a/pbm/log/discard.go
+++ b/pbm/log/discard.go
@@ -28,6 +28,10 @@ func (discardLoggerImpl) PauseMgo() {
 func (discardLoggerImpl) ResumeMgo() {
 }
 
+func (discardLoggerImpl) Write([]byte) (int, error) {
+	return 0, nil
+}
+
 func (discardLoggerImpl) Printf(msg string, args ...any) {
 }
 

--- a/pbm/log/log.go
+++ b/pbm/log/log.go
@@ -26,6 +26,8 @@ type Logger interface {
 	PauseMgo()
 	ResumeMgo()
 
+	Write(p []byte) (n int, err error)
+
 	Printf(msg string, args ...any)
 	Debug(event, obj, opid string, epoch primitive.Timestamp, msg string, args ...any)
 	Info(event, obj, opid string, epoch primitive.Timestamp, msg string, args ...any)
@@ -60,19 +62,44 @@ const (
 	Debug
 )
 
+const (
+	F = "F"
+	E = "E"
+	W = "W"
+	I = "I"
+	D = "D"
+)
+
 func (s Severity) String() string {
 	switch s {
 	case Fatal:
-		return "F"
+		return F
 	case Error:
-		return "E"
+		return E
 	case Warning:
-		return "W"
+		return W
 	case Info:
-		return "I"
+		return I
 	case Debug:
-		return "D"
+		return D
 	default:
 		return ""
+	}
+}
+
+func strToSeverity(s string) Severity {
+	switch s {
+	case F:
+		return Fatal
+	case E:
+		return Error
+	case W:
+		return Warning
+	case I:
+		return Info
+	case D:
+		return Debug
+	default:
+		return Debug
 	}
 }

--- a/pbm/log/logger.go
+++ b/pbm/log/logger.go
@@ -34,6 +34,14 @@ func New(cn *mongo.Collection, rs, node string) Logger {
 		out:  os.Stderr,
 		rs:   rs,
 		node: node,
+
+// Opts represents options that are specified by the user.
+type Opts struct {
+	LogPath  string
+	LogJSON  bool
+	LogLevel string
+}
+
 	}
 }
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1226

In the current version, PBM supports sending diagnostic logging information to:
- database collection `admin.pbmLogs`: PBM's central logging which includes logs from all pbm-agents,
- `stderr` for every pbm-agent.  

This PR allows sending logging information into an arbitrary log file instead of `stderr`. Each pbm-agent creates the log file at the specified path for that purpose.
Logging configuration is possible to define using:
- pbm-agent's options
- environment variables

#### pbm-agent's options for logger:
```
$ pbm-agent help                                                                                                                                                 
Flags:
 ...
  --log-path="/dev/stderr"  Path to file
  --log-json                Enable JSON output
  --log-level=D             Minimal log level based on severity level: D, I, W, E or F, low to high. Choosing one includes higher levels too.
```
#### pbm-agent's env variables for logger:
```
LOG_PATH="/dev/stderr"
LOG_JSON=false
LOG_LEVEL=D
```
#### Explanation of the parameters:
- `log-path` or `LOG_PATH` - path to the file or stderr. For `stderr` it should be empty/unspecified or "/dev/stderr". Default is stderr.
- `log-level` or `LOG_LEVEL` - see option description for `log-level`. Default is debug level: D.
- `log-json` or `LOG_JSON` - if `true` will produce json output, otherwise it will be text output. Default is text output.

#### Other behavior:
- If PBM's options are provided, they overrides pbm-agent's env variables.
- When logger cannot write to file due to error, PBM will fallback to `stderr` instead.