### PR TITLE
PBM-1465: Selective backup/restore for sharded collections fails for setups with config shards

### DIFF
--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -377,6 +378,11 @@ func makeConfigsvrDocFilter(nss []string, selector util.ChunkSelector) archive.D
 			return ok && selectedNS(ns)
 		case "config.chunks":
 			return selector.Selected(doc)
+		}
+
+		// Config Shard should keep non-config collections
+		if slices.Contains(nss, ns) {
+			return true
 		}
 
 		return false

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"path"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -381,7 +380,7 @@ func makeConfigsvrDocFilter(nss []string, selector util.ChunkSelector) archive.D
 		}
 
 		// Config Shard should keep non-config collections
-		if slices.Contains(nss, ns) {
+		if selectedNS(ns) {
 			return true
 		}
 

--- a/pbm/backup/logical_test.go
+++ b/pbm/backup/logical_test.go
@@ -1,0 +1,102 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/percona/percona-backup-mongodb/pbm/util"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMakeConfigsvrDocFilter(t *testing.T) {
+	t.Run("selective backup without wildcards", func(t *testing.T) {
+		testCases := []struct {
+			desc     string
+			bcpNS    []string
+			docNS    string
+			selected bool
+		}{
+			{
+				desc:     "single backup ns, doc selected",
+				bcpNS:    []string{"d.c"},
+				docNS:    "d.c",
+				selected: true,
+			},
+			{
+				desc:     "multiple backup ns, doc selected",
+				bcpNS:    []string{"d.c1", "d.c2", "d.c3"},
+				docNS:    "d.c2",
+				selected: true,
+			},
+			{
+				desc:     "single backup ns, doc not selected",
+				bcpNS:    []string{"d.c"},
+				docNS:    "x.y",
+				selected: false,
+			},
+			{
+				desc:     "single backup ns, doc not selected different coll",
+				bcpNS:    []string{"d.c"},
+				docNS:    "d.y",
+				selected: false,
+			},
+			{
+				desc:     "multiple backup ns, doc not selected",
+				bcpNS:    []string{"d.c1", "d.c2", "d.c3"},
+				docNS:    "d.c4",
+				selected: false,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				docFilter := makeConfigsvrDocFilter(tC.bcpNS, util.NewUUIDChunkSelector())
+				res := docFilter(tC.docNS, bson.Raw{})
+				if res != tC.selected {
+					t.Errorf("want=%t, got=%t, for backup ns: %s and doc ns: %s", tC.selected, res, tC.bcpNS, tC.docNS)
+				}
+			})
+		}
+	})
+
+	t.Run("selective backup with wildcards", func(t *testing.T) {
+		testCases := []struct {
+			desc     string
+			bcpNS    []string
+			docNS    string
+			selected bool
+		}{
+			{
+				desc:     "single backup ns, doc selected",
+				bcpNS:    []string{"d.*"},
+				docNS:    "d.c",
+				selected: true,
+			},
+			{
+				desc:     "multiple backup ns, doc selected",
+				bcpNS:    []string{"d1.*", "d2.*", "d3.*"},
+				docNS:    "d2.c2",
+				selected: true,
+			},
+			{
+				desc:     "single backup ns, doc not selected",
+				bcpNS:    []string{"d.*"},
+				docNS:    "x.y",
+				selected: false,
+			},
+			{
+				desc:     "multiple backup ns, doc not selected",
+				bcpNS:    []string{"d1.*", "d2.*", "d3.*"},
+				docNS:    "d4.c4",
+				selected: false,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				docFilter := makeConfigsvrDocFilter(tC.bcpNS, util.NewUUIDChunkSelector())
+				res := docFilter(tC.docNS, bson.Raw{})
+				if res != tC.selected {
+					t.Errorf("want=%t, got=%t, for backup ns: %s and doc ns: %s", tC.selected, res, tC.bcpNS, tC.docNS)
+				}
+			})
+		}
+	})
+}

--- a/pbm/backup/logical_test.go
+++ b/pbm/backup/logical_test.go
@@ -3,8 +3,9 @@ package backup
 import (
 	"testing"
 
-	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/percona/percona-backup-mongodb/pbm/util"
 )
 
 func TestMakeConfigsvrDocFilter(t *testing.T) {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -294,6 +294,9 @@ func newConfigsvrOpFilter(nss []string) oplog.OpFilter {
 	selected := util.MakeSelectedPred(nss)
 
 	return func(r *oplog.Record) bool {
+		if selected(r.Namespace) {
+			return true
+		}
 		if r.Namespace != "config.databases" {
 			return false
 		}
@@ -436,6 +439,7 @@ func (r *Restore) PITR(
 	}
 	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 		oplogOption.nss = []string{"config.databases"}
+		oplogOption.nss = append(oplogOption.nss, nss...)
 		oplogOption.filter = newConfigsvrOpFilter(nss)
 	}
 	err = r.applyOplog(ctx, oplogRanges, &oplogOption)


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1465

PR fixes the following two different issues within the Config Shard environment:
- selective backup didn't dump non-config namespaces on Config Shard RS
- during the restore procedure, oplog replay step didn't apply entries for non-config namespace on Config Shard RS