### PR TITLE
PBM-1553: Improve mongod restart procedure during physical restore

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -55,11 +55,10 @@ const (
 
 	defaultPort = 27017
 
-	tryConnCount       = 5
-	tryConnTimeout     = 5 * time.Minute
-	mongodLockTimeout  = 30 * time.Minute
-	mongodPortTimeout  = 5 * time.Minute
-	mongodPortPollTick = 5 * time.Second
+	tryConnCount      = 5
+	tryConnTimeout    = 5 * time.Minute
+	mongodLockTimeout = 30 * time.Minute
+	mongodPortTimeout = 5 * time.Minute
 
 	internalMongodLog = "pbm.restore.log"
 )

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -455,6 +455,8 @@ func nodeShutdown(ctx context.Context, m *mongo.Client) error {
 	return err
 }
 
+// waitMgoShutdown waits until mongod releases mongod.lock file within dbpath dir.
+// In case of timeout or unexpected error it'll return error.
 func waitMgoShutdown(dbpath string) error {
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
@@ -477,9 +479,10 @@ func waitMgoShutdown(dbpath string) error {
 			return errors.Errorf("timeout during waiting for lock file %s", path.Join(dbpath, mongofslock))
 		}
 	}
-
 }
 
+// waitMgoFreePort waits for port p to be free.
+// It case of timeout it'll return error.
 func waitMgoFreePort(p int) error {
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1553

This fix improves how PBM does `mongod` restarts during physical restore:
- When waiting for `mongod.lock` file, PBM has global timeout for that operation.
- After `mongod.lock` is released, PBM waits for the port to be available, and only after that continues. This prevents any port conflicts when PBM attempts to restart `mongod` again.
- It introduces port waiting timeout.