### PR TITLE
PBM_tests. Unset LD_PRELOAD on physical restore to prevent PSMDB 8.0 getting stuck

### DIFF
--- a/e2e-tests/cmd/pbm-test/run_physical.go
+++ b/e2e-tests/cmd/pbm-test/run_physical.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"math/rand"
 
-	"golang.org/x/mod/semver"
-
 	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 )
@@ -60,11 +58,8 @@ func runPhysical(t *sharded.Cluster, typ testTyp) {
 			t.DistributedTrxPhysical)
 	}
 
-	// Skip test for 8.0 until PBM-1447 is fixed
-	if semver.Compare(cVersion, "v8.0") < 0 {
-		runTest("Clock Skew Tests",
-			func() { t.ClockSkew(defs.PhysicalBackup, cVersion) })
-	}
+	runTest("Clock Skew Tests",
+		func() { t.ClockSkew(defs.PhysicalBackup, cVersion) })
 
 	flushStore(t)
 }

--- a/e2e-tests/pkg/tests/sharded/cluster.go
+++ b/e2e-tests/pkg/tests/sharded/cluster.go
@@ -145,6 +145,14 @@ func (c *Cluster) PhysicalRestore(ctx context.Context, bcpName string) {
 }
 
 func (c *Cluster) PhysicalRestoreWithParams(ctx context.Context, bcpName string, options []string) {
+	stdlog.Println("reset ENV variables")
+	for name := range c.shards {
+		err := pbmt.ClockSkew(name, "0", c.cfg.DockerURI)
+		if err != nil {
+			stdlog.Fatalln("reset ENV variables:", err)
+		}
+	}
+
 	stdlog.Println("restoring the backup")
 	name, err := c.pbm.Restore(bcpName, options)
 	if err != nil {

--- a/e2e-tests/pkg/tests/sharded/test_clock_skew.go
+++ b/e2e-tests/pkg/tests/sharded/test_clock_skew.go
@@ -2,6 +2,7 @@ package sharded
 
 import (
 	"log"
+	"math/rand"
 
 	pbmt "github.com/percona/percona-backup-mongodb/e2e-tests/pkg/pbm"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
@@ -11,16 +12,14 @@ func (c *Cluster) ClockSkew(typ defs.BackupType, mongoVersion string) {
 	timeShifts := []string{
 		"+90m", "-195m", "+2d", "-7h", "+11m", "+42d", "-13h",
 	}
-	rsNames := []string{"cfg"}
+	rsNames := []string{}
 	for s := range c.shards {
 		rsNames = append(rsNames, s)
 	}
 
-	for k, rs := range rsNames {
-		if k >= len(timeShifts) {
-			k %= len(timeShifts)
-		}
-		shift := timeShifts[k]
+	for _, rs := range rsNames {
+		randomIndex := rand.Intn(len(timeShifts))
+		shift := timeShifts[randomIndex]
 
 		err := pbmt.ClockSkew(rs, shift, c.cfg.DockerURI)
 		if err != nil {


### PR DESCRIPTION
In PSMDB 8.0 tcmalloc is used by default, however since both tcmalloc and libfaketime use interceptors, it causes tcmalloc to get into a dead lock, hence PSMDB is just getting stuck. Since there is no way to fix PSMDB, use of libfaketime is disabled during physical restore.