### PR TITLE
PBM-1460: Connection error isn't written to PBM log despite log-path option is specified

### DIFF
--- a/cmd/pbm-agent/main.go
+++ b/cmd/pbm-agent/main.go
@@ -93,12 +93,14 @@ func main() {
 		LogLevel: *logLevel,
 		LogJSON:  *logJSON,
 	}
+	l := log.NewWithOpts(nil, "", "", logOpts).NewDefaultEvent()
 
 	err = runAgent(url, *dumpConns, logOpts)
-	stdlog.Println("Exit:", err)
 	if err != nil {
+		l.Error("Exit: %v", err)
 		os.Exit(1)
 	}
+	l.Info("Exit: <nil>")
 }
 
 func runAgent(
@@ -125,7 +127,6 @@ func runAgent(
 	}
 
 	logger := log.NewWithOpts(
-		ctx,
 		agent.leadConn,
 		agent.brief.SetName,
 		agent.brief.Me,

--- a/pbm/log/logger.go
+++ b/pbm/log/logger.go
@@ -54,7 +54,7 @@ func New(conn connect.Client, rs, node string) Logger {
 }
 
 // NewWithOpts creates logger based on provided options.
-func NewWithOpts(ctx context.Context, conn connect.Client, rs, node string, opts *Opts) Logger {
+func NewWithOpts(conn connect.Client, rs, node string, opts *Opts) Logger {
 	l := &loggerImpl{
 		conn:     conn,
 		rs:       rs,

--- a/pbm/log/logger_test.go
+++ b/pbm/log/logger_test.go
@@ -1,0 +1,47 @@
+package log
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestLoggerConstructor(t *testing.T) {
+	t.Run("logger logs without db connection", func(t *testing.T) {
+		t.Run("logger with opts", func(t *testing.T) {
+			f := "db-conn-nil"
+			l := NewWithOpts(nil, "rs", "node", &Opts{LogPath: f})
+			defer os.Remove(f)
+
+			l.Debug("", "", "", primitive.Timestamp{}, "msg: %v", "nil conn")
+
+			lEntry, _ := os.ReadFile(f)
+			if !strings.Contains(string(lEntry), "msg: nil conn") {
+				t.Errorf("expected: 'msg: nil conn', got: %q", string(lEntry))
+			}
+
+		})
+
+		t.Run("logger without opts", func(t *testing.T) {
+			old := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+			defer func() { os.Stderr = old }()
+
+			l := New(nil, "rs", "node").NewDefaultEvent()
+			msg := "msg from logger without opts"
+
+			l.Info(msg)
+
+			w.Close()
+			stdErrOut, _ := io.ReadAll(r)
+
+			if !strings.Contains(string(stdErrOut), msg) {
+				t.Errorf("expected: %q, got: %q", msg, string(stdErrOut))
+			}
+		})
+	})
+}

--- a/pbm/log/logger_test.go
+++ b/pbm/log/logger_test.go
@@ -22,7 +22,6 @@ func TestLoggerConstructor(t *testing.T) {
 			if !strings.Contains(string(lEntry), "msg: nil conn") {
 				t.Errorf("expected: 'msg: nil conn', got: %q", string(lEntry))
 			}
-
 		})
 
 		t.Run("logger without opts", func(t *testing.T) {


### PR DESCRIPTION
Fix for https://perconadev.atlassian.net/browse/PBM-1460

`pbm-agent` should handle log-related settings even in the early phase of running, when the DB connection hasn't been established yet, and even when connecting to DB fails. This PR fixes such a situation because it currently places all logs into `stderr`.