### PR TITLE
PBM-1238: Add guard when parsing HB during physical restore

### DIFF
--- a/pbm/restore/storage.go
+++ b/pbm/restore/storage.go
@@ -268,10 +268,11 @@ func parsePhysRestoreCond(stg storage.Storage, fname, restoreName string) (*Cond
 		return &cond, nil
 	}
 
-	cond.Timestamp, err = strconv.ParseInt(string(b), 10, 0)
-	if err != nil {
-		return nil, errors.Wrapf(err, "read ts from %s", fname)
+	if len(b) != 0 {
+		cond.Timestamp, err = strconv.ParseInt(string(b), 10, 0)
+		if err != nil {
+			return nil, errors.Wrapf(err, "read ts from %s", fname)
+		}
 	}
-
 	return &cond, nil
 }


### PR DESCRIPTION
When starting the physical restore, occasionally, PBM reports the following error:
```
Error: get metadata: parse physical restore status: read ts from cluster.hb: strconv.ParseInt: parsing "": invalid syntax
```
This PR fixes that by simply processing the timestamp from the file if it exists.