### PR TITLE
PBM-1499 Unformatted error in restore metadata

### DIFF
--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"time"
 
@@ -238,7 +239,9 @@ func addRestoreMetaWithError(
 	errStr string,
 	args ...any,
 ) error {
-	l.Error(errStr, args...)
+	errMsg := fmt.Sprintf(errStr, args...)
+
+	l.Error(errMsg)
 
 	meta := &restore.RestoreMeta{
 		Type:     defs.LogicalBackup,
@@ -248,7 +251,7 @@ func addRestoreMetaWithError(
 		PITR:     int64(cmd.OplogTS.T),
 		StartTS:  time.Now().UTC().Unix(),
 		Status:   defs.StatusError,
-		Error:    errStr,
+		Error:    errMsg,
 		Replsets: []restore.RestoreReplset{},
 	}
 	err := restore.SetRestoreMetaIfNotExists(ctx, conn, meta)
@@ -260,7 +263,7 @@ func addRestoreMetaWithError(
 		Name:       setName,
 		StartTS:    time.Now().UTC().Unix(),
 		Status:     defs.StatusError,
-		Error:      errStr,
+		Error:      errMsg,
 		Conditions: restore.Conditions{},
 	}
 	err = restore.AddRestoreRSMeta(ctx, conn, cmd.Name, rs)


### PR DESCRIPTION
`addRestoreMetaWithError` now formats the message once, so both the log and restore-metadata have the full error text instead of the `%v` placeholder. This only affects error reporting, behavior stays the same.