### PR TITLE
PBM-1459: PBM ignores index removal during selective PITR restore with name remapping

### DIFF
--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -114,8 +114,8 @@ type cloneNS struct {
 
 func (c *cloneNS) SetNSPair(nsPair snapshot.CloneNS) {
 	c.CloneNS = nsPair
-	c.fromDB, c.fromColl, _ = strings.Cut(nsPair.FromNS, ".")
-	c.toDB, c.toColl, _ = strings.Cut(nsPair.ToNS, ".")
+	c.fromDB, c.fromColl = nsPair.SplitFromNS()
+	c.toDB, c.toColl = nsPair.SplitToNS()
 }
 
 // OplogRestore is the oplog applyer

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -794,7 +794,7 @@ func (o *OplogRestore) cloneEntry(op *db.Oplog) {
 	}
 
 	cmdName := op.Object[0].Key
-	if cmdName != "create" && cmdName != "drop" {
+	if _, ok := cloningNSSupportedCommands[cmdName]; !ok {
 		return
 	}
 

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"io"
 	"runtime"
+	"strings"
 
 	"github.com/mongodb/mongo-tools/common/options"
 	"github.com/mongodb/mongo-tools/mongorestore"
@@ -42,15 +43,27 @@ var ExcludeFromRestore = []string{
 
 type restorer struct{ *mongorestore.MongoRestore }
 
-// CloneNS contains clone from/to info for cloning NS use case
+// CloneNS contains clone from/to info for cloning NS use case.
 type CloneNS struct {
 	FromNS string
 	ToNS   string
 }
 
-// IsSpecified returns true in case of cloning use case
+// IsSpecified returns true in case of cloning use case.
 func (c *CloneNS) IsSpecified() bool {
 	return c.FromNS != "" && c.ToNS != ""
+}
+
+// SplitFromNS breaks cloning-from namespace to database & collection pair.
+func (c *CloneNS) SplitFromNS() (string, string) {
+	db, coll, _ := strings.Cut(c.FromNS, ".")
+	return db, coll
+}
+
+// SplitToNS breaks cloning-to namespace to database & collection pair.
+func (c *CloneNS) SplitToNS() (string, string) {
+	db, coll, _ := strings.Cut(c.ToNS, ".")
+	return db, coll
 }
 
 func NewRestore(uri string,


### PR DESCRIPTION
Fix for https://perconadev.atlassian.net/browse/PBM-1459

PBM creates an index catalog during the snapshot restore phase. This PR changes the approach of handling changes within the index catalog:
- Previously PBM cloned indexes after the PITR procedure from the index catalog.
- With this PR, cloning is performed during the snapshot restore phase, as well as, during the PITR phase. Logic for cloning indexes after PITR phase is removed.