### PR TITLE
PBM-1494 Added condition if S3 EntypointURL is empty

### DIFF
--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -309,10 +309,14 @@ func (s *StorageConf) Path() string {
 	switch s.Type {
 	case storage.S3:
 		path = s.S3.EndpointURL
-		if !strings.Contains(path, "://") {
-			path = "s3://" + path
+		if path == "" {
+			path = "s3://" + s.S3.Bucket
+		} else {
+			if !strings.Contains(path, "://") {
+				path = "s3://" + path
+			}
+			path += "/" + s.S3.Bucket
 		}
-		path += "/" + s.S3.Bucket
 		if s.S3.Prefix != "" {
 			path += "/" + s.S3.Prefix
 		}


### PR DESCRIPTION
Trying to fix a bug with S3
https://perconadev.atlassian.net/browse/PBM-1494

I think the error happens when the EndpointURL is empty. I added a check if it is empty. 
Since I can't test all variants, I made the check right after the path definition to leave the old logic unchanged. 