### PR TITLE
PBM-1335: Fallback dbpath for physical restore

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -290,7 +290,6 @@ func (r *PhysRestore) flush(ctx context.Context) error {
 		}
 	}
 
-	r.log.Debug("move data to fallback path")
 	err = r.migrateDbDirToFallbackDir()
 	if err != nil {
 		return errors.Wrapf(err, "move files to fallback path")
@@ -321,6 +320,7 @@ func (r *PhysRestore) migrateDbDirToFallbackDir() error {
 		return errors.Wrapf(err, "creating dir %s", fallbackPath)
 	}
 
+	r.log.Info("move data files from %s to %s", r.dbpath, fallbackDir)
 	err = r.moveToFallback()
 	if err != nil {
 		return errors.Wrapf(err, "fail to move to %s", fallbackPath)
@@ -338,6 +338,7 @@ func (r *PhysRestore) migrateFromFallbackDirToDbDir() error {
 		r.log.Error("flush dbpath %s: %v", r.dbpath, err)
 	}
 
+	r.log.Info("move data files from %s to %s", fallbackDir, r.dbpath)
 	err = r.moveFromFallback()
 	if err != nil {
 		r.log.Error("moving from %s: %v", fallbackDir, err)

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -46,6 +46,7 @@ import (
 const (
 	defaultRSdbpath   = "/data/db"
 	defaultCSRSdbpath = "/data/configdb"
+	fallbackDir       = ".fallbackDbPath"
 
 	mongofslock = "mongod.lock"
 
@@ -53,6 +54,8 @@ const (
 
 	tryConnCount   = 5
 	tryConnTimeout = 5 * time.Minute
+
+	internalMongodLog = "pbm.restore.log"
 )
 
 type files struct {
@@ -1786,8 +1789,6 @@ func tryConn(port int, logpath string) (*mongo.Client, error) {
 
 	return nil, errors.Errorf("failed to  connect after %d tries: %v", tryConnCount, err)
 }
-
-const internalMongodLog = "pbm.restore.log"
 
 func (r *PhysRestore) startMongo(opts ...string) error {
 	if r.tmpConf != nil {

--- a/pbm/restore/physical_test.go
+++ b/pbm/restore/physical_test.go
@@ -22,11 +22,11 @@ func TestMoveAll(t *testing.T) {
 		for i, file := range testFiles {
 			_ = os.WriteFile(
 				filepath.Join(tempSrc, file),
-				[]byte(fmt.Sprintf("test content %d", i)), 0644)
+				[]byte(fmt.Sprintf("test content %d", i)), 0o644)
 		}
 
 		subDir := filepath.Join(tempSrc, "subdir")
-		_ = os.Mkdir(subDir, 0755)
+		_ = os.Mkdir(subDir, 0o755)
 
 		err := moveAll(tempSrc, tempDst, nil, log.DiscardLogger.NewDefaultEvent())
 		if err != nil {
@@ -63,11 +63,11 @@ func TestMoveAll(t *testing.T) {
 		for i, file := range testFiles {
 			_ = os.WriteFile(
 				filepath.Join(tempSrc, file),
-				[]byte(fmt.Sprintf("test content %d", i)), 0644)
+				[]byte(fmt.Sprintf("test content %d", i)), 0o644)
 		}
 
-		_ = os.Mkdir(filepath.Join(tempSrc, "ignore_dir"), 0755)
-		_ = os.Mkdir(filepath.Join(tempSrc, "normal_dir"), 0755)
+		_ = os.Mkdir(filepath.Join(tempSrc, "ignore_dir"), 0o755)
+		_ = os.Mkdir(filepath.Join(tempSrc, "normal_dir"), 0o755)
 
 		toIgnore := []string{"ignore_me", "ignore_dir"}
 
@@ -122,13 +122,12 @@ func TestMoveAll(t *testing.T) {
 		tempDst, _ := os.MkdirTemp("", "dst")
 		defer os.RemoveAll(tempDst)
 
-		_ = os.Chmod(tempDst, 0500)   // read-only
-		defer os.Chmod(tempDst, 0700) // Restore permissions for cleanup
+		_ = os.Chmod(tempDst, 0o400)
 
 		// Create test file in source
 		_ = os.WriteFile(
 			filepath.Join(tempSrc, "test"),
-			[]byte("test content"), 0644)
+			[]byte("test content"), 0o644)
 
 		err := moveAll(tempSrc, tempDst, nil, log.DiscardLogger.NewDefaultEvent())
 		if err == nil {

--- a/pbm/restore/physical_test.go
+++ b/pbm/restore/physical_test.go
@@ -1,0 +1,142 @@
+package restore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/percona/percona-backup-mongodb/pbm/log"
+)
+
+func TestMoveAll(t *testing.T) {
+	t.Run("move all files and dir", func(t *testing.T) {
+		tempSrc, _ := os.MkdirTemp("", "src")
+		defer os.RemoveAll(tempSrc)
+
+		tempDst, _ := os.MkdirTemp("", "dst")
+		defer os.RemoveAll(tempDst)
+
+		testFiles := []string{"file1", "file2", "file3"}
+		for i, file := range testFiles {
+			_ = os.WriteFile(
+				filepath.Join(tempSrc, file),
+				[]byte(fmt.Sprintf("test content %d", i)), 0644)
+		}
+
+		subDir := filepath.Join(tempSrc, "subdir")
+		_ = os.Mkdir(subDir, 0755)
+
+		err := moveAll(tempSrc, tempDst, nil, log.DiscardLogger.NewDefaultEvent())
+		if err != nil {
+			t.Fatalf("moveAll failed: %v", err)
+		}
+
+		// files are moved
+		for _, file := range testFiles {
+			if _, err := os.Stat(filepath.Join(tempDst, file)); os.IsNotExist(err) {
+				t.Errorf("file %s not found in destination directory", file)
+			}
+			if _, err := os.Stat(filepath.Join(tempSrc, file)); !os.IsNotExist(err) {
+				t.Errorf("file %s still exists in source directory", file)
+			}
+		}
+
+		// subdir is moved
+		if _, err := os.Stat(filepath.Join(tempDst, "subdir")); os.IsNotExist(err) {
+			t.Errorf("subdirectory not found in destination directory")
+		}
+		if _, err := os.Stat(filepath.Join(tempSrc, "subdir")); !os.IsNotExist(err) {
+			t.Errorf("subdirectory still exists in source directory")
+		}
+	})
+
+	t.Run("ignore files and dirs", func(t *testing.T) {
+		tempSrc, _ := os.MkdirTemp("", "src")
+		defer os.RemoveAll(tempSrc)
+
+		tempDst, _ := os.MkdirTemp("", "dst")
+		defer os.RemoveAll(tempDst)
+
+		testFiles := []string{"file1", "file2", "ignore_me"}
+		for i, file := range testFiles {
+			_ = os.WriteFile(
+				filepath.Join(tempSrc, file),
+				[]byte(fmt.Sprintf("test content %d", i)), 0644)
+		}
+
+		_ = os.Mkdir(filepath.Join(tempSrc, "ignore_dir"), 0755)
+		_ = os.Mkdir(filepath.Join(tempSrc, "normal_dir"), 0755)
+
+		toIgnore := []string{"ignore_me", "ignore_dir"}
+
+		err := moveAll(tempSrc, tempDst, toIgnore, log.DiscardLogger.NewDefaultEvent())
+		if err != nil {
+			t.Fatalf("moveAll failed: %v", err)
+		}
+
+		// non-ignored files are moved
+		movedFiles := []string{"file1", "file2"}
+		for _, file := range movedFiles {
+			if _, err := os.Stat(filepath.Join(tempDst, file)); os.IsNotExist(err) {
+				t.Errorf("file %s not found in destination directory", file)
+			}
+		}
+
+		// ignored items remain in source
+		for _, item := range toIgnore {
+			if _, err := os.Stat(filepath.Join(tempSrc, item)); os.IsNotExist(err) {
+				t.Errorf("ignored item %s not found in source directory", item)
+			}
+			if _, err := os.Stat(filepath.Join(tempDst, item)); !os.IsNotExist(err) {
+				t.Errorf("ignored item %s was moved to destination directory", item)
+			}
+		}
+
+		// non-ignored directory is moved
+		if _, err := os.Stat(filepath.Join(tempDst, "normal_dir")); os.IsNotExist(err) {
+			t.Errorf("normal directory not found in destination directory")
+		}
+	})
+
+	t.Run("source dir doesn't exist", func(t *testing.T) {
+		tempDst, _ := os.MkdirTemp("", "dst")
+		defer os.RemoveAll(tempDst)
+
+		nonExistentDir := "/path/not/exist"
+
+		err := moveAll(nonExistentDir, tempDst, nil, log.DiscardLogger.NewDefaultEvent())
+		if err == nil {
+			t.Fatal("want error")
+		}
+		if !strings.Contains(err.Error(), "open dir") {
+			t.Errorf("want:'open dir', got:%v", err)
+		}
+	})
+
+	t.Run("write permission error", func(t *testing.T) {
+		tempSrc, _ := os.MkdirTemp("", "src")
+		defer os.RemoveAll(tempSrc)
+
+		tempDst, _ := os.MkdirTemp("", "dst")
+		defer os.RemoveAll(tempDst)
+
+		_ = os.Chmod(tempDst, 0500)   // read-only
+		defer os.Chmod(tempDst, 0700) // Restore permissions for cleanup
+
+		// Create test file in source
+		_ = os.WriteFile(
+			filepath.Join(tempSrc, "test"),
+			[]byte("test content"), 0644)
+
+		err := moveAll(tempSrc, tempDst, nil, log.DiscardLogger.NewDefaultEvent())
+		if err == nil {
+			t.Fatal("want perm error")
+		}
+
+		if !strings.Contains(err.Error(), "move test") {
+			t.Errorf("want:'move test', got:%v", err)
+		}
+	})
+}


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1507

This feature improves the resiliency of the physical restore procedure by:
- adding an alternative dbpath directory (`.fallbacksync`), which will be used in case of failed restore
- in sharded cluster environment, applying files from `.fallbacksync` dir will be done only in case when the restore procedure finishes with status `error`
- if the restore procedure finishes in status `done` or `partalyDone`, `.fallbacksync` db dir is not applied

PR also improves cluster status after the restore procedure by setting appropriate status in case of an error during the restore procedure.