### PR TITLE
PBM-1452: Stop balancer automatically during restore

### DIFF
--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -293,7 +293,7 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 			}
 
 			l.Debug("waiting for balancer off")
-			bs := waitForBalancerOff(ctx, b.leadConn, time.Second*30, l)
+			bs := topo.WaitForBalancerOff(ctx, b.leadConn, time.Second*30, l)
 			l.Debug("balancer status: %s", bs)
 		}
 	}
@@ -376,40 +376,6 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 		err = b.waitForStatus(ctx, bcp.Name, defs.StatusDone, nil)
 		return errors.Wrap(err, "waiting for done")
 	}
-}
-
-func waitForBalancerOff(ctx context.Context, conn connect.Client, t time.Duration, l log.LogEvent) topo.BalancerMode {
-	dn := time.NewTimer(t)
-	defer dn.Stop()
-
-	tk := time.NewTicker(time.Millisecond * 500)
-	defer tk.Stop()
-
-	var bs *topo.BalancerStatus
-	var err error
-
-Loop:
-	for {
-		select {
-		case <-tk.C:
-			bs, err = topo.GetBalancerStatus(ctx, conn)
-			if err != nil {
-				l.Error("get balancer status: %v", err)
-				continue
-			}
-			if bs.Mode == topo.BalancerModeOff {
-				return topo.BalancerModeOff
-			}
-		case <-dn.C:
-			break Loop
-		}
-	}
-
-	if bs == nil {
-		return topo.BalancerMode("")
-	}
-
-	return bs.Mode
 }
 
 func (b *Backup) toState(


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1452

With this feature, PBM stops `balancer` at the beginning of the `restore` procedure:
- it does it for `logical` and `physical` restore
- stopping balancer command is always executed exclusively by Config Server Primary node