### PR TITLE
PBM-1531: Fix deadlock during physical restore file copying

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -987,7 +987,9 @@ func (r *PhysRestore) Snapshot(
 		buf:   &bytes.Buffer{},
 		path:  fmt.Sprintf("%s/%s/rs.%s/log/%s", defs.PhysRestoresDir, r.name, r.rsConf.ID, r.nodeInfo.Me),
 		limit: 1 << 20, // 1Mb
-		write: func(name string, data io.Reader) error { return r.stg.Save(name, data, -1) },
+		write: func(name string, data io.Reader) error {
+			return r.stg.Save(name, data, -1, storage.UseLogger(false))
+		},
 	})
 	logger.PauseMgo()
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -988,6 +988,7 @@ func (r *PhysRestore) Snapshot(
 		path:  fmt.Sprintf("%s/%s/rs.%s/log/%s", defs.PhysRestoresDir, r.name, r.rsConf.ID, r.nodeInfo.Me),
 		limit: 1 << 20, // 1Mb
 		write: func(name string, data io.Reader) error {
+			// Logger should be disabled due to: PBM-1531
 			return r.stg.Save(name, data, -1, storage.UseLogger(false))
 		},
 	})

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -129,6 +129,13 @@ func (*Blob) Type() storage.Type {
 }
 
 func (b *Blob) Save(name string, data io.Reader, sizeb int64, options ...storage.Option) error {
+	opts := storage.GetDefaultOpts()
+	for _, opt := range options {
+		if err := opt(opts); err != nil {
+			return errors.Wrap(err, "processing options for save")
+		}
+	}
+
 	bufsz := defaultUploadBuff
 	if sizeb > 0 {
 		ps := int(sizeb / maxBlocks * 11 / 10) // add 10% just in case
@@ -142,7 +149,7 @@ func (b *Blob) Save(name string, data io.Reader, sizeb int64, options ...storage
 		cc = 1
 	}
 
-	if b.log != nil {
+	if b.log != nil && opts.UseLogger {
 		b.log.Debug("BufferSize is set to %d (~%dMb) | %d", bufsz, bufsz>>20, sizeb)
 	}
 

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -128,7 +128,7 @@ func (*Blob) Type() storage.Type {
 	return storage.Azure
 }
 
-func (b *Blob) Save(name string, data io.Reader, sizeb int64) error {
+func (b *Blob) Save(name string, data io.Reader, sizeb int64, options ...storage.Option) error {
 	bufsz := defaultUploadBuff
 	if sizeb > 0 {
 		ps := int(sizeb / maxBlocks * 11 / 10) // add 10% just in case

--- a/pbm/storage/blackhole/blackhole.go
+++ b/pbm/storage/blackhole/blackhole.go
@@ -18,7 +18,7 @@ func (*Blackhole) Type() storage.Type {
 	return storage.Blackhole
 }
 
-func (*Blackhole) Save(_ string, data io.Reader, _ int64) error {
+func (*Blackhole) Save(_ string, data io.Reader, _ int64, _ ...storage.Option) error {
 	_, err := io.Copy(io.Discard, data)
 	return err
 }

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -151,7 +151,7 @@ func writeSync(finalpath string, data io.Reader) (err error) {
 	return nil
 }
 
-func (fs *FS) Save(name string, data io.Reader, _ int64) error {
+func (fs *FS) Save(name string, data io.Reader, _ int64, _ ...storage.Option) error {
 	return writeSync(path.Join(fs.root, name), data)
 }
 

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -142,7 +142,7 @@ func (*GCS) Type() storage.Type {
 	return storage.GCS
 }
 
-func (g *GCS) Save(name string, data io.Reader, size int64) error {
+func (g *GCS) Save(name string, data io.Reader, size int64, _ ...storage.Option) error {
 	ctx := context.Background()
 
 	w := g.bucketHandle.Object(path.Join(g.opts.Prefix, name)).NewWriter(ctx)

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -315,6 +315,12 @@ func (*S3) Type() storage.Type {
 }
 
 func (s *S3) Save(name string, data io.Reader, sizeb int64, options ...storage.Option) error {
+	opts := storage.GetDefaultOpts()
+	for _, opt := range options {
+		if err := opt(opts); err != nil {
+			return errors.Wrap(err, "processing options for save")
+		}
+	}
 	cc := runtime.NumCPU() / 2
 	if cc == 0 {
 		cc = 1
@@ -367,7 +373,7 @@ func (s *S3) Save(name string, data io.Reader, sizeb int64, options ...storage.O
 		}
 	}
 
-	if s.log != nil {
+	if s.log != nil && opts.UseLogger {
 		s.log.Debug("uploading %q [size hint: %v (%v); part size: %v (%v)]",
 			name,
 			sizeb,

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -314,7 +314,7 @@ func (*S3) Type() storage.Type {
 	return storage.S3
 }
 
-func (s *S3) Save(name string, data io.Reader, sizeb int64) error {
+func (s *S3) Save(name string, data io.Reader, sizeb int64, options ...storage.Option) error {
 	cc := runtime.NumCPU() / 2
 	if cc == 0 {
 		cc = 1

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -37,7 +37,7 @@ type FileInfo struct {
 
 type Storage interface {
 	Type() Type
-	Save(name string, data io.Reader, size int64, opts ...Option) error
+	Save(name string, data io.Reader, size int64, options ...Option) error
 	SourceReader(name string) (io.ReadCloser, error)
 	// FileStat returns file info. It returns error if file is empty or not exists.
 	FileStat(name string) (FileInfo, error)

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -37,7 +37,7 @@ type FileInfo struct {
 
 type Storage interface {
 	Type() Type
-	Save(name string, data io.Reader, size int64) error
+	Save(name string, data io.Reader, size int64, opts ...Option) error
 	SourceReader(name string) (io.ReadCloser, error)
 	// FileStat returns file info. It returns error if file is empty or not exists.
 	FileStat(name string) (FileInfo, error)
@@ -66,6 +66,30 @@ func ParseType(s string) Type {
 		return GCS
 	default:
 		return Undefined
+	}
+}
+
+// Opts represents storage options
+type Opts struct {
+	UseLogger bool
+}
+
+// GetDefaultOpts creates default options.
+func GetDefaultOpts() *Opts {
+	return &Opts{
+		UseLogger: true,
+	}
+}
+
+// Option is function for setting the storage option
+type Option func(*Opts) error
+
+// UseLogger option enables/disables logger when working with storage.
+// Logger is enabled by default.
+func UseLogger(useLogger bool) Option {
+	return func(o *Opts) error {
+		o.UseLogger = useLogger
+		return nil
 	}
 }
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1531

PR fixes deadlock issue that happens during the physical restore. 

During physical restore PBM stores logs on the backup storage (db is down). 
Logger is shared by many goroutines so it holds mutex to provide synchronized write access, during which logger writes to the storage using the PBM's storage API.
PBM's storage API started to add log entries in v2.6, e.g.:
```
uploading "...rs.starting" [size hint: 10 (10.00B); part size: 10485760 (10.00MB)]
```
While doing that, it tries to do lock of the same mutex, and that's deadlock.

This fix skips logging from PBM's storage API (log entry above) only during storing logger entries as part of physical restore.
It is applied for AWS S3 and Azure (for FS and GCS, PBM doesn't log).