### PR TITLE
PBM-1553: Improve mongod logging during physical restore

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -2604,7 +2604,7 @@ func removeAll(dir string, toIgnore []string, l log.LogEvent) error {
 		return errors.Wrap(err, "read file names")
 	}
 	for _, n := range names {
-		if n == internalMongodLog || slices.Contains(toIgnore, n) {
+		if isInternalMongoLog(n) || slices.Contains(toIgnore, n) {
 			continue
 		}
 		err = os.RemoveAll(filepath.Join(dir, n))
@@ -2614,6 +2614,12 @@ func removeAll(dir string, toIgnore []string, l log.LogEvent) error {
 		l.Debug("remove %s", filepath.Join(dir, n))
 	}
 	return nil
+}
+
+// isInternalMongoLog checks whether the file with the name f
+// is internal mongo log file
+func isInternalMongoLog(f string) bool {
+	return strings.HasPrefix(f, internalMongodLog)
 }
 
 func majmin(v string) string {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -220,16 +220,12 @@ func (r *PhysRestore) close(noerr, cleanup bool) {
 			r.log.Error("remove tmp config %s: %v", r.tmpConf.Name(), err)
 		}
 	}
-	// clean-up internal mongod log only if there is no error
+
+	// if there is no error clean-up internal restore files, internal log file(s) should stay
 	if noerr {
-		r.log.Debug("rm tmp logs")
-		err := os.Remove(path.Join(r.dbpath, internalMongodLog))
-		if err != nil {
-			r.log.Warning("remove tmp mongod logs %s: %v", path.Join(r.dbpath, internalMongodLog), err)
-		}
 		extMeta := filepath.Join(r.dbpath,
 			fmt.Sprintf(defs.ExternalRsMetaFile, util.MakeReverseRSMapFunc(r.rsMap)(r.nodeInfo.SetName)))
-		err = os.Remove(extMeta)
+		err := os.Remove(extMeta)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			r.log.Warning("remove external rs meta <%s>: %v", extMeta, err)
 		}

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -248,7 +248,7 @@ func (r *PhysRestore) close(noerr, cleanup bool) {
 		}
 	} else if cleanup { // clean-up dbpath on err if needed (cluster is done or partlyDone)
 		r.log.Debug("clean-up dbpath")
-		err := removeAll(r.dbpath, r.log, getInternlLogFileSkipRule())
+		err := removeAll(r.dbpath, r.log, getInternalLogFileSkipRule())
 		if err != nil {
 			r.log.Error("flush dbpath %s: %v", r.dbpath, err)
 		}
@@ -402,7 +402,7 @@ func (r *PhysRestore) migrateDBDirToFallbackDir() error {
 // moves all content from fallback path.
 func (r *PhysRestore) migrateFromFallbackDirToDBDir() error {
 	r.log.Debug("clean-up dbpath")
-	err := removeAll(r.dbpath, r.log, getFallbackSyncFileSkipRule(), getInternlLogFileSkipRule())
+	err := removeAll(r.dbpath, r.log, getFallbackSyncFileSkipRule(), getInternalLogFileSkipRule())
 	if err != nil {
 		r.log.Error("flush dbpath %s: %v", r.dbpath, err)
 		return errors.Wrap(err, "remove all from dbpath")
@@ -2665,7 +2665,7 @@ func isFileToSkip(f string, skipRules ...fileSkipRule) bool {
 	return false
 }
 
-func getInternlLogFileSkipRule() fileSkipRule {
+func getInternalLogFileSkipRule() fileSkipRule {
 	return func(f string) bool {
 		return isInternalMongoLog(f)
 	}

--- a/pbm/restore/physical_test.go
+++ b/pbm/restore/physical_test.go
@@ -198,10 +198,10 @@ func TestRemoveAll(t *testing.T) {
 		}
 	})
 
-	t.Run("skiping internal mongod log files", func(t *testing.T) {
+	t.Run("skipping internal mongod log files", func(t *testing.T) {
 		tmpDir := setupTestFiles(t)
 
-		err := removeAll(tmpDir, log.DiscardEvent, getInternlLogFileSkipRule())
+		err := removeAll(tmpDir, log.DiscardEvent, getInternalLogFileSkipRule())
 		if err != nil {
 			t.Fatalf("got error when removing all files, err=%v", err)
 		}
@@ -212,7 +212,7 @@ func TestRemoveAll(t *testing.T) {
 		}
 	})
 
-	t.Run("skiping fallback dir", func(t *testing.T) {
+	t.Run("skipping fallback dir", func(t *testing.T) {
 		tmpDir := setupTestFiles(t)
 
 		err := removeAll(tmpDir, log.DiscardEvent, getFallbackSyncFileSkipRule())
@@ -231,10 +231,10 @@ func TestRemoveAll(t *testing.T) {
 		}
 	})
 
-	t.Run("skiping all pbm related", func(t *testing.T) {
+	t.Run("skipping all pbm related", func(t *testing.T) {
 		tmpDir := setupTestFiles(t)
 
-		err := removeAll(tmpDir, log.DiscardEvent, getFallbackSyncFileSkipRule(), getInternlLogFileSkipRule())
+		err := removeAll(tmpDir, log.DiscardEvent, getFallbackSyncFileSkipRule(), getInternalLogFileSkipRule())
 		if err != nil {
 			t.Fatalf("got error when removing all files, err=%v", err)
 		}

--- a/pbm/restore/physical_test.go
+++ b/pbm/restore/physical_test.go
@@ -246,6 +246,25 @@ func TestRemoveAll(t *testing.T) {
 	})
 }
 
+func TestRemoveInternalMongoLogs(t *testing.T) {
+	tmpDir := setupTestFiles(t)
+
+	err := removeInternalMongoLogs(tmpDir, log.DiscardEvent)
+	if err != nil {
+		t.Fatalf("got error when removing internal mongod logs, err=%v", err)
+	}
+
+	files := readDir(t, tmpDir)
+	if len(files) != 6 {
+		t.Fatalf("only mongod log files should be removed, expected 6 files, got=%d files", len(files))
+	}
+	for _, f := range files {
+		if strings.HasPrefix(f, internalMongodLog) {
+			t.Fatalf("internal mongod log file is not deleted: %s", f)
+		}
+	}
+}
+
 func readDir(t *testing.T, dir string) []string {
 	t.Helper()
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1553

This fix improves how PBM handles internal `mongod` logs during the physical restore procedure:
- After physical restore PBM keeps all internal mongod logs (`pbm.restore.log*`) within `dbpath` dir, no matter whether it was successful or failed one.
-  Before new physical restore, internal `mongod` logs are removed as part of wipe-up procedure.