### PR TITLE
PBM-1497: Exclude balancer ops during PITR

### DIFF
--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -334,6 +334,9 @@ func (o *OplogRestore) SetCloneNS(ctx context.Context, ns snapshot.CloneNS) erro
 	return nil
 }
 
+// isOpAllowed inspects whether op is allowed from config database point of view.
+// It allows/disallows only specific collections for config database.
+// It disallows balancer settings that would cause the balancer to work during PITR.
 func isOpAllowed(oe *Record) bool {
 	coll, ok := strings.CutPrefix(oe.Namespace, "config.")
 	if !ok {


### PR DESCRIPTION
[![PBM-1497](https://badgen.net/badge/JIRA/PBM-1497/green)](https://jira.percona.com/browse/PBM-1497) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[PBM-1497]: https://perconadev.atlassian.net/browse/PBM-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


PR ensures that the `balancer` will not be started during the PITR chunks applying phase within the PBM's `restore` procedure.

When the balancer is started within the PITR restore procedure, it can happen that the balancer and PBM procedure concurrently modify the same documents, which leads to the following error:
```
applyOps: (StaleConfig) The critical section for mydb.c1 is acquired with reason: { recvChunk: 1, sessionId: "rs2_rs1_6852e7daf7039dd8b1 ...
```

The PR fixes the problem by excluding all oplog entries that start the balancer, which means excluding balancer-related documents within `config.settings` collection.