### PR TITLE
PBM-1522 Check full db name instead of a prefix

### DIFF
--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1408,7 +1408,7 @@ func (r *Restore) swapUsers(ctx context.Context, exclude *topo.AuthInfo, nss []s
 	for _, ns := range nss {
 		// ns can be "*.*" or "admin.pbmRUsers" or "admin.pbmRRoles"
 		db, _ := util.ParseNS(ns)
-		if len(db) == 0 || strings.HasPrefix(db, defs.DB) {
+		if len(db) == 0 || db == defs.DB {
 			continue
 		}
 		dbs = append(dbs, db)


### PR DESCRIPTION
Make sure to not skip other databases than 'admin'.

It aims to solve following issues:
1. When restoring a namespace with problematic database name (for example `administration.*`) it makes the database filter empty and ALL the users are restored (includes users from other databases).
2. When restoring multiple namespaces, including the problematic one (for example `administration.*,somedb.*`) it skips the`administation` database in filters and as a result the user related to this database is NOT restored (the other ones are).