### PR TITLE
Align linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
     - nilerr
     - nilnil
     - lll
-    - typecheck
     - gochecknoinits
     - nonamedreturns
   disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,16 @@
 version: "2"
 linters:
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - durationcheck
-    - err113
-    - errchkjson
     - errname
-    - errorlint
-    - gocheckcompilerdirectives
-    - gochecknoinits
-    - gochecksumtype
-    - gosmopolitan
-    - lll
-    - loggercheck
-    - makezero
-    - misspell
-    - musttag
-    - nilerr
-    - nilnesserr
-    - nilnil
-    - noctx
-    - nonamedreturns
     - predeclared
-    - protogetter
-    - reassign
-    - recvcheck
-    - rowserrcheck
-    - spancheck
-    - sqlclosecheck
     - staticcheck
-    - testifylint
-    - unparam
-    - zerologlint
+    - misspell
+    - nilerr
+    - nilnil
+    - lll
+    - typecheck
+    - gochecknoinits
+    - nonamedreturns
   disable:
     - contextcheck
     - exhaustive


### PR DESCRIPTION
Align linters with the ones on dev and update config for V2:
- `stylecheck` linter is now part of `staticcheck`
- `typecheck` is removed since it is no longer treated as linter