### PR TITLE
PBM-1569 Validation error message for pbm restore

### DIFF
--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -750,6 +750,22 @@ func (app *pbmApp) buildRestoreCmd() *cobra.Command {
 	restoreCmd := &cobra.Command{
 		Use:   "restore [backup_name]",
 		Short: "Restore backup",
+		Args: func(cmd *cobra.Command, args []string) error {
+			timeFlag, _ := cmd.Flags().GetString("time")
+			external, _ := cmd.Flags().GetBool("external")
+
+			hasBackup := len(args) > 0
+			hasTime := timeFlag != ""
+
+			if hasBackup && hasTime {
+				return errors.New("backup name and --time cannot be used together")
+			}
+			if !external && !hasBackup && !hasTime {
+				return errors.New("specify a backup name, --time, or --external")
+			}
+
+			return nil
+		},
 		RunE: app.wrapRunE(func(cmd *cobra.Command, args []string) (fmt.Stringer, error) {
 			if len(args) == 1 {
 				restoreOptions.bcp = args[0]


### PR DESCRIPTION
[![PBM-1569](https://badgen.net/badge/JIRA/PBM-1569/green)](https://jira.percona.com/browse/PBM-1569) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds validation for restore command arguments.

These scenarios were taken into account:
```
pbm restore [backupname]
pbm restore --time ...
pbm restore --external
```

[PBM-1569]: https://perconadev.atlassian.net/browse/PBM-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ