### PR TITLE
PBM-1512: Unable to take physical backup in mixed deployments

### DIFF
--- a/pbm/topo/cluster.go
+++ b/pbm/topo/cluster.go
@@ -182,6 +182,15 @@ func getShardMapImpl(ctx context.Context, m *mongo.Client) (map[ReplsetName]Shar
 		hostsByShard[shardID] = append(hostsByShard[shardID], host)
 	}
 
+	// for PSMDB 6 and below, config srv is not reported within hosts field
+	if len(hostsByShard["config"]) == 0 {
+		cfgHostgs, err := GetReplsetHosts(ctx, m)
+		if err != nil {
+			return nil, errors.Wrap(err, "get all hosts for config RS")
+		}
+		hostsByShard["config"] = cfgHostgs
+	}
+
 	shards := make(map[string]Shard, len(shardMap.Map))
 	for id, host := range shardMap.Map {
 		rs, _, _ := strings.Cut(host, "/")

--- a/pbm/topo/cluster.go
+++ b/pbm/topo/cluster.go
@@ -121,6 +121,7 @@ func ClusterMembers(ctx context.Context, m *mongo.Client) ([]Shard, error) {
 		return nil, errors.Wrap(err, "define cluster state")
 	}
 
+	// sharded cluster topo
 	var shards []Shard
 	if inf.IsMongos() || inf.IsSharded() {
 		members, err := getShardMapImpl(ctx, m)
@@ -136,10 +137,15 @@ func ClusterMembers(ctx context.Context, m *mongo.Client) ([]Shard, error) {
 		return shards, nil
 	}
 
+	// RS topo
+	hosts, err := GetReplsetHosts(ctx, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "get all hosts for RS")
+	}
 	shards = []Shard{{
 		ID:   inf.SetName,
 		RS:   inf.SetName,
-		Host: inf.SetName + "/" + strings.Join(inf.Hosts, ","),
+		Host: fmt.Sprintf("%s/%s", inf.SetName, strings.Join(hosts, ",")),
 	}}
 	return shards, nil
 }

--- a/pbm/topo/topo.go
+++ b/pbm/topo/topo.go
@@ -195,6 +195,21 @@ func GetReplsetStatus(ctx context.Context, m *mongo.Client) (*ReplsetStatus, err
 	return status, nil
 }
 
+// GetReplsetHosts returns host names for all RS members.
+// It includes also hidden and passive RS members.
+func GetReplsetHosts(ctx context.Context, m *mongo.Client) ([]string, error) {
+	s, err := GetReplsetStatus(ctx, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "get replset status")
+	}
+
+	hosts := []string{}
+	for _, m := range s.Members {
+		hosts = append(hosts, m.Name)
+	}
+	return hosts, nil
+}
+
 func GetNodeStatus(ctx context.Context, m *mongo.Client, name string) (*NodeStatus, error) {
 	s, err := GetReplsetStatus(ctx, m)
 	if err != nil {

--- a/pbm/topo/topo.go
+++ b/pbm/topo/topo.go
@@ -110,7 +110,7 @@ func collectTopoCheckErrors(
 		anyAvail := false
 		for _, host := range hosts {
 			a, ok := agents[host]
-			if !ok || a.Arbiter || a.Passive {
+			if !ok || a.Arbiter {
 				continue
 			}
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1512

When reporting cluster members (`topo.ClusterMembers`) PBM doesn't include hidden/passive members due to the bug:
- for RS topology, it uses `isMaster.hosts` command which [doesn't include hidden/passive members](https://www.mongodb.com/docs/manual/reference/command/hello/#mongodb-data-hello.hosts)
- for sharded cluster topology, it uses `getShardMap.map` command which, again doesn't include hidden/passive members

Provided fixes for RS and sharded cluster use both commands above, with a combination of `replSetGetStatus` command to report hidden/passive members for the whole cluster.