### PR TITLE
CI. Send report to codecov for dev branch

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,25 @@
+name: 'codecov'
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  go-test:
+    name: runner / go-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.22"
+      - name: test
+        run: go test -v ./... -covermode=atomic -coverprofile=cover.out
+
+      - name: upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          file: cover.out
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
On codecov it's required to have 'branch context' to be able to observe the general trend over time. When report is sent only on PR, it's possible to switch over different branches, but no possibility to select one for branch context of data in coverage dashboard.