### PR TITLE
PBM-772 Use "hello" command instead of "isMaster"

### DIFF
--- a/e2e-tests/pkg/pbm/mongod.go
+++ b/e2e-tests/pkg/pbm/mongod.go
@@ -257,7 +257,7 @@ func (m *Mongo) GetCounters() ([]Counter, error) {
 
 func (m *Mongo) GetNodeInfo() (*topo.NodeInfo, error) {
 	inf := &topo.NodeInfo{}
-	err := m.cn.Database("test").RunCommand(m.ctx, bson.M{"isMaster": 1}).Decode(inf)
+	err := m.cn.Database("test").RunCommand(m.ctx, bson.M{"hello": 1}).Decode(inf)
 	if err != nil {
 		return nil, errors.Wrap(err, "run mongo command")
 	}

--- a/pbm/connect/todo.go
+++ b/pbm/connect/todo.go
@@ -17,7 +17,7 @@ type nodeInfo struct {
 	Me                string `bson:"me"`
 	SetName           string `bson:"setName,omitempty"`
 	Primary           string `bson:"primary,omitempty"`
-	IsPrimary         bool   `bson:"ismaster"`
+	IsPrimary         bool   `bson:"isWritablePrimary"`
 	ConfigSvr         int    `bson:"configsvr,omitempty"`
 	ConfigServerState *struct {
 		OpTime *struct {
@@ -59,9 +59,9 @@ type mongodOpts struct {
 }
 
 func getNodeInfo(ctx context.Context, m *mongo.Client) (*nodeInfo, error) {
-	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"isMaster", 1}})
+	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"hello", 1}})
 	if err := res.Err(); err != nil {
-		return nil, errors.Wrap(err, "cmd: isMaster")
+		return nil, errors.Wrap(err, "cmd: hello")
 	}
 
 	n := &nodeInfo{}

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -81,7 +81,7 @@ type NodeInfo struct {
 	SetName                      string               `bson:"setName,omitempty"`
 	Primary                      string               `bson:"primary,omitempty"`
 	SetVersion                   int32                `bson:"setVersion,omitempty"`
-	IsPrimary                    bool                 `bson:"ismaster"`
+	IsPrimary                    bool                 `bson:"isWritablePrimary"`
 	Secondary                    bool                 `bson:"secondary,omitempty"`
 	Hidden                       bool                 `bson:"hidden,omitempty"`
 	Passive                      bool                 `bson:"passive,omitempty"`
@@ -238,9 +238,9 @@ func GetNodeInfoExt(ctx context.Context, m *mongo.Client) (*NodeInfo, error) {
 }
 
 func GetNodeInfo(ctx context.Context, m *mongo.Client) (*NodeInfo, error) {
-	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"isMaster", 1}})
+	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"hello", 1}})
 	if err := res.Err(); err != nil {
-		return nil, errors.Wrap(err, "cmd: isMaster")
+		return nil, errors.Wrap(err, "cmd: hello")
 	}
 
 	n := &NodeInfo{}


### PR DESCRIPTION
Swtich to `hello` and `isWritablePrimary`. When doing diff of db.adminCommand({isMaster:1}) and db.adminCommand({hello:1}), the only change is from `ismaster: bool` to `isWritablePrimary: bool`

Checked diff both and primary and secondary.