### PR TITLE
PBM-1498 hmac support for gcs fix

### DIFF
--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -2,12 +2,12 @@ package gcs
 
 import (
 	"container/heap"
-	"google.golang.org/api/googleapi"
 	"io"
 	"net/http"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"google.golang.org/api/googleapi"
 )
 
 type Download struct {

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -2,12 +2,9 @@ package gcs
 
 import (
 	"container/heap"
-	"context"
+	"google.golang.org/api/googleapi"
 	"io"
 	"net/http"
-	"time"
-
-	"google.golang.org/api/googleapi"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
@@ -66,10 +63,7 @@ func (g *GCS) newPartReader(fname string, fsize int64, chunkSize int) *storage.P
 		Buf:       make([]byte, 32*1024),
 		L:         g.log,
 		GetChunk: func(fname string, arena *storage.Arena, cli interface{}, start, end int64) (io.ReadCloser, error) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
-
-			return cli.(gcsClient).getPartialObject(ctx, fname, start, end-start+1)
+			return cli.(gcsClient).getPartialObject(fname, arena, start, end-start+1)
 		},
 		GetSess: func() (interface{}, error) {
 			return g.client, nil // re-use the already-initialized client

--- a/pbm/storage/gcs/download.go
+++ b/pbm/storage/gcs/download.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"net/http"
 
+	"google.golang.org/api/googleapi"
+
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	"google.golang.org/api/googleapi"
 )
 
 type Download struct {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -1,7 +1,6 @@
 package gcs
 
 import (
-	"context"
 	"io"
 	"path"
 	"reflect"
@@ -67,7 +66,7 @@ type gcsClient interface {
 	list(prefix, suffix string) ([]storage.FileInfo, error)
 	delete(name string) error
 	copy(src, dst string) error
-	getPartialObject(ctx context.Context, name string, start, length int64) (io.ReadCloser, error)
+	getPartialObject(name string, buf *storage.Arena, start, length int64) (io.ReadCloser, error)
 }
 
 type GCS struct {

--- a/pbm/storage/gcs/hmac_client.go
+++ b/pbm/storage/gcs/hmac_client.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -181,7 +182,10 @@ func (h hmacClient) copy(src, dst string) error {
 	return err
 }
 
-func (h hmacClient) getPartialObject(ctx context.Context, name string, start, length int64) (io.ReadCloser, error) {
+func (h hmacClient) getPartialObject(name string, buf *storage.Arena, start, length int64) (io.ReadCloser, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
 	objectName := path.Join(h.opts.Prefix, name)
 
 	opts := minio.GetObjectOptions{}

--- a/pbm/storage/gcs/hmac_client.go
+++ b/pbm/storage/gcs/hmac_client.go
@@ -204,6 +204,14 @@ func (h hmacClient) getPartialObject(name string, buf *storage.Arena, start, len
 
 		return nil, storage.GetObjError{Err: err}
 	}
+	defer object.Close()
 
-	return object, nil
+	ch := buf.GetSpan()
+	_, err = io.CopyBuffer(ch, object, buf.CpBuf)
+	if err != nil {
+		ch.Close()
+		return nil, errors.Wrap(err, "copy")
+	}
+
+	return ch, nil
 }


### PR DESCRIPTION
This PR updates the getPartialObject implementations for Google Cloud Storage (GCS) and MinIO (via HMAC) to match the buffering strategy already used by AWS S3. Previously, both backends returned open io.ReadCloser streams from their respective SDKs. This was already present in the original GCS implementation.