### PR TITLE
PBM-1482: Selective Restore hangs on oplog replay and doesn't finish

### DIFF
--- a/pbm/restore/selective.go
+++ b/pbm/restore/selective.go
@@ -338,7 +338,11 @@ func (r *Restore) configsvrRestoreChunks(
 			models = append(models, mongo.NewInsertOneModel().SetDocument(doc))
 		}
 
-		if len(models) == 0 {
+		if len(models) == 0 && !done {
+			// if it's not done, we just reached maxBulkWriteCount, we need to process more
+			continue
+		} else if len(models) == 0 && done {
+			// it's done and there's nothing to update
 			return nil
 		}
 

--- a/pbm/restore/selective.go
+++ b/pbm/restore/selective.go
@@ -127,6 +127,8 @@ func (r *Restore) configsvrRestoreDatabases(
 	if err != nil {
 		return err
 	}
+	defer rdr.Close()
+
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return err
@@ -210,6 +212,8 @@ func (r *Restore) configsvrRestoreCollections(
 	if err != nil {
 		return nil, err
 	}
+	defer rdr.Close()
+
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return nil, err
@@ -274,6 +278,8 @@ func (r *Restore) configsvrRestoreChunks(
 	if err != nil {
 		return err
 	}
+	defer rdr.Close()
+
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return err


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1482

PR fixes two issues:
- When dealing with selective restore and processing `config` db related collections, backup files were not closed, which implies possible resource leaks and deadlock in case when S3 compatible storage is used (while using `io.Pipe`).
- When processing `config.chunks` database, not all documents were processed, only the first batch of documents was processed.