### PR TITLE
PBM-1506 GCS support concurrent downloading

### DIFF
--- a/pbm/restore/phys/phys.go
+++ b/pbm/restore/phys/phys.go
@@ -8,15 +8,15 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 type RestoreStat struct {
 	RS map[string]map[string]RestoreRSMetrics `bson:"rs,omitempty" json:"rs,omitempty"`
 }
 type RestoreRSMetrics struct {
-	DistTxn  DistTxnStat     `bson:"txn,omitempty" json:"txn,omitempty"`
-	Download s3.DownloadStat `bson:"download,omitempty" json:"download,omitempty"`
+	DistTxn  DistTxnStat          `bson:"txn,omitempty" json:"txn,omitempty"`
+	Download storage.DownloadStat `bson:"download,omitempty" json:"download,omitempty"`
 }
 
 type DistTxnStat struct {
@@ -35,8 +35,8 @@ type DistTxnStat struct {
 }
 
 type RestoreShardStat struct {
-	Txn DistTxnStat      `json:"txn"`
-	D   *s3.DownloadStat `json:"d"`
+	Txn DistTxnStat           `json:"txn"`
+	D   *storage.DownloadStat `json:"d"`
 }
 
 type TxnState string

--- a/pbm/storage/download.go
+++ b/pbm/storage/download.go
@@ -68,6 +68,16 @@ type DownloadStat struct {
 	BufSize     int         `bson:"bufSize" json:"bufSize"`
 }
 
+func NewDownloadStat(concurrency, arenaSize, spanSize int) DownloadStat {
+	return DownloadStat{
+		Concurrency: concurrency,
+		ArenaSize:   arenaSize,
+		SpansNum:    arenaSize / spanSize,
+		SpanSize:    spanSize,
+		BufSize:     arenaSize * concurrency,
+	}
+}
+
 func (s DownloadStat) String() string {
 	return fmt.Sprintf("buf %d, arena %d, span %d, spanNum %d, cc %d, %v",
 		s.BufSize, s.ArenaSize, s.SpanSize, s.SpansNum, s.Concurrency, s.Arenas)

--- a/pbm/storage/download.go
+++ b/pbm/storage/download.go
@@ -24,6 +24,8 @@ const (
 
 // DownloadOpts adjusts download options. We go from spanSize. But if bufMaxMb is
 // set, it will be a hard limit on total memory.
+//
+//nolint:nonamedreturns
 func DownloadOpts(cc, bufMaxMb, spanSizeMb int) (arenaSize, span, c int) {
 	if cc == 0 {
 		cc = runtime.GOMAXPROCS(0)
@@ -215,10 +217,10 @@ func popcnt(x uint64) int {
 // a queue (heap) for out-of-order chunks
 type ChunksQueue []*Chunk
 
-func (b ChunksQueue) Len() int           { return len(b) }
-func (b ChunksQueue) Less(i, j int) bool { return b[i].Meta.Start < b[j].Meta.Start }
-func (b ChunksQueue) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b *ChunksQueue) Push(x any)        { *b = append(*b, x.(*Chunk)) }
+func (b *ChunksQueue) Len() int           { return len(*b) }
+func (b *ChunksQueue) Less(i, j int) bool { return (*b)[i].Meta.Start < (*b)[j].Meta.Start }
+func (b *ChunksQueue) Swap(i, j int)      { (*b)[i], (*b)[j] = (*b)[j], (*b)[i] }
+func (b *ChunksQueue) Push(x any)         { *b = append(*b, x.(*Chunk)) }
 func (b *ChunksQueue) Pop() any {
 	old := *b
 	n := len(old)

--- a/pbm/storage/download.go
+++ b/pbm/storage/download.go
@@ -1,0 +1,360 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	DownloadChuckSizeDefault = 8 << 20
+	downloadRetries          = 10
+
+	ccSpanDefault = 32 << 20
+	arenaSpans    = 8 // an amount of spans in arena
+
+	// assume we need more spans in arena above this number of CPUs used
+	lowCPU = 8
+)
+
+// DownloadOpts adjusts download options. We go from spanSize. But if bufMaxMb is
+// set, it will be a hard limit on total memory.
+func DownloadOpts(cc, bufMaxMb, spanSizeMb int) (arenaSize, span, c int) {
+	if cc == 0 {
+		cc = runtime.GOMAXPROCS(0)
+	}
+
+	// broad assumption that increased amount of concurrency may lead to
+	// extra contention hence need in more spans in arena
+	spans := arenaSpans
+	if cc > lowCPU {
+		spans *= 2
+	}
+
+	spanSize := spanSizeMb << 20
+	if spanSize == 0 {
+		spanSize = ccSpanDefault
+	}
+
+	bufSize := bufMaxMb << 20
+	if bufSize == 0 || spanSize*spans*cc <= bufSize {
+		return spanSize * spans, spanSize, cc
+	}
+
+	// download buffer can't be smaller than spanSize
+	if bufSize < spanSize {
+		spanSize = bufSize
+	}
+
+	// shrink coucurrency if bufSize too small
+	if bufSize/cc < spanSize {
+		cc = bufSize / spanSize
+	}
+
+	return spanSize * (bufSize / cc / spanSize), spanSize, cc
+}
+
+type DownloadStat struct {
+	Arenas      []ArenaStat `bson:"a" json:"a"`
+	Concurrency int         `bson:"cc" json:"cc"`
+	ArenaSize   int         `bson:"arSize" json:"arSize"`
+	SpansNum    int         `bson:"spanNum" json:"spanNum"`
+	SpanSize    int         `bson:"spanSize" json:"spanSize"`
+	BufSize     int         `bson:"bufSize" json:"bufSize"`
+}
+
+func (s DownloadStat) String() string {
+	return fmt.Sprintf("buf %d, arena %d, span %d, spanNum %d, cc %d, %v",
+		s.BufSize, s.ArenaSize, s.SpanSize, s.SpansNum, s.Concurrency, s.Arenas)
+}
+
+// ARENA
+
+type ArenaStat struct {
+	// the max amount of span was occupied simultaneously
+	MaxSpan int `bson:"MaxSpan" json:"MaxSpan"`
+	// how many times getSpan() was waiting for the free span
+	WaitCnt int `bson:"WaitCnt" json:"WaitCnt"`
+}
+
+// Arena (bytes slice) is split into spans (represented by `dpsan`)
+// whose size should be equal to download chunks. `dspan` implements io.Wrire
+// and io.ReaderCloser interface. Close() marks the span as free to use
+// (download another chunk).
+// Free/busy spans list is managed via lock-free bitmap index.
+type Arena struct {
+	Buf        []byte
+	SpanSize   int
+	SpanBitCnt uint64
+	FreeIndex  atomic.Uint64 // free slots bitmap
+
+	Stat ArenaStat
+
+	CpBuf []byte // preallocated buffer for io.Copy
+}
+
+func NewArena(size, spansize int) *Arena {
+	snum := size / spansize
+
+	size = spansize * snum
+	return &Arena{
+		Buf:        make([]byte, size),
+		SpanSize:   spansize,
+		SpanBitCnt: 1<<(size/spansize) - 1,
+		CpBuf:      make([]byte, 32*1024),
+	}
+}
+
+type dspan struct {
+	rp   int // current read pos in the arena
+	wp   int // current write pos in the arena
+	high int // high bound index of span in the arena
+
+	slot  int    // slot number in the arena
+	arena *Arena // link to the arena
+}
+
+func (s *dspan) Write(p []byte) (int, error) {
+	n := copy(s.arena.Buf[s.wp:s.high], p)
+
+	s.wp += n
+	return n, nil
+}
+
+func (s *dspan) Read(p []byte) (int, error) {
+	n := copy(p, s.arena.Buf[s.rp:s.wp])
+	s.rp += n
+
+	if s.rp == s.wp {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func (s *dspan) Close() error {
+	s.arena.putSpan(s)
+	return nil
+}
+
+func (b *Arena) GetSpan() *dspan {
+	var w bool
+	for {
+		m := b.FreeIndex.Load()
+		if m >= b.SpanBitCnt {
+			// write stat on contention - no free spans now
+			if !w {
+				b.Stat.WaitCnt++
+				w = true
+			}
+
+			continue
+		}
+		i := firstzero(m)
+
+		if i+1 > b.Stat.MaxSpan {
+			b.Stat.MaxSpan = i + 1
+		}
+
+		if b.FreeIndex.CompareAndSwap(m, m^uint64(1)<<i) {
+			return &dspan{
+				rp:    i * b.SpanSize,
+				wp:    i * b.SpanSize,
+				high:  (i + 1) * b.SpanSize,
+				slot:  i,
+				arena: b,
+			}
+		}
+	}
+}
+
+func (b *Arena) putSpan(c *dspan) {
+	flip := uint64(1 << uint64(c.slot))
+	for {
+		m := b.FreeIndex.Load()
+		if b.FreeIndex.CompareAndSwap(m, m&^flip) {
+			return
+		}
+	}
+}
+
+// returns a position of the first (rightmost) unset (zero) bit
+func firstzero(x uint64) int {
+	x = ^x
+	return popcnt((x & (-x)) - 1)
+}
+
+// count the num of populated (set to 1) bits
+func popcnt(x uint64) int {
+	const m1 = 0x5555555555555555
+	const m2 = 0x3333333333333333
+	const m4 = 0x0f0f0f0f0f0f0f0f
+	const h01 = 0x0101010101010101
+
+	x -= (x >> 1) & m1
+	x = (x & m2) + ((x >> 2) & m2)
+	x = (x + (x >> 4)) & m4
+	return int((x * h01) >> 56)
+}
+
+// a queue (heap) for out-of-order chunks
+type ChunksQueue []*Chunk
+
+func (b ChunksQueue) Len() int           { return len(b) }
+func (b ChunksQueue) Less(i, j int) bool { return b[i].Meta.Start < b[j].Meta.Start }
+func (b ChunksQueue) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b *ChunksQueue) Push(x any)        { *b = append(*b, x.(*Chunk)) }
+func (b *ChunksQueue) Pop() any {
+	old := *b
+	n := len(old)
+	x := old[n-1]
+	*b = old[0 : n-1]
+	return x
+}
+
+// PART READER: common concurrent download logic.
+
+// GetChunkFunc is a provider-specific callback to download a chunk
+// given an Arena and a byte range [start, end].
+type GetChunkFunc func(fname string, arena *Arena, start, end int64) (io.ReadCloser, error)
+
+type chunkMeta struct {
+	Start int64
+	End   int64
+}
+
+type Chunk struct {
+	r    io.ReadCloser
+	Meta chunkMeta
+}
+
+// requests an object in chunks and retries if download has failed
+type PartReader struct {
+	Fname     string
+	Fsize     int64 // a total size of object (file) to download
+	Written   int64
+	ChunkSize int64
+
+	GetChunk GetChunkFunc
+
+	Buf []byte // preallocated buf for io.Copy
+
+	taskq   chan chunkMeta
+	Resultq chan Chunk
+	Errc    chan error
+	close   chan struct{}
+}
+
+func (pr *PartReader) Run(concurrency int, arenas []*Arena) {
+	pr.taskq = make(chan chunkMeta, concurrency)
+	pr.Resultq = make(chan Chunk)
+	pr.Errc = make(chan error)
+	pr.close = make(chan struct{})
+
+	// schedule chunks for download
+	go func() {
+		for sent := int64(0); sent <= pr.Fsize; {
+			select {
+			case <-pr.close:
+				return
+			case pr.taskq <- chunkMeta{sent, sent + pr.ChunkSize - 1}:
+				sent += pr.ChunkSize
+			}
+		}
+	}()
+
+	for i := 0; i < concurrency; i++ {
+		go pr.worker(arenas[i])
+	}
+}
+
+func (pr *PartReader) worker(buf *Arena) {
+	//sess, err := pr.getSess()
+	//if err != nil {
+	//	pr.errc <- errors.Wrap(err, "create session")
+	//	return
+	//}
+
+	for {
+		select {
+		case ch := <-pr.taskq:
+			r, err := pr.retryChunk(buf, ch.Start, ch.End, downloadRetries)
+			if err != nil {
+				pr.Errc <- err
+				return
+			}
+
+			pr.Resultq <- Chunk{r: r, Meta: ch}
+
+		case <-pr.close:
+			return
+		}
+	}
+}
+
+func (pr *PartReader) retryChunk(buf *Arena, start, end int64, retries int) (io.ReadCloser, error) {
+	var r io.ReadCloser
+	var err error
+
+	for i := 0; i < retries; i++ {
+		r, err = pr.tryChunk(buf, start, end)
+		if err == nil {
+			return r, nil
+		}
+
+		//pr.l.Warning("retryChunk got %v, try to reconnect in %v", err, time.Second*time.Duration(i))
+		time.Sleep(time.Second * time.Duration(i))
+		//s, err = pr.getSess()
+		//if err != nil {
+		//	pr.l.Warning("recreate session err: %v", err)
+		//	continue
+		//}
+		//pr.l.Info("session recreated, resuming download")
+	}
+
+	//return nil, fmt.Errorf("failed to download chunk %d-%d after %d retries: %v", start, end, retries, err)
+	return nil, err
+}
+
+func (pr *PartReader) tryChunk(buf *Arena, start, end int64) (io.ReadCloser, error) {
+	return pr.GetChunk(pr.Fname, buf, start, end)
+}
+
+func (pr *PartReader) WriteChunk(r *Chunk, to io.Writer) error {
+	if r == nil || r.r == nil {
+		return nil
+	}
+
+	b, err := io.CopyBuffer(to, r.r, pr.Buf)
+	pr.Written += b
+	r.r.Close()
+
+	return err
+}
+
+func (pr *PartReader) Reset() {
+	close(pr.close)
+}
+
+type GetObjError struct {
+	Err error
+}
+
+func (e GetObjError) Error() string {
+	return e.Err.Error()
+}
+
+func (e GetObjError) Unwap() error {
+	return e.Err
+}
+
+func (GetObjError) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(GetObjError) //nolint:errorlint
+	return ok
+}

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -4,60 +4,35 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"io"
 	"net/http"
 	"path"
-	"runtime"
-	"sync/atomic"
 	"time"
 
 	gcs "cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
 )
-
-const (
-	downloadChuckSizeDefault = 8 << 20
-	downloadRetries          = 10
-
-	ccSpanDefault = 32 << 20
-	arenaSpans    = 8 // an amount of spans in arena
-	lowCPU        = 8
-)
-
-type DownloadStat struct {
-	Arenas      []ArenaStat `bson:"a" json:"a"`
-	Concurrency int         `bson:"cc" json:"cc"`
-	ArenaSize   int         `bson:"arSize" json:"arSize"`
-	SpansNum    int         `bson:"spanNum" json:"spanNum"`
-	SpanSize    int         `bson:"spanSize" json:"spanSize"`
-	BufSize     int         `bson:"bufSize" json:"bufSize"`
-}
-
-func (s DownloadStat) String() string {
-	return fmt.Sprintf("buf %d, arena %d, span %d, spanNum %d, cc %d, %v",
-		s.BufSize, s.ArenaSize, s.SpanSize, s.SpansNum, s.Concurrency, s.Arenas)
-}
 
 type Download struct {
 	gcs *GCS
 
-	arenas   []*arena // mem buffer for downloads
+	arenas   []*storage.Arena // mem buffer for downloads
 	spanSize int
 	cc       int // download concurrency
 
-	stat DownloadStat
+	stat storage.DownloadStat
 }
 
 func (g *GCS) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
-	arenaSize, spanSize, cc := downloadOpts(cc, bufSizeMb, spanSizeMb)
+	arenaSize, spanSize, cc := storage.DownloadOpts(cc, bufSizeMb, spanSizeMb)
 	g.log.Debug("download max buf %d (arena %d, span %d, concurrency %d)", arenaSize*cc, arenaSize, spanSize, cc)
 
-	arenas := []*arena{}
+	var arenas []*storage.Arena
 	for i := 0; i < cc; i++ {
-		arenas = append(arenas, newArena(arenaSize, spanSize))
+		arenas = append(arenas, storage.NewArena(arenaSize, spanSize))
 	}
 
 	return &Download{
@@ -66,7 +41,7 @@ func (g *GCS) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 		spanSize: spanSize,
 		cc:       cc,
 
-		stat: DownloadStat{
+		stat: storage.DownloadStat{
 			Concurrency: cc,
 			ArenaSize:   arenaSize,
 			SpansNum:    arenaSize / spanSize,
@@ -76,49 +51,14 @@ func (g *GCS) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 	}
 }
 
-func downloadOpts(cc, bufMaxMb, spanSizeMb int) (arenaSize, span, c int) {
-	if cc == 0 {
-		cc = runtime.GOMAXPROCS(0)
-	}
-
-	// broad assumption that increased amount of concurrency may lead to
-	// extra contention hence need in more spans in arena
-	spans := arenaSpans
-	if cc > lowCPU {
-		spans *= 2
-	}
-
-	spanSize := spanSizeMb << 20
-	if spanSize == 0 {
-		spanSize = ccSpanDefault
-	}
-
-	bufSize := bufMaxMb << 20
-	if bufSize == 0 || spanSize*spans*cc <= bufSize {
-		return spanSize * spans, spanSize, cc
-	}
-
-	// download buffer can't be smaller than spanSize
-	if bufSize < spanSize {
-		spanSize = bufSize
-	}
-
-	// shrink coucurrency if bufSize too small
-	if bufSize/cc < spanSize {
-		cc = bufSize / spanSize
-	}
-
-	return spanSize * (bufSize / cc / spanSize), spanSize, cc
-}
-
 func (d *Download) SourceReader(name string) (io.ReadCloser, error) {
 	return d.gcs.sourceReader(name, d.arenas, d.cc, d.spanSize)
 }
 
-func (d *Download) Stat() DownloadStat {
-	d.stat.Arenas = []ArenaStat{}
+func (d *Download) Stat() storage.DownloadStat {
+	d.stat.Arenas = []storage.ArenaStat{}
 	for _, a := range d.arenas {
-		d.stat.Arenas = append(d.stat.Arenas, a.stat)
+		d.stat.Arenas = append(d.stat.Arenas, a.Stat)
 	}
 
 	return d.stat
@@ -128,84 +68,45 @@ func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
 	return g.d.SourceReader(name)
 }
 
-type getObjError struct {
-	Err error
-}
+//// requests an object in chunks and retries if download has failed
+//type partReader struct {
+//	fname     string
+//	fsize     int64 // a total size of object (file) to download
+//	written   int64
+//	chunkSize int64
+//
+//	getSess func() (*gcs.BucketHandle, error)
+//	l       log.LogEvent
+//	opts    *Config
+//	buf     []byte // preallocated buf for io.Copy
+//
+//	taskq   chan chunkMeta
+//	resultq chan chunk
+//	errc    chan error
+//	close   chan struct{}
+//}
 
-func (e getObjError) Error() string {
-	return e.Err.Error()
-}
-
-func (e getObjError) Unwap() error {
-	return e.Err
-}
-
-func (getObjError) Is(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	_, ok := err.(getObjError) //nolint:errorlint
-	return ok
-}
-
-// requests an object in chunks and retries if download has failed
-type partReader struct {
-	fname     string
-	fsize     int64 // a total size of object (file) to download
-	written   int64
-	chunkSize int64
-
-	getSess func() (*gcs.BucketHandle, error)
-	l       log.LogEvent
-	opts    *Config
-	buf     []byte // preallocated buf for io.Copy
-
-	taskq   chan chunkMeta
-	resultq chan chunk
-	errc    chan error
-	close   chan struct{}
-}
-
-func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *partReader {
-	return &partReader{
-		l:         g.log,
-		buf:       make([]byte, 32*1024),
-		opts:      g.opts,
-		fname:     fname,
-		fsize:     fsize,
-		chunkSize: int64(chunkSize),
-		getSess: func() (*gcs.BucketHandle, error) {
+func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *storage.PartReader {
+	return &storage.PartReader{
+		Fname:     fname,
+		Fsize:     fsize,
+		ChunkSize: int64(chunkSize),
+		Buf:       make([]byte, 32*1024),
+		L:         g.log,
+		GetChunk: func(fname string, arena *storage.Arena, cli interface{}, start, end int64) (io.ReadCloser, error) {
+			bucketHandle, ok := cli.(*gcs.BucketHandle)
+			if !ok {
+				return nil, fmt.Errorf("expected *s3.Client, got %T", cli)
+			}
+			return g.getChunk(fname, arena, bucketHandle, start, end)
+		},
+		GetSess: func() (interface{}, error) {
 			return g.bucketHandle, nil
 		},
 	}
 }
 
-type chunkMeta struct {
-	start int64
-	end   int64
-}
-
-type chunk struct {
-	r    io.ReadCloser
-	meta chunkMeta
-}
-
-type chunksQueue []*chunk
-
-func (b chunksQueue) Len() int           { return len(b) }
-func (b chunksQueue) Less(i, j int) bool { return b[i].meta.start < b[j].meta.start }
-func (b chunksQueue) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b *chunksQueue) Push(x any)        { *b = append(*b, x.(*chunk)) }
-func (b *chunksQueue) Pop() any {
-	old := *b
-	n := len(old)
-	x := old[n-1]
-	*b = old[0 : n-1]
-	return x
-}
-
-func (g *GCS) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize int) (io.ReadCloser, error) {
+func (g *GCS) sourceReader(fname string, arenas []*storage.Arena, cc, downloadChuckSize int) (io.ReadCloser, error) {
 	if cc < 1 {
 		return nil, errors.Errorf("num of workers shuld be at least 1 (got %d)", cc)
 	}
@@ -231,44 +132,44 @@ func (g *GCS) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize 
 			pr.Reset()
 		}()
 
-		cqueue := &chunksQueue{}
+		cqueue := &storage.ChunksQueue{}
 		heap.Init(cqueue)
 
 		for {
 			select {
-			case rs := <-pr.resultq:
+			case rs := <-pr.Resultq:
 				// Although chunks are requested concurrently they must be written sequentially
 				// to the destination as it is not necessary a file (decompress, mongorestore etc.).
 				// If it is not its turn (previous chunks weren't written yet) the chunk will be
 				// added to the buffer to wait. If the buffer grows too much the scheduling of new
 				// chunks will be paused for buffer to be handled.
-				if rs.meta.start != pr.written {
+				if rs.Meta.Start != pr.Written {
 					heap.Push(cqueue, &rs)
 					continue
 				}
 
-				err := pr.writeChunk(&rs, w)
+				err := pr.WriteChunk(&rs, w)
 				if err != nil {
-					exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse", rs.meta.start, rs.meta.end)
+					exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse", rs.Meta.Start, rs.Meta.End)
 					return
 				}
 
 				// check if we can send something from the buffer
-				for len(*cqueue) > 0 && []*chunk(*cqueue)[0].meta.start == pr.written {
-					r := heap.Pop(cqueue).(*chunk)
-					err := pr.writeChunk(r, w)
+				for len(*cqueue) > 0 && (*cqueue)[0].Meta.Start == pr.Written {
+					r := heap.Pop(cqueue).(*storage.Chunk)
+					err := pr.WriteChunk(r, w)
 					if err != nil {
-						exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse buffer", r.meta.start, r.meta.end)
+						exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse buffer", r.Meta.Start, r.Meta.End)
 						return
 					}
 				}
 
 				// we've read all bytes in the object
-				if pr.written >= pr.fsize {
+				if pr.Written >= pr.Fsize {
 					return
 				}
 
-			case err := <-pr.errc:
+			case err := <-pr.Errc:
 				exitErr = errors.Wrapf(err, "SourceReader: download '%s/%s'", g.opts.Bucket, fname)
 				return
 			}
@@ -278,133 +179,24 @@ func (g *GCS) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize 
 	return r, nil
 }
 
-func (pr *partReader) Run(concurrency int, arenas []*arena) {
-	pr.taskq = make(chan chunkMeta, concurrency)
-	pr.resultq = make(chan chunk)
-	pr.errc = make(chan error)
-	pr.close = make(chan struct{})
-
-	// schedule chunks for download
-	go func() {
-		for sent := int64(0); sent <= pr.fsize; {
-			select {
-			case <-pr.close:
-				return
-			case pr.taskq <- chunkMeta{sent, sent + pr.chunkSize - 1}:
-				sent += pr.chunkSize
-			}
-		}
-	}()
-
-	for i := 0; i < concurrency; i++ {
-		go pr.worker(arenas[i])
-	}
-}
-
-func (pr *partReader) Reset() {
-	close(pr.close)
-}
-
-func (pr *partReader) writeChunk(r *chunk, to io.Writer) error {
-	if r == nil || r.r == nil {
-		return nil
-	}
-
-	b, err := io.CopyBuffer(to, r.r, pr.buf)
-	pr.written += b
-	r.r.Close()
-
-	return err
-}
-
-func (pr *partReader) worker(buf *arena) {
-	sess, err := pr.getSess()
-	if err != nil {
-		pr.errc <- errors.Wrap(err, "create session")
-		return
-	}
-
-	for {
-		select {
-		case ch := <-pr.taskq:
-			r, err := pr.retryChunk(buf, sess, ch.start, ch.end, downloadRetries)
-			if err != nil {
-				pr.errc <- err
-				return
-			}
-
-			pr.resultq <- chunk{r: r, meta: ch}
-
-		case <-pr.close:
-			return
-		}
-	}
-}
-
-func (pr *partReader) retryChunk(buf *arena, s *gcs.BucketHandle, start, end int64, retries int) (io.ReadCloser, error) {
-	var r io.ReadCloser
-	var err error
-
-	for i := 0; i < retries; i++ {
-		r, err = pr.tryChunk(buf, s, start, end)
-		if err == nil {
-			return r, nil
-		}
-
-		pr.l.Warning("retryChunk got %v, try to reconnect in %v", err, time.Second*time.Duration(i))
-		time.Sleep(time.Second * time.Duration(i))
-		s, err = pr.getSess()
-		if err != nil {
-			pr.l.Warning("recreate session err: %v", err)
-			continue
-		}
-		pr.l.Info("session recreated, resuming download")
-	}
-
-	return nil, err
-}
-
-func (pr *partReader) tryChunk(buf *arena, s *gcs.BucketHandle, start, end int64) (io.ReadCloser, error) {
-	// just quickly retry w/o new session in case of fail.
-	// more sophisticated retry on a caller side.
-	const retry = 2
-	var err error
-	for i := 0; i < retry; i++ {
-		var r io.ReadCloser
-		r, err = pr.getChunk(buf, s, start, end)
-
-		if err == nil || errors.Is(err, io.EOF) {
-			return r, nil
-		}
-
-		if errors.Is(err, &getObjError{}) {
-			return r, err
-		}
-
-		pr.l.Warning("failed to download chunk %d-%d", start, end)
-	}
-
-	return nil, errors.Wrapf(err, "failed to download chunk %d-%d (of %d) after %d retries", start, end, pr.fsize, retry)
-}
-
-func (pr *partReader) getChunk(buf *arena, bucketHandle *gcs.BucketHandle, start, end int64) (io.ReadCloser, error) {
+func (g *GCS) getChunk(fname string, buf *storage.Arena, bucketHandle *gcs.BucketHandle, start, end int64) (io.ReadCloser, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()
 
 	length := end - start + 1
-	obj := bucketHandle.Object(path.Join(pr.opts.Prefix, pr.fname))
+	obj := bucketHandle.Object(path.Join(g.opts.Prefix, fname))
 	reader, err := obj.NewRangeReader(ctx, start, length)
 	if err != nil {
 		if errors.Is(err, gcs.ErrObjectNotExist) || (err != nil && isRangeNotSatisfiable(err)) {
 			return nil, io.EOF
 		}
 
-		pr.l.Warning("errGetObj Err: %v", err)
-		return nil, getObjError{err}
+		g.log.Warning("errGetObj Err: %v", err)
+		return nil, storage.GetObjError{Err: err}
 	}
 
-	ch := buf.getSpan()
-	_, err = io.CopyBuffer(ch, reader, buf.cpbuf)
+	ch := buf.GetSpan()
+	_, err = io.CopyBuffer(ch, reader, buf.CpBuf)
 	if err != nil {
 		ch.Close()
 		return nil, errors.Wrap(err, "copy")
@@ -420,131 +212,4 @@ func isRangeNotSatisfiable(err error) bool {
 		}
 	}
 	return false
-}
-
-// Download arena (bytes slice) is split into spans (represented by `dpsan`)
-// whose size should be equal to download chunks. `dspan` implements io.Wrire
-// and io.ReaderCloser interface. Close() marks the span as free to use
-// (download another chunk).
-// Free/busy spans list is managed via lock-free bitmap index.
-type arena struct {
-	buf        []byte
-	spansize   int
-	spanBitCnt uint64
-	freeindex  atomic.Uint64 // free slots bitmap
-
-	stat ArenaStat
-
-	cpbuf []byte // preallocated buffer for io.Copy
-}
-
-type ArenaStat struct {
-	// the max amount of span was occupied simultaneously
-	MaxSpan int `bson:"MaxSpan" json:"MaxSpan"`
-	// how many times getSpan() was waiting for the free span
-	WaitCnt int `bson:"WaitCnt" json:"WaitCnt"`
-}
-
-func newArena(size, spansize int) *arena {
-	snum := size / spansize
-
-	size = spansize * snum
-	return &arena{
-		buf:        make([]byte, size),
-		spansize:   spansize,
-		spanBitCnt: 1<<(size/spansize) - 1,
-		cpbuf:      make([]byte, 32*1024),
-	}
-}
-
-func (b *arena) getSpan() *dspan {
-	var w bool
-	for {
-		m := b.freeindex.Load()
-		if m >= b.spanBitCnt {
-			// write stat on contention - no free spans now
-			if !w {
-				b.stat.WaitCnt++
-				w = true
-			}
-
-			continue
-		}
-		i := firstzero(m)
-
-		if i+1 > b.stat.MaxSpan {
-			b.stat.MaxSpan = i + 1
-		}
-
-		if b.freeindex.CompareAndSwap(m, m^uint64(1)<<i) {
-			return &dspan{
-				rp:    i * b.spansize,
-				wp:    i * b.spansize,
-				high:  (i + 1) * b.spansize,
-				slot:  i,
-				arena: b,
-			}
-		}
-	}
-}
-
-func (b *arena) putSpan(c *dspan) {
-	flip := uint64(1 << uint64(c.slot))
-	for {
-		m := b.freeindex.Load()
-		if b.freeindex.CompareAndSwap(m, m&^flip) {
-			return
-		}
-	}
-}
-
-// returns a position of the first (rightmost) unset (zero) bit
-func firstzero(x uint64) int {
-	x = ^x
-	return popcnt((x & (-x)) - 1)
-}
-
-// count the num of populated (set to 1) bits
-func popcnt(x uint64) int {
-	const m1 = 0x5555555555555555
-	const m2 = 0x3333333333333333
-	const m4 = 0x0f0f0f0f0f0f0f0f
-	const h01 = 0x0101010101010101
-
-	x -= (x >> 1) & m1
-	x = (x & m2) + ((x >> 2) & m2)
-	x = (x + (x >> 4)) & m4
-	return int((x * h01) >> 56)
-}
-
-type dspan struct {
-	rp   int // current read pos in the arena
-	wp   int // current write pos in the arena
-	high int // high bound index of span in the arena
-
-	slot  int    // slot number in the arena
-	arena *arena // link to the arena
-}
-
-func (s *dspan) Write(p []byte) (int, error) {
-	n := copy(s.arena.buf[s.wp:s.high], p)
-
-	s.wp += n
-	return n, nil
-}
-
-func (s *dspan) Read(p []byte) (int, error) {
-	n := copy(p, s.arena.buf[s.rp:s.wp])
-	s.rp += n
-
-	if s.rp == s.wp {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
-func (s *dspan) Close() error {
-	s.arena.putSpan(s)
-	return nil
 }

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -88,7 +88,7 @@ func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *storage.P
 		GetChunk: func(fname string, arena *storage.Arena, cli interface{}, start, end int64) (io.ReadCloser, error) {
 			bucketHandle, ok := cli.(*gcs.BucketHandle)
 			if !ok {
-				return nil, errors.Errorf("expected *s3.Client, got %T", cli)
+				return nil, errors.Errorf("expected *gcs.BucketHandle, got %T", cli)
 			}
 			return g.getChunk(fname, arena, bucketHandle, start, end)
 		},

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -60,24 +60,6 @@ func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
 	return g.d.SourceReader(name)
 }
 
-//// requests an object in chunks and retries if download has failed
-//type partReader struct {
-//	fname     string
-//	fsize     int64 // a total size of object (file) to download
-//	written   int64
-//	chunkSize int64
-//
-//	getSess func() (*gcs.BucketHandle, error)
-//	l       log.LogEvent
-//	opts    *Config
-//	buf     []byte // preallocated buf for io.Copy
-//
-//	taskq   chan chunkMeta
-//	resultq chan chunk
-//	errc    chan error
-//	close   chan struct{}
-//}
-
 func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *storage.PartReader {
 	return &storage.PartReader{
 		Fname:     fname,

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -1,0 +1,550 @@
+package gcs
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	gcs "cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/log"
+)
+
+const (
+	downloadChuckSizeDefault = 8 << 20
+	downloadRetries          = 10
+
+	ccSpanDefault = 32 << 20
+	arenaSpans    = 8 // an amount of spans in arena
+	lowCPU        = 8
+)
+
+type DownloadStat struct {
+	Arenas      []ArenaStat `bson:"a" json:"a"`
+	Concurrency int         `bson:"cc" json:"cc"`
+	ArenaSize   int         `bson:"arSize" json:"arSize"`
+	SpansNum    int         `bson:"spanNum" json:"spanNum"`
+	SpanSize    int         `bson:"spanSize" json:"spanSize"`
+	BufSize     int         `bson:"bufSize" json:"bufSize"`
+}
+
+func (s DownloadStat) String() string {
+	return fmt.Sprintf("buf %d, arena %d, span %d, spanNum %d, cc %d, %v",
+		s.BufSize, s.ArenaSize, s.SpanSize, s.SpansNum, s.Concurrency, s.Arenas)
+}
+
+type Download struct {
+	gcs *GCS
+
+	arenas   []*arena // mem buffer for downloads
+	spanSize int
+	cc       int // download concurrency
+
+	stat DownloadStat
+}
+
+func (g *GCS) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
+	arenaSize, spanSize, cc := downloadOpts(cc, bufSizeMb, spanSizeMb)
+	g.log.Debug("download max buf %d (arena %d, span %d, concurrency %d)", arenaSize*cc, arenaSize, spanSize, cc)
+
+	arenas := []*arena{}
+	for i := 0; i < cc; i++ {
+		arenas = append(arenas, newArena(arenaSize, spanSize))
+	}
+
+	return &Download{
+		gcs:      g,
+		arenas:   arenas,
+		spanSize: spanSize,
+		cc:       cc,
+
+		stat: DownloadStat{
+			Concurrency: cc,
+			ArenaSize:   arenaSize,
+			SpansNum:    arenaSize / spanSize,
+			SpanSize:    spanSize,
+			BufSize:     arenaSize * cc,
+		},
+	}
+}
+
+func downloadOpts(cc, bufMaxMb, spanSizeMb int) (arenaSize, span, c int) {
+	if cc == 0 {
+		cc = runtime.GOMAXPROCS(0)
+	}
+
+	// broad assumption that increased amount of concurrency may lead to
+	// extra contention hence need in more spans in arena
+	spans := arenaSpans
+	if cc > lowCPU {
+		spans *= 2
+	}
+
+	spanSize := spanSizeMb << 20
+	if spanSize == 0 {
+		spanSize = ccSpanDefault
+	}
+
+	bufSize := bufMaxMb << 20
+	if bufSize == 0 || spanSize*spans*cc <= bufSize {
+		return spanSize * spans, spanSize, cc
+	}
+
+	// download buffer can't be smaller than spanSize
+	if bufSize < spanSize {
+		spanSize = bufSize
+	}
+
+	// shrink coucurrency if bufSize too small
+	if bufSize/cc < spanSize {
+		cc = bufSize / spanSize
+	}
+
+	return spanSize * (bufSize / cc / spanSize), spanSize, cc
+}
+
+func (d *Download) SourceReader(name string) (io.ReadCloser, error) {
+	return d.gcs.sourceReader(name, d.arenas, d.cc, d.spanSize)
+}
+
+func (d *Download) Stat() DownloadStat {
+	d.stat.Arenas = []ArenaStat{}
+	for _, a := range d.arenas {
+		d.stat.Arenas = append(d.stat.Arenas, a.stat)
+	}
+
+	return d.stat
+}
+
+func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
+	return g.d.SourceReader(name)
+}
+
+type getObjError struct {
+	Err error
+}
+
+func (e getObjError) Error() string {
+	return e.Err.Error()
+}
+
+func (e getObjError) Unwap() error {
+	return e.Err
+}
+
+func (getObjError) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(getObjError) //nolint:errorlint
+	return ok
+}
+
+// requests an object in chunks and retries if download has failed
+type partReader struct {
+	fname     string
+	fsize     int64 // a total size of object (file) to download
+	written   int64
+	chunkSize int64
+
+	getSess func() (*gcs.BucketHandle, error)
+	l       log.LogEvent
+	opts    *Config
+	buf     []byte // preallocated buf for io.Copy
+
+	taskq   chan chunkMeta
+	resultq chan chunk
+	errc    chan error
+	close   chan struct{}
+}
+
+func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *partReader {
+	return &partReader{
+		l:         g.log,
+		buf:       make([]byte, 32*1024),
+		opts:      g.opts,
+		fname:     fname,
+		fsize:     fsize,
+		chunkSize: int64(chunkSize),
+		getSess: func() (*gcs.BucketHandle, error) {
+			return g.bucketHandle, nil
+		},
+	}
+}
+
+type chunkMeta struct {
+	start int64
+	end   int64
+}
+
+type chunk struct {
+	r    io.ReadCloser
+	meta chunkMeta
+}
+
+type chunksQueue []*chunk
+
+func (b chunksQueue) Len() int           { return len(b) }
+func (b chunksQueue) Less(i, j int) bool { return b[i].meta.start < b[j].meta.start }
+func (b chunksQueue) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b *chunksQueue) Push(x any)        { *b = append(*b, x.(*chunk)) }
+func (b *chunksQueue) Pop() any {
+	old := *b
+	n := len(old)
+	x := old[n-1]
+	*b = old[0 : n-1]
+	return x
+}
+
+func (g *GCS) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize int) (io.ReadCloser, error) {
+	if cc < 1 {
+		return nil, errors.Errorf("num of workers shuld be at least 1 (got %d)", cc)
+	}
+	if len(arenas) < cc {
+		return nil, errors.Errorf("num of arenas (%d) less then workers (%d)", len(arenas), cc)
+	}
+
+	fstat, err := g.FileStat(fname)
+	if err != nil {
+		return nil, errors.Wrap(err, "get file stat")
+	}
+
+	r, w := io.Pipe()
+
+	go func() {
+		pr := g.newPartReader(fname, fstat.Size, downloadChuckSize)
+
+		pr.Run(cc, arenas)
+
+		exitErr := io.EOF
+		defer func() {
+			w.CloseWithError(exitErr)
+			pr.Reset()
+		}()
+
+		cqueue := &chunksQueue{}
+		heap.Init(cqueue)
+
+		for {
+			select {
+			case rs := <-pr.resultq:
+				// Although chunks are requested concurrently they must be written sequentially
+				// to the destination as it is not necessary a file (decompress, mongorestore etc.).
+				// If it is not its turn (previous chunks weren't written yet) the chunk will be
+				// added to the buffer to wait. If the buffer grows too much the scheduling of new
+				// chunks will be paused for buffer to be handled.
+				if rs.meta.start != pr.written {
+					heap.Push(cqueue, &rs)
+					continue
+				}
+
+				err := pr.writeChunk(&rs, w)
+				if err != nil {
+					exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse", rs.meta.start, rs.meta.end)
+					return
+				}
+
+				// check if we can send something from the buffer
+				for len(*cqueue) > 0 && []*chunk(*cqueue)[0].meta.start == pr.written {
+					r := heap.Pop(cqueue).(*chunk)
+					err := pr.writeChunk(r, w)
+					if err != nil {
+						exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse buffer", r.meta.start, r.meta.end)
+						return
+					}
+				}
+
+				// we've read all bytes in the object
+				if pr.written >= pr.fsize {
+					return
+				}
+
+			case err := <-pr.errc:
+				exitErr = errors.Wrapf(err, "SourceReader: download '%s/%s'", g.opts.Bucket, fname)
+				return
+			}
+		}
+	}()
+
+	return r, nil
+}
+
+func (pr *partReader) Run(concurrency int, arenas []*arena) {
+	pr.taskq = make(chan chunkMeta, concurrency)
+	pr.resultq = make(chan chunk)
+	pr.errc = make(chan error)
+	pr.close = make(chan struct{})
+
+	// schedule chunks for download
+	go func() {
+		for sent := int64(0); sent <= pr.fsize; {
+			select {
+			case <-pr.close:
+				return
+			case pr.taskq <- chunkMeta{sent, sent + pr.chunkSize - 1}:
+				sent += pr.chunkSize
+			}
+		}
+	}()
+
+	for i := 0; i < concurrency; i++ {
+		go pr.worker(arenas[i])
+	}
+}
+
+func (pr *partReader) Reset() {
+	close(pr.close)
+}
+
+func (pr *partReader) writeChunk(r *chunk, to io.Writer) error {
+	if r == nil || r.r == nil {
+		return nil
+	}
+
+	b, err := io.CopyBuffer(to, r.r, pr.buf)
+	pr.written += b
+	r.r.Close()
+
+	return err
+}
+
+func (pr *partReader) worker(buf *arena) {
+	sess, err := pr.getSess()
+	if err != nil {
+		pr.errc <- errors.Wrap(err, "create session")
+		return
+	}
+
+	for {
+		select {
+		case ch := <-pr.taskq:
+			r, err := pr.retryChunk(buf, sess, ch.start, ch.end, downloadRetries)
+			if err != nil {
+				pr.errc <- err
+				return
+			}
+
+			pr.resultq <- chunk{r: r, meta: ch}
+
+		case <-pr.close:
+			return
+		}
+	}
+}
+
+func (pr *partReader) retryChunk(buf *arena, s *gcs.BucketHandle, start, end int64, retries int) (io.ReadCloser, error) {
+	var r io.ReadCloser
+	var err error
+
+	for i := 0; i < retries; i++ {
+		r, err = pr.tryChunk(buf, s, start, end)
+		if err == nil {
+			return r, nil
+		}
+
+		pr.l.Warning("retryChunk got %v, try to reconnect in %v", err, time.Second*time.Duration(i))
+		time.Sleep(time.Second * time.Duration(i))
+		s, err = pr.getSess()
+		if err != nil {
+			pr.l.Warning("recreate session err: %v", err)
+			continue
+		}
+		pr.l.Info("session recreated, resuming download")
+	}
+
+	return nil, err
+}
+
+func (pr *partReader) tryChunk(buf *arena, s *gcs.BucketHandle, start, end int64) (io.ReadCloser, error) {
+	// just quickly retry w/o new session in case of fail.
+	// more sophisticated retry on a caller side.
+	const retry = 2
+	var err error
+	for i := 0; i < retry; i++ {
+		var r io.ReadCloser
+		r, err = pr.getChunk(buf, s, start, end)
+
+		if err == nil || errors.Is(err, io.EOF) {
+			return r, nil
+		}
+
+		if errors.Is(err, &getObjError{}) {
+			return r, err
+		}
+
+		pr.l.Warning("failed to download chunk %d-%d", start, end)
+	}
+
+	return nil, errors.Wrapf(err, "failed to download chunk %d-%d (of %d) after %d retries", start, end, pr.fsize, retry)
+}
+
+func (pr *partReader) getChunk(buf *arena, bucketHandle *gcs.BucketHandle, start, end int64) (io.ReadCloser, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
+	length := end - start + 1
+	obj := bucketHandle.Object(path.Join(pr.opts.Prefix, pr.fname))
+	reader, err := obj.NewRangeReader(ctx, start, length)
+	if err != nil {
+		if errors.Is(err, gcs.ErrObjectNotExist) || (err != nil && isRangeNotSatisfiable(err)) {
+			return nil, io.EOF
+		}
+
+		pr.l.Warning("errGetObj Err: %v", err)
+		return nil, getObjError{err}
+	}
+
+	ch := buf.getSpan()
+	_, err = io.CopyBuffer(ch, reader, buf.cpbuf)
+	if err != nil {
+		ch.Close()
+		return nil, errors.Wrap(err, "copy")
+	}
+	reader.Close()
+	return ch, nil
+}
+
+func isRangeNotSatisfiable(err error) bool {
+	if herr, ok := err.(*googleapi.Error); ok {
+		if herr.Code == http.StatusRequestedRangeNotSatisfiable {
+			return true
+		}
+	}
+	return false
+}
+
+// Download arena (bytes slice) is split into spans (represented by `dpsan`)
+// whose size should be equal to download chunks. `dspan` implements io.Wrire
+// and io.ReaderCloser interface. Close() marks the span as free to use
+// (download another chunk).
+// Free/busy spans list is managed via lock-free bitmap index.
+type arena struct {
+	buf        []byte
+	spansize   int
+	spanBitCnt uint64
+	freeindex  atomic.Uint64 // free slots bitmap
+
+	stat ArenaStat
+
+	cpbuf []byte // preallocated buffer for io.Copy
+}
+
+type ArenaStat struct {
+	// the max amount of span was occupied simultaneously
+	MaxSpan int `bson:"MaxSpan" json:"MaxSpan"`
+	// how many times getSpan() was waiting for the free span
+	WaitCnt int `bson:"WaitCnt" json:"WaitCnt"`
+}
+
+func newArena(size, spansize int) *arena {
+	snum := size / spansize
+
+	size = spansize * snum
+	return &arena{
+		buf:        make([]byte, size),
+		spansize:   spansize,
+		spanBitCnt: 1<<(size/spansize) - 1,
+		cpbuf:      make([]byte, 32*1024),
+	}
+}
+
+func (b *arena) getSpan() *dspan {
+	var w bool
+	for {
+		m := b.freeindex.Load()
+		if m >= b.spanBitCnt {
+			// write stat on contention - no free spans now
+			if !w {
+				b.stat.WaitCnt++
+				w = true
+			}
+
+			continue
+		}
+		i := firstzero(m)
+
+		if i+1 > b.stat.MaxSpan {
+			b.stat.MaxSpan = i + 1
+		}
+
+		if b.freeindex.CompareAndSwap(m, m^uint64(1)<<i) {
+			return &dspan{
+				rp:    i * b.spansize,
+				wp:    i * b.spansize,
+				high:  (i + 1) * b.spansize,
+				slot:  i,
+				arena: b,
+			}
+		}
+	}
+}
+
+func (b *arena) putSpan(c *dspan) {
+	flip := uint64(1 << uint64(c.slot))
+	for {
+		m := b.freeindex.Load()
+		if b.freeindex.CompareAndSwap(m, m&^flip) {
+			return
+		}
+	}
+}
+
+// returns a position of the first (rightmost) unset (zero) bit
+func firstzero(x uint64) int {
+	x = ^x
+	return popcnt((x & (-x)) - 1)
+}
+
+// count the num of populated (set to 1) bits
+func popcnt(x uint64) int {
+	const m1 = 0x5555555555555555
+	const m2 = 0x3333333333333333
+	const m4 = 0x0f0f0f0f0f0f0f0f
+	const h01 = 0x0101010101010101
+
+	x -= (x >> 1) & m1
+	x = (x & m2) + ((x >> 2) & m2)
+	x = (x + (x >> 4)) & m4
+	return int((x * h01) >> 56)
+}
+
+type dspan struct {
+	rp   int // current read pos in the arena
+	wp   int // current write pos in the arena
+	high int // high bound index of span in the arena
+
+	slot  int    // slot number in the arena
+	arena *arena // link to the arena
+}
+
+func (s *dspan) Write(p []byte) (int, error) {
+	n := copy(s.arena.buf[s.wp:s.high], p)
+
+	s.wp += n
+	return n, nil
+}
+
+func (s *dspan) Read(p []byte) (int, error) {
+	n := copy(p, s.arena.buf[s.rp:s.wp])
+	s.rp += n
+
+	if s.rp == s.wp {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func (s *dspan) Close() error {
+	s.arena.putSpan(s)
+	return nil
+}

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -40,14 +40,7 @@ func (g *GCS) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 		arenas:   arenas,
 		spanSize: spanSize,
 		cc:       cc,
-
-		stat: storage.DownloadStat{
-			Concurrency: cc,
-			ArenaSize:   arenaSize,
-			SpansNum:    arenaSize / spanSize,
-			SpanSize:    spanSize,
-			BufSize:     arenaSize * cc,
-		},
+		stat:     storage.NewDownloadStat(cc, arenaSize, spanSize),
 	}
 }
 

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"io"
 	"net/http"
 	"path"
@@ -14,6 +13,7 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 type Download struct {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -162,17 +162,6 @@ func (g *GCS) Save(name string, data io.Reader, size int64) error {
 	return nil
 }
 
-//func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
-//	ctx := context.Background()
-//
-//	reader, err := g.bucketHandle.Object(path.Join(g.opts.Prefix, name)).NewReader(ctx)
-//	if err != nil {
-//		return nil, errors.Wrap(err, "object not found")
-//	}
-//
-//	return reader, nil
-//}
-
 func (g *GCS) FileStat(name string) (storage.FileInfo, error) {
 	ctx := context.Background()
 

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -66,6 +66,8 @@ type GCS struct {
 	opts         *Config
 	bucketHandle *gcs.BucketHandle
 	log          log.LogEvent
+
+	d *Download
 }
 
 func (cfg *Config) Clone() *Config {
@@ -126,6 +128,13 @@ func New(opts *Config, node string, l log.LogEvent) (*GCS, error) {
 
 	g.bucketHandle = bucketHandle
 
+	g.d = &Download{
+		gcs:      g,
+		arenas:   []*arena{newArena(downloadChuckSizeDefault, downloadChuckSizeDefault)},
+		spanSize: downloadChuckSizeDefault,
+		cc:       1,
+	}
+
 	return g, nil
 }
 
@@ -153,16 +162,16 @@ func (g *GCS) Save(name string, data io.Reader, size int64) error {
 	return nil
 }
 
-func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
-	ctx := context.Background()
-
-	reader, err := g.bucketHandle.Object(path.Join(g.opts.Prefix, name)).NewReader(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "object not found")
-	}
-
-	return reader, nil
-}
+//func (g *GCS) SourceReader(name string) (io.ReadCloser, error) {
+//	ctx := context.Background()
+//
+//	reader, err := g.bucketHandle.Object(path.Join(g.opts.Prefix, name)).NewReader(ctx)
+//	if err != nil {
+//		return nil, errors.Wrap(err, "object not found")
+//	}
+//
+//	return reader, nil
+//}
 
 func (g *GCS) FileStat(name string) (storage.FileInfo, error) {
 	ctx := context.Background()

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -130,8 +130,8 @@ func New(opts *Config, node string, l log.LogEvent) (*GCS, error) {
 
 	g.d = &Download{
 		gcs:      g,
-		arenas:   []*arena{newArena(downloadChuckSizeDefault, downloadChuckSizeDefault)},
-		spanSize: downloadChuckSizeDefault,
+		arenas:   []*storage.Arena{storage.NewArena(storage.DownloadChuckSizeDefault, storage.DownloadChuckSizeDefault)},
+		spanSize: storage.DownloadChuckSizeDefault,
 		cc:       1,
 	}
 

--- a/pbm/storage/s3/download.go
+++ b/pbm/storage/s3/download.go
@@ -68,14 +68,7 @@ func (s *S3) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 		arenas:   arenas,
 		spanSize: spanSize,
 		cc:       cc,
-
-		stat: storage.DownloadStat{
-			Concurrency: cc,
-			ArenaSize:   arenaSize,
-			SpansNum:    arenaSize / spanSize,
-			SpanSize:    spanSize,
-			BufSize:     arenaSize * cc,
-		},
+		stat:     storage.NewDownloadStat(cc, arenaSize, spanSize),
 	}
 }
 

--- a/pbm/storage/s3/download.go
+++ b/pbm/storage/s3/download.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"runtime"
-	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,7 +17,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
-	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
 // Downloading objects from the storage.
@@ -45,46 +43,24 @@ import (
 // `arenaSize` is `spanSize * spansInArena`. It doesn't mean all of this size
 // would be allocated as some of the span slots may remain unused.
 
-const (
-	downloadChuckSizeDefault = 8 << 20
-	downloadRetries          = 10
-
-	ccSpanDefault = 32 << 20
-	arenaSpans    = 8 // an amount of spans in arena
-)
-
-type DownloadStat struct {
-	Arenas      []ArenaStat `bson:"a" json:"a"`
-	Concurrency int         `bson:"cc" json:"cc"`
-	ArenaSize   int         `bson:"arSize" json:"arSize"`
-	SpansNum    int         `bson:"spanNum" json:"spanNum"`
-	SpanSize    int         `bson:"spanSize" json:"spanSize"`
-	BufSize     int         `bson:"bufSize" json:"bufSize"`
-}
-
-func (s DownloadStat) String() string {
-	return fmt.Sprintf("buf %d, arena %d, span %d, spanNum %d, cc %d, %v",
-		s.BufSize, s.ArenaSize, s.SpanSize, s.SpansNum, s.Concurrency, s.Arenas)
-}
-
 // Download is used to concurrently download objects from the storage.
 type Download struct {
 	s3 *S3
 
-	arenas   []*arena // mem buffer for downloads
+	arenas   []*storage.Arena // mem buffer for downloads
 	spanSize int
 	cc       int // download concurrency
 
-	stat DownloadStat
+	stat storage.DownloadStat
 }
 
 func (s *S3) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
-	arenaSize, spanSize, cc := downloadOpts(cc, bufSizeMb, spanSizeMb)
+	arenaSize, spanSize, cc := storage.DownloadOpts(cc, bufSizeMb, spanSizeMb)
 	s.log.Debug("download max buf %d (arena %d, span %d, concurrency %d)", arenaSize*cc, arenaSize, spanSize, cc)
 
-	arenas := []*arena{}
+	var arenas []*storage.Arena
 	for i := 0; i < cc; i++ {
-		arenas = append(arenas, newArena(arenaSize, spanSize))
+		arenas = append(arenas, storage.NewArena(arenaSize, spanSize))
 	}
 
 	return &Download{
@@ -93,7 +69,7 @@ func (s *S3) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 		spanSize: spanSize,
 		cc:       cc,
 
-		stat: DownloadStat{
+		stat: storage.DownloadStat{
 			Concurrency: cc,
 			ArenaSize:   arenaSize,
 			SpansNum:    arenaSize / spanSize,
@@ -103,56 +79,14 @@ func (s *S3) NewDownload(cc, bufSizeMb, spanSizeMb int) *Download {
 	}
 }
 
-// assume we need more spans in arena above this number of CPUs used
-const lowCPU = 8
-
-// Adjust download options. We go from spanSize. But if bufMaxMb is
-// set, it will be a hard limit on total memory.
-//
-//nolint:nonamedreturns
-func downloadOpts(cc, bufMaxMb, spanSizeMb int) (arenaSize, span, c int) {
-	if cc == 0 {
-		cc = runtime.GOMAXPROCS(0)
-	}
-
-	// broad assumption that increased amount of concurrency may lead to
-	// extra contention hence need in more spans in arena
-	spans := arenaSpans
-	if cc > lowCPU {
-		spans *= 2
-	}
-
-	spanSize := spanSizeMb << 20
-	if spanSize == 0 {
-		spanSize = ccSpanDefault
-	}
-
-	bufSize := bufMaxMb << 20
-	if bufSize == 0 || spanSize*spans*cc <= bufSize {
-		return spanSize * spans, spanSize, cc
-	}
-
-	// download buffer can't be smaller than spanSize
-	if bufSize < spanSize {
-		spanSize = bufSize
-	}
-
-	// shrink coucurrency if bufSize too small
-	if bufSize/cc < spanSize {
-		cc = bufSize / spanSize
-	}
-
-	return spanSize * (bufSize / cc / spanSize), spanSize, cc
-}
-
 func (d *Download) SourceReader(name string) (io.ReadCloser, error) {
 	return d.s3.sourceReader(name, d.arenas, d.cc, d.spanSize)
 }
 
-func (d *Download) Stat() DownloadStat {
-	d.stat.Arenas = []ArenaStat{}
+func (d *Download) Stat() storage.DownloadStat {
+	d.stat.Arenas = []storage.ArenaStat{}
 	for _, a := range d.arenas {
-		d.stat.Arenas = append(d.stat.Arenas, a.stat)
+		d.stat.Arenas = append(d.stat.Arenas, a.Stat)
 	}
 
 	return d.stat
@@ -162,54 +96,21 @@ func (s *S3) SourceReader(name string) (io.ReadCloser, error) {
 	return s.d.SourceReader(name)
 }
 
-type getObjError struct {
-	Err error
-}
-
-func (e getObjError) Error() string {
-	return e.Err.Error()
-}
-
-func (e getObjError) Unwap() error {
-	return e.Err
-}
-
-func (getObjError) Is(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	_, ok := err.(getObjError) //nolint:errorlint
-	return ok
-}
-
-// requests an object in chunks and retries if download has failed
-type partReader struct {
-	fname     string
-	fsize     int64 // a total size of object (file) to download
-	written   int64
-	chunkSize int64
-
-	getSess func() (*s3.Client, error)
-	l       log.LogEvent
-	opts    *Config
-	buf     []byte // preallocated buf for io.Copy
-
-	taskq   chan chunkMeta
-	resultq chan chunk
-	errc    chan error
-	close   chan struct{}
-}
-
-func (s *S3) newPartReader(fname string, fsize int64, chunkSize int) *partReader {
-	return &partReader{
-		l:         s.log,
-		buf:       make([]byte, 32*1024),
-		opts:      s.opts,
-		fname:     fname,
-		fsize:     fsize,
-		chunkSize: int64(chunkSize),
-		getSess: func() (*s3.Client, error) {
+func (s *S3) newPartReader(fname string, fsize int64, chunkSize int) *storage.PartReader {
+	return &storage.PartReader{
+		Fname:     fname,
+		Fsize:     fsize,
+		ChunkSize: int64(chunkSize),
+		Buf:       make([]byte, 32*1024),
+		L:         s.log,
+		GetChunk: func(fname string, arena *storage.Arena, cli interface{}, start, end int64) (io.ReadCloser, error) {
+			s3cli, ok := cli.(*s3.Client)
+			if !ok {
+				return nil, fmt.Errorf("expected *s3.Client, got %T", cli)
+			}
+			return s.getChunk(fname, arena, s3cli, start, end)
+		},
+		GetSess: func() (interface{}, error) {
 			cli, err := s.s3client()
 			if err != nil {
 				return nil, err
@@ -219,32 +120,7 @@ func (s *S3) newPartReader(fname string, fsize int64, chunkSize int) *partReader
 	}
 }
 
-type chunkMeta struct {
-	start int64
-	end   int64
-}
-
-type chunk struct {
-	r    io.ReadCloser
-	meta chunkMeta
-}
-
-// a queue (heap) for out-of-order chunks
-type chunksQueue []*chunk
-
-func (b chunksQueue) Len() int           { return len(b) }
-func (b chunksQueue) Less(i, j int) bool { return b[i].meta.start < b[j].meta.start }
-func (b chunksQueue) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b *chunksQueue) Push(x any)        { *b = append(*b, x.(*chunk)) }
-func (b *chunksQueue) Pop() any {
-	old := *b
-	n := len(old)
-	x := old[n-1]
-	*b = old[0 : n-1]
-	return x
-}
-
-func (s *S3) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize int) (io.ReadCloser, error) {
+func (s *S3) sourceReader(fname string, arenas []*storage.Arena, cc, downloadChuckSize int) (io.ReadCloser, error) {
 	if cc < 1 {
 		return nil, errors.Errorf("num of workers shuld be at least 1 (got %d)", cc)
 	}
@@ -270,44 +146,44 @@ func (s *S3) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize i
 			pr.Reset()
 		}()
 
-		cqueue := &chunksQueue{}
+		cqueue := &storage.ChunksQueue{}
 		heap.Init(cqueue)
 
 		for {
 			select {
-			case rs := <-pr.resultq:
+			case rs := <-pr.Resultq:
 				// Although chunks are requested concurrently they must be written sequentially
 				// to the destination as it is not necessary a file (decompress, mongorestore etc.).
 				// If it is not its turn (previous chunks weren't written yet) the chunk will be
 				// added to the buffer to wait. If the buffer grows too much the scheduling of new
 				// chunks will be paused for buffer to be handled.
-				if rs.meta.start != pr.written {
+				if rs.Meta.Start != pr.Written {
 					heap.Push(cqueue, &rs)
 					continue
 				}
 
-				err := pr.writeChunk(&rs, w)
+				err := pr.WriteChunk(&rs, w)
 				if err != nil {
-					exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse", rs.meta.start, rs.meta.end)
+					exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse", rs.Meta.Start, rs.Meta.End)
 					return
 				}
 
 				// check if we can send something from the buffer
-				for len(*cqueue) > 0 && []*chunk(*cqueue)[0].meta.start == pr.written {
-					r := heap.Pop(cqueue).(*chunk)
-					err := pr.writeChunk(r, w)
+				for len(*cqueue) > 0 && (*cqueue)[0].Meta.Start == pr.Written {
+					r := heap.Pop(cqueue).(*storage.Chunk)
+					err := pr.WriteChunk(r, w)
 					if err != nil {
-						exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse buffer", r.meta.start, r.meta.end)
+						exitErr = errors.Wrapf(err, "SourceReader: copy bytes %d-%d from resoponse buffer", r.Meta.Start, r.Meta.End)
 						return
 					}
 				}
 
 				// we've read all bytes in the object
-				if pr.written >= pr.fsize {
+				if pr.Written >= pr.Fsize {
 					return
 				}
 
-			case err := <-pr.errc:
+			case err := <-pr.Errc:
 				exitErr = errors.Wrapf(err, "SourceReader: download '%s/%s'", s.opts.Bucket, fname)
 				return
 			}
@@ -317,123 +193,14 @@ func (s *S3) sourceReader(fname string, arenas []*arena, cc, downloadChuckSize i
 	return r, nil
 }
 
-func (pr *partReader) Run(concurrency int, arenas []*arena) {
-	pr.taskq = make(chan chunkMeta, concurrency)
-	pr.resultq = make(chan chunk)
-	pr.errc = make(chan error)
-	pr.close = make(chan struct{})
-
-	// schedule chunks for download
-	go func() {
-		for sent := int64(0); sent <= pr.fsize; {
-			select {
-			case <-pr.close:
-				return
-			case pr.taskq <- chunkMeta{sent, sent + pr.chunkSize - 1}:
-				sent += pr.chunkSize
-			}
-		}
-	}()
-
-	for i := 0; i < concurrency; i++ {
-		go pr.worker(arenas[i])
-	}
-}
-
-func (pr *partReader) Reset() {
-	close(pr.close)
-}
-
-func (pr *partReader) writeChunk(r *chunk, to io.Writer) error {
-	if r == nil || r.r == nil {
-		return nil
-	}
-
-	b, err := io.CopyBuffer(to, r.r, pr.buf)
-	pr.written += b
-	r.r.Close()
-
-	return err
-}
-
-func (pr *partReader) worker(buf *arena) {
-	sess, err := pr.getSess()
-	if err != nil {
-		pr.errc <- errors.Wrap(err, "create session")
-		return
-	}
-
-	for {
-		select {
-		case ch := <-pr.taskq:
-			r, err := pr.retryChunk(buf, sess, ch.start, ch.end, downloadRetries)
-			if err != nil {
-				pr.errc <- err
-				return
-			}
-
-			pr.resultq <- chunk{r: r, meta: ch}
-
-		case <-pr.close:
-			return
-		}
-	}
-}
-
-func (pr *partReader) retryChunk(buf *arena, s *s3.Client, start, end int64, retries int) (io.ReadCloser, error) {
-	var r io.ReadCloser
-	var err error
-
-	for i := 0; i < retries; i++ {
-		r, err = pr.tryChunk(buf, s, start, end)
-		if err == nil {
-			return r, nil
-		}
-
-		pr.l.Warning("retryChunk got %v, try to reconnect in %v", err, time.Second*time.Duration(i))
-		time.Sleep(time.Second * time.Duration(i))
-		s, err = pr.getSess()
-		if err != nil {
-			pr.l.Warning("recreate session err: %v", err)
-			continue
-		}
-		pr.l.Info("session recreated, resuming download")
-	}
-
-	return nil, err
-}
-
-func (pr *partReader) tryChunk(buf *arena, s *s3.Client, start, end int64) (io.ReadCloser, error) {
-	// just quickly retry w/o new session in case of fail.
-	// more sophisticated retry on a caller side.
-	const retry = 2
-	var err error
-	for i := 0; i < retry; i++ {
-		var r io.ReadCloser
-		r, err = pr.getChunk(buf, s, start, end)
-
-		if err == nil || errors.Is(err, io.EOF) {
-			return r, nil
-		}
-
-		if errors.Is(err, &getObjError{}) {
-			return r, err
-		}
-
-		pr.l.Warning("failed to download chunk %d-%d", start, end)
-	}
-
-	return nil, errors.Wrapf(err, "failed to download chunk %d-%d (of %d) after %d retries", start, end, pr.fsize, retry)
-}
-
-func (pr *partReader) getChunk(buf *arena, s *s3.Client, start, end int64) (io.ReadCloser, error) {
+func (s *S3) getChunk(fname string, buf *storage.Arena, cli *s3.Client, start, end int64) (io.ReadCloser, error) {
 	getObjOpts := &s3.GetObjectInput{
-		Bucket: aws.String(pr.opts.Bucket),
-		Key:    aws.String(path.Join(pr.opts.Prefix, pr.fname)),
+		Bucket: aws.String(s.opts.Bucket),
+		Key:    aws.String(path.Join(s.opts.Prefix, fname)),
 		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", start, end)),
 	}
 
-	sse := pr.opts.ServerSideEncryption
+	sse := s.opts.ServerSideEncryption
 	if sse != nil && sse.SseCustomerAlgorithm != "" {
 		getObjOpts.SSECustomerAlgorithm = aws.String(sse.SseCustomerAlgorithm)
 		decodedKey, err := base64.StdEncoding.DecodeString(sse.SseCustomerKey)
@@ -448,7 +215,7 @@ func (pr *partReader) getChunk(buf *arena, s *s3.Client, start, end int64) (io.R
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	defer cancel()
 
-	s3obj, err := s.GetObject(ctx, getObjOpts)
+	s3obj, err := cli.GetObject(ctx, getObjOpts)
 	if err != nil {
 		// if object size is undefined, we would read
 		// until HTTP code 416 (Requested Range Not Satisfiable)
@@ -457,8 +224,8 @@ func (pr *partReader) getChunk(buf *arena, s *s3.Client, start, end int64) (io.R
 			return nil, io.EOF
 		}
 
-		pr.l.Warning("errGetObj Err: %v", err)
-		return nil, getObjError{err}
+		s.log.Warning("errGetObj Err: %v", err)
+		return nil, storage.GetObjError{Err: err}
 	}
 	defer s3obj.Body.Close()
 
@@ -477,138 +244,11 @@ func (pr *partReader) getChunk(buf *arena, s *s3.Client, start, end int64) (io.R
 		}
 	}
 
-	ch := buf.getSpan()
-	_, err = io.CopyBuffer(ch, s3obj.Body, buf.cpbuf)
+	ch := buf.GetSpan()
+	_, err = io.CopyBuffer(ch, s3obj.Body, buf.CpBuf)
 	if err != nil {
 		ch.Close()
 		return nil, errors.Wrap(err, "copy")
 	}
 	return ch, nil
-}
-
-// Download arena (bytes slice) is split into spans (represented by `dpsan`)
-// whose size should be equal to download chunks. `dspan` implements io.Wrire
-// and io.ReaderCloser interface. Close() marks the span as free to use
-// (download another chunk).
-// Free/busy spans list is managed via lock-free bitmap index.
-type arena struct {
-	buf        []byte
-	spansize   int
-	spanBitCnt uint64
-	freeindex  atomic.Uint64 // free slots bitmap
-
-	stat ArenaStat
-
-	cpbuf []byte // preallocated buffer for io.Copy
-}
-
-type ArenaStat struct {
-	// the max amount of span was occupied simultaneously
-	MaxSpan int `bson:"MaxSpan" json:"MaxSpan"`
-	// how many times getSpan() was waiting for the free span
-	WaitCnt int `bson:"WaitCnt" json:"WaitCnt"`
-}
-
-func newArena(size, spansize int) *arena {
-	snum := size / spansize
-
-	size = spansize * snum
-	return &arena{
-		buf:        make([]byte, size),
-		spansize:   spansize,
-		spanBitCnt: 1<<(size/spansize) - 1,
-		cpbuf:      make([]byte, 32*1024),
-	}
-}
-
-func (b *arena) getSpan() *dspan {
-	var w bool
-	for {
-		m := b.freeindex.Load()
-		if m >= b.spanBitCnt {
-			// write stat on contention - no free spans now
-			if !w {
-				b.stat.WaitCnt++
-				w = true
-			}
-
-			continue
-		}
-		i := firstzero(m)
-
-		if i+1 > b.stat.MaxSpan {
-			b.stat.MaxSpan = i + 1
-		}
-
-		if b.freeindex.CompareAndSwap(m, m^uint64(1)<<i) {
-			return &dspan{
-				rp:    i * b.spansize,
-				wp:    i * b.spansize,
-				high:  (i + 1) * b.spansize,
-				slot:  i,
-				arena: b,
-			}
-		}
-	}
-}
-
-func (b *arena) putSpan(c *dspan) {
-	flip := uint64(1 << uint64(c.slot))
-	for {
-		m := b.freeindex.Load()
-		if b.freeindex.CompareAndSwap(m, m&^flip) {
-			return
-		}
-	}
-}
-
-// returns a position of the first (rightmost) unset (zero) bit
-func firstzero(x uint64) int {
-	x = ^x
-	return popcnt((x & (-x)) - 1)
-}
-
-// count the num of populated (set to 1) bits
-func popcnt(x uint64) int {
-	const m1 = 0x5555555555555555
-	const m2 = 0x3333333333333333
-	const m4 = 0x0f0f0f0f0f0f0f0f
-	const h01 = 0x0101010101010101
-
-	x -= (x >> 1) & m1
-	x = (x & m2) + ((x >> 2) & m2)
-	x = (x + (x >> 4)) & m4
-	return int((x * h01) >> 56)
-}
-
-type dspan struct {
-	rp   int // current read pos in the arena
-	wp   int // current write pos in the arena
-	high int // high bound index of span in the arena
-
-	slot  int    // slot number in the arena
-	arena *arena // link to the arena
-}
-
-func (s *dspan) Write(p []byte) (int, error) {
-	n := copy(s.arena.buf[s.wp:s.high], p)
-
-	s.wp += n
-	return n, nil
-}
-
-func (s *dspan) Read(p []byte) (int, error) {
-	n := copy(p, s.arena.buf[s.rp:s.wp])
-	s.rp += n
-
-	if s.rp == s.wp {
-		return n, io.EOF
-	}
-
-	return n, nil
-}
-
-func (s *dspan) Close() error {
-	s.arena.putSpan(s)
-	return nil
 }

--- a/pbm/storage/s3/download.go
+++ b/pbm/storage/s3/download.go
@@ -99,7 +99,7 @@ func (s *S3) newPartReader(fname string, fsize int64, chunkSize int) *storage.Pa
 		GetChunk: func(fname string, arena *storage.Arena, cli interface{}, start, end int64) (io.ReadCloser, error) {
 			s3cli, ok := cli.(*s3.Client)
 			if !ok {
-				return nil, fmt.Errorf("expected *s3.Client, got %T", cli)
+				return nil, errors.Errorf("expected *s3.Client, got %T", cli)
 			}
 			return s.getChunk(fname, arena, s3cli, start, end)
 		},

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -302,8 +302,8 @@ func New(opts *Config, node string, l log.LogEvent) (*S3, error) {
 
 	s.d = &Download{
 		s3:       s,
-		arenas:   []*arena{newArena(downloadChuckSizeDefault, downloadChuckSizeDefault)},
-		spanSize: downloadChuckSizeDefault,
+		arenas:   []*storage.Arena{storage.NewArena(storage.DownloadChuckSizeDefault, storage.DownloadChuckSizeDefault)},
+		spanSize: storage.DownloadChuckSizeDefault,
 		cc:       1,
 	}
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1506

It reintroduces the ability to download a single large file in parallel for Google Cloud Storage (GCS) after introducing Google's native SDK.

Users can speed up restores by using multiple workers to download big files in parallel. With these changes, it will be available for S3 and GCS but has been made with consideration of supporting additional storage types in the future.

The changes reuse the existing logic from the S3 download module.