### PR TITLE
PBM-1439 - Fix backup failure: MaxUploadParts exceeded

### DIFF
--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -98,6 +98,7 @@ func (b *Backup) doLogical(
 			filename := rsMeta.OplogName + "/" + FormatChunkName(from, till, bcp.Compression)
 
 			estimatedSize := int64(bytesPerSecond * float64(till.T-from.T))
+			estimatedSize *= 2 // allow 2× growth during slice
 			if bcp.Compression == compress.CompressionTypeNone {
 				estimatedSize *= 4
 			}

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -97,14 +97,14 @@ func (b *Backup) doLogical(
 				return 0, errors.Wrap(err, "oplog stats unavailable")
 			}
 
-			durSecs := till.T - from.T
-			estimatedSize := int64(bytesPerSecond * float64(durSecs))
+			estimatedSize := int64(bytesPerSecond * float64(till.T-from.T))
 			if bcp.Compression == compress.CompressionTypeNone {
 				estimatedSize *= 4
 			}
 
-			l.Debug("oplog slice %s‑%s: rate %.0f B/s, dur %d s, hint %s",
-				from, till, bytesPerSecond, durSecs, storage.PrettySize(estimatedSize))
+			if estimatedSize < 1<<30 {
+				estimatedSize = int64(float64(estimatedSize) * 1.5)
+			}
 
 			return storage.Upload(ctx, w, stg, bcp.Compression, bcp.CompressionLevel, filename, estimatedSize)
 		})


### PR DESCRIPTION
This PR addresses an issue where the configured `maxUploadParts` setting was being honored during multipart upload but ignored during part size calculation for instances where the size was unknown, leading to upload failures on oplog slices.

Estimate oplog slice size using bytes/sec × duration with extra growth and a 1 GiB minimum to avoid exceeding multipart limits. Ensures partSize is computed reliably, preventing upload failures.