### PR TITLE
PBM-1551 - PBM reissues the previously executed command

### DIFF
--- a/pbm/ctrl/recv.go
+++ b/pbm/ctrl/recv.go
@@ -39,8 +39,7 @@ func ListenCmd(ctx context.Context, m connect.Client, cl <-chan struct{}) (<-cha
 		defer close(cmd)
 		defer close(errc)
 
-		ts := time.Now().UTC().Unix()
-		var lastTS int64
+		lastTS := time.Now().UTC().Unix()
 		var lastCmd Command
 		for {
 			select {
@@ -53,7 +52,7 @@ func ListenCmd(ctx context.Context, m connect.Client, cl <-chan struct{}) (<-cha
 			}
 			cur, err := m.CmdStreamCollection().Find(
 				ctx,
-				bson.M{"ts": bson.M{"$gte": ts}},
+				bson.M{"ts": bson.M{"$gt": lastTS}},
 			)
 			if err != nil {
 				errc <- errors.Wrap(err, "watch the cmd stream")
@@ -83,7 +82,6 @@ func ListenCmd(ctx context.Context, m connect.Client, cl <-chan struct{}) (<-cha
 				lastCmd = c.Cmd
 				lastTS = c.TS
 				cmd <- c
-				ts = time.Now().UTC().Unix()
 			}
 			if err := cur.Err(); err != nil {
 				errc <- CursorClosedError{err}


### PR DESCRIPTION
Previously, the PBM agent could re-execute the same command twice, leading to errors like active lock is present. This happened because the agent was querying for commands with timestamp >= X, and if two commands were created in the same second, the second query would still pick up the previous one.

What changed:
This PR updates the query to use timestamp > last-seen, and the last-seen value is only updated after the agent fully processes a command. This ensures the query window moves strictly forward, so commands are processed exactly once, even under load or rapid command issuance.