### PR TITLE
PBM-1483: Fix `no such file` error during physical restore

### DIFF
--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -198,6 +198,10 @@ func (fs *FS) List(prefix, suffix string) ([]storage.FileInfo, error) {
 
 		info, err := entry.Info()
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// file was removed in the meantime, and that's fine
+				return nil
+			}
 			return errors.Wrap(err, "getting file info")
 		}
 		if info.IsDir() {


### PR DESCRIPTION
PR is the improvement for #1120.

When working with FS storage, PBM will occasionally logs following entry:
```
Starting restore 2025-06-06T17:27:12.565119675Z from '2025-06-05T16:57:35Z'.Error: get metadata: parse physical restore status: get files: getting file info: lstat /opt/backups/pbm/.pbm.restore/2025-06-06T17:27:12.565119675Z/rs.rs1/rs.hb.tmp: no such file or directory
```
This improvement just silently ignores that type of situation.