### PR TITLE
PBM-1519: PBM logs inexistent PITR error during physical restore

### DIFF
--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
@@ -110,6 +111,13 @@ func (a *Agent) PITR(ctx context.Context) {
 	l.Printf("starting PITR routine")
 
 	for {
+		select {
+		case <-a.closeCMD:
+			l.Debug(string(ctrl.CmdPITR), "", "", primitive.Timestamp{}, "stopping main loop")
+			return
+		default:
+		}
+
 		err := a.pitr(ctx)
 		if err != nil {
 			// we need epoch just to log pitr err with an extra context

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1054,7 +1054,7 @@ func (r *PhysRestore) Snapshot(
 	// the cmd stream anymore and will flood logs with errors on that.
 	l.Info("send to stopAgent chan")
 	if stopAgentC != nil {
-		stopAgentC <- struct{}{}
+		close(stopAgentC)
 	}
 	// anget will be stopped only after we exit this func
 	// so stop heartbeats not to spam logs while the restore is running


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1519

PR fixes following noise within logs during physical restore:
```
2025-03-14T09:42:35.000+0000 E [pitr] init: get conf: get: server selection error: context canceled ...
```