### PR TITLE
PBM-1583: Exclude logical session docs from routing collections during restore

### DIFF
--- a/pbm/defs/defs.go
+++ b/pbm/defs/defs.go
@@ -38,6 +38,13 @@ const (
 )
 
 const (
+	ConfigDatabasesNS      = "config.databases"
+	ConfigCollectionsNS    = "config.collections"
+	ConfigChunksNS         = "config.chunks"
+	ConfigSystemSessionsNS = "config.system.sessions"
+)
+
+const (
 	// TmpUsersCollection and TmpRoles are tmp collections used to avoid
 	// user related issues while resoring on new cluster and preserving UUID
 	// See https://jira.percona.com/browse/PBM-425, https://jira.percona.com/browse/PBM-636

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -97,6 +97,9 @@ var dontPreserveUUID = []string{
 	"admin.system.users",
 	"admin.system.roles",
 	"admin.system.keys",
+	defs.ConfigDatabasesNS,
+	defs.ConfigCollectionsNS,
+	defs.ConfigChunksNS,
 	"*.system.buckets.*", // timeseries
 	"*.system.views",     // timeseries
 }

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -1001,6 +1001,10 @@ func (o *OplogRestore) handleNonTxnOp(op db.Oplog) error {
 		return nil
 	}
 
+	if err := o.setPreserveUUID(op); err != nil {
+		return err
+	}
+
 	op, err := o.filterUUIDs(op)
 	if err != nil {
 		return errors.Wrap(err, "filtering UUIDs from oplog")

--- a/pbm/oplog/restore_test.go
+++ b/pbm/oplog/restore_test.go
@@ -856,7 +856,7 @@ func configSettingsAnyOtherEntry() *db.Oplog {
 	}
 }
 
-func createConfigCollectionsEntry(shardedColl string, sessUUID string) *db.Oplog {
+func createConfigCollectionsEntry(shardedColl, sessUUID string) *db.Oplog {
 	uuid, _ := hex.DecodeString(sessUUID)
 	return &db.Oplog{
 		Operation: "i",

--- a/pbm/oplog/restore_test.go
+++ b/pbm/oplog/restore_test.go
@@ -964,16 +964,6 @@ func createConfigCollectionsEntry(shardedColl, collUUID string) *db.Oplog {
 	}
 }
 
-func createConfigCollectionsEntryWithoutUUID(shardedColl string) *db.Oplog {
-	return &db.Oplog{
-		Operation: "i",
-		Namespace: "config.collections",
-		Object: bson.D{
-			{"_id", shardedColl},
-		},
-	}
-}
-
 func createConfigChunksEntry(uuid string) *db.Oplog {
 	uuidDecoded, _ := hex.DecodeString(uuid)
 	id, _ := hex.DecodeString("some id")

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1010,7 +1010,7 @@ func (r *Restore) RunSnapshot(
 			if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
 				return err
 			}
-		} else { // full restore on CFSRS
+		} else { // full restore on CSRS
 			if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
 				return err
 			}

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1006,7 +1006,7 @@ func (r *Restore) RunSnapshot(
 		}
 
 		// restore cluster specific configs only
-		if err := r.configsvrRestore(ctx, bcp, nss, mapRS); err != nil {
+		if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
 			return err
 		}
 	} else {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1000,25 +1000,25 @@ func (r *Restore) RunSnapshot(
 	defer rdr.Close()
 
 	if r.nodeInfo.IsConfigSrv() {
-		if util.IsSelective(nss) {
-			err = r.snapshot(rdr, cloneNS, true)
-			if err != nil {
-				return errors.Wrap(err, "mongorestore")
-			}
+		err = r.snapshot(rdr, cloneNS, true)
+		if err != nil {
+			return errors.Wrap(err, "mongorestore")
+		}
 
+		if util.IsSelective(nss) {
 			// restore cluster specific configs only
 			if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
 				return err
 			}
-		} else {
-			err = r.snapshot(rdr, cloneNS, false)
-			if err != nil {
-				return errors.Wrap(err, "mongorestore")
-			}
-
+		} else { // full restore on CFSRS
 			if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
 				return err
 			}
+		}
+	} else { // restore on the RS topo or Shard
+		err = r.snapshot(rdr, cloneNS, false)
+		if err != nil {
+			return errors.Wrap(err, "mongorestore")
 		}
 	}
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -1014,6 +1014,10 @@ func (r *Restore) RunSnapshot(
 		if err != nil {
 			return errors.Wrap(err, "mongorestore")
 		}
+
+		if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
+			return err
+		}
 	}
 
 	if usersAndRolesOpt {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -266,7 +266,8 @@ func (r *Restore) Snapshot(
 		return err
 	}
 
-	err = r.RunSnapshot(ctx, dump, bcp, nss, cloneNS, usersAndRolesOpt)
+	sysSessionsUUID := ""
+	sysSessionsUUID, err = r.RunSnapshot(ctx, dump, bcp, nss, cloneNS, usersAndRolesOpt)
 	if err != nil {
 		return err
 	}
@@ -280,9 +281,10 @@ func (r *Restore) Snapshot(
 		{chunks: chunks, storage: r.bcpStg},
 	}
 	oplogOption := &applyOplogOption{
-		end:     &bcp.LastWriteTS,
-		nss:     nss,
-		cloudNS: cloneNS,
+		end:      &bcp.LastWriteTS,
+		nss:      nss,
+		cloudNS:  cloneNS,
+		sessUUID: sysSessionsUUID,
 	}
 	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 		oplogOption.nss = []string{"config.databases"}
@@ -452,7 +454,8 @@ func (r *Restore) PITR(
 		return err
 	}
 
-	err = r.RunSnapshot(ctx, dump, bcp, nss, cloneNS, usersAndRolesOpt)
+	sysSessionsUUID := ""
+	sysSessionsUUID, err = r.RunSnapshot(ctx, dump, bcp, nss, cloneNS, usersAndRolesOpt)
 	if err != nil {
 		return err
 	}
@@ -467,9 +470,10 @@ func (r *Restore) PITR(
 		{chunks: chunks, storage: r.oplogStg},
 	}
 	oplogOption := applyOplogOption{
-		end:     &cmd.OplogTS,
-		nss:     nss,
-		cloudNS: cloneNS,
+		end:      &cmd.OplogTS,
+		nss:      nss,
+		cloudNS:  cloneNS,
+		sessUUID: sysSessionsUUID,
 	}
 	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
 		oplogOption.nss = []string{"config.databases"}
@@ -941,13 +945,13 @@ func (r *Restore) RunSnapshot(
 	nss []string,
 	cloneNS snapshot.CloneNS,
 	usersAndRolesOpt restoreUsersAndRolesOption,
-) error {
+) (string, error) {
 	if version.IsLegacyArchive(bcp.PBMVersion) {
 		if util.IsSelective(bcp.Namespaces) || util.IsSelective(nss) {
-			return errors.New("selective restore is not supported from legacy backup")
+			return "", errors.New("selective restore is not supported from legacy backup")
 		}
 
-		return r.restoreLegacyArchive(ctx, dump, bcp)
+		return "", r.restoreLegacyArchive(ctx, dump, bcp)
 	}
 
 	if !util.IsSelective(nss) {
@@ -995,40 +999,44 @@ func (r *Restore) RunSnapshot(
 		util.MakeSelectedPred(nss),
 		r.numParallelColls)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer rdr.Close()
 
+	sysSessionsUUID := ""
 	if r.nodeInfo.IsConfigSrv() {
 		err = r.snapshot(rdr, cloneNS, true)
 		if err != nil {
-			return errors.Wrap(err, "mongorestore")
+			return "", errors.Wrap(err, "mongorestore")
 		}
 
 		if util.IsSelective(nss) {
 			// restore cluster specific configs only
 			if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
-				return err
+				return "", err
 			}
-		} else { // full restore on CSRS
-			if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
-				return err
+		} else {
+			// full restore on CSRS
+			sysSessionsUUID, err = r.configsvrFullRestore(ctx, bcp, mapRS)
+			if err != nil {
+				return "", err
 			}
 		}
-	} else { // restore on the RS topo or Shard
+	} else {
+		// restore on the RS topo or Shard
 		err = r.snapshot(rdr, cloneNS, false)
 		if err != nil {
-			return errors.Wrap(err, "mongorestore")
+			return "", errors.Wrap(err, "mongorestore")
 		}
 	}
 
 	if usersAndRolesOpt {
 		if err := r.restoreUsersAndRoles(ctx, nss); err != nil {
-			return errors.Wrap(err, "restoring users and roles")
+			return "", errors.Wrap(err, "restoring users and roles")
 		}
 	}
 
-	return nil
+	return sysSessionsUUID, nil
 }
 
 func (r *Restore) restoreLegacyArchive(

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -999,24 +999,26 @@ func (r *Restore) RunSnapshot(
 	}
 	defer rdr.Close()
 
-	if r.nodeInfo.IsConfigSrv() && util.IsSelective(nss) {
-		err = r.snapshot(rdr, cloneNS, true)
-		if err != nil {
-			return errors.Wrap(err, "mongorestore")
-		}
+	if r.nodeInfo.IsConfigSrv() {
+		if util.IsSelective(nss) {
+			err = r.snapshot(rdr, cloneNS, true)
+			if err != nil {
+				return errors.Wrap(err, "mongorestore")
+			}
 
-		// restore cluster specific configs only
-		if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
-			return err
-		}
-	} else {
-		err = r.snapshot(rdr, cloneNS, false)
-		if err != nil {
-			return errors.Wrap(err, "mongorestore")
-		}
+			// restore cluster specific configs only
+			if err := r.configsvrSelRestore(ctx, bcp, nss, mapRS); err != nil {
+				return err
+			}
+		} else {
+			err = r.snapshot(rdr, cloneNS, false)
+			if err != nil {
+				return errors.Wrap(err, "mongorestore")
+			}
 
-		if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
-			return err
+			if err := r.configsvrFullRestore(ctx, bcp, mapRS); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -1,0 +1,266 @@
+package restore
+
+import (
+	"context"
+	"encoding/hex"
+	"io"
+	"path"
+
+	"github.com/percona/percona-backup-mongodb/pbm/archive"
+	"github.com/percona/percona-backup-mongodb/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/util"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// configsvrFullRestore restores config.collections and config.chunks
+// for the purpose of full logical restore.
+// It adds special handling for config.system.sessions routing data.
+func (r *Restore) configsvrFullRestore(
+	ctx context.Context,
+	bcp *backup.BackupMeta,
+	mapRS util.RSMapFunc,
+) error {
+	mapS := util.MakeRSMapFunc(r.sMap)
+
+	bcpSysSessUUIDToSkip, err := r.fullRestoreConfigCollections(ctx, bcp, mapRS)
+	if err != nil {
+		return errors.Wrap(err, "full restore config.collections")
+	}
+
+	if err := r.fullRestoreConfigChunks(ctx, bcp, bcpSysSessUUIDToSkip, mapRS, mapS); err != nil {
+		return errors.Wrap(err, "full restore config.chunks")
+	}
+
+	return nil
+}
+
+// fullRestoreConfigCollections does full restore of config.collections
+// collection. It adds special handling for system.sessions document within
+// collection:
+//   - on target cluster it just leave that document as is
+//   - in case of backup data it just ignores possible entry within collection dump
+//   - for the backup data it finds UUID for config.system.sessions collection referneced
+//     within the backup data. By having that UUID it'll be possible to filter out
+//     corresponding chunk's documents late in the processing logic.
+//
+// fullRestoreConfigCollections returns UUID for the config.system.session collection
+// referenced within the backup. In case of error mentioned UUID is empty string.
+func (r *Restore) fullRestoreConfigCollections(
+	ctx context.Context,
+	bcp *backup.BackupMeta,
+	mapRS util.RSMapFunc,
+) (string, error) {
+	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigCollectionsNS+bcp.Compression.Suffix())
+	rdr, err := r.bcpStg.SourceReader(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer rdr.Close()
+
+	rdr, err = compress.Decompress(rdr, bcp.Compression)
+	if err != nil {
+		return "", err
+	}
+
+	if err = r.cleanUpConfigCollections(ctx); err != nil {
+		return "", errors.Wrap(err, "cleaning up config.collections")
+	}
+
+	bcpSysSessUUID := ""
+	models := []mongo.WriteModel{}
+	buf := make([]byte, archive.MaxBSONSize)
+	for {
+		buf, err = archive.ReadBSONBuffer(rdr, buf[:cap(buf)])
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return "", err
+		}
+
+		bsonDoc := bson.Raw(buf)
+		ns := bsonDoc.Lookup("_id").StringValue()
+		if ns == defs.ConfigSystemSessionsNS {
+			_, uuid, ok := bsonDoc.Lookup("uuid").BinaryOK()
+			if ok {
+				// save confgi.system.sessions UUID, we need it for filtering out chunks docs
+				bcpSysSessUUID = hex.EncodeToString(uuid)
+			}
+
+			// skip system.sessions if it's in the backup
+			continue
+		}
+
+		doc := bson.D{}
+		err = bson.Unmarshal(buf, &doc)
+		if err != nil {
+			return "", errors.Wrap(err, "unmarshal")
+		}
+
+		model := mongo.NewReplaceOneModel()
+		model.SetFilter(bson.D{{"_id", ns}})
+		model.SetReplacement(doc)
+		model.SetUpsert(true)
+		models = append(models, model)
+	}
+
+	if len(models) == 0 {
+		return bcpSysSessUUID, nil
+	}
+
+	coll := r.leadConn.ConfigDatabase().Collection("collections")
+	if _, err = coll.BulkWrite(ctx, models); err != nil {
+		return "", errors.Wrap(err, "restore config.collections")
+	}
+
+	return bcpSysSessUUID, nil
+}
+
+// fullRestoreConfigChunks does full restore of config.chunks collection.
+// It adds special handling for system.sessions related documents within
+// collection:
+//   - on the target cluster it just leaves all related docs untouched.
+//   - it uses sysSessToSkip parameter which represents UUID for the system.sessions
+//     collection, to be able to skip referenced chunks within the backup dump.
+//
+// All other chunk docs are deleted before PBM start to restore docs from the backup.
+func (r *Restore) fullRestoreConfigChunks(
+	ctx context.Context,
+	bcp *backup.BackupMeta,
+	sysSessToSkip string,
+	mapRS,
+	mapS util.RSMapFunc,
+) error {
+	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigChunksNS+bcp.Compression.Suffix())
+	rdr, err := r.bcpStg.SourceReader(filepath)
+	if err != nil {
+		return err
+	}
+	defer rdr.Close()
+
+	rdr, err = compress.Decompress(rdr, bcp.Compression)
+	if err != nil {
+		return err
+	}
+
+	if err = r.cleanUpConfigChunks(ctx); err != nil {
+		return errors.Wrap(err, "clean up config.chunks during full restore")
+	}
+
+	models := []mongo.WriteModel{}
+	buf := make([]byte, archive.MaxBSONSize)
+	for done := false; !done; {
+		// there could be thousands of chunks. write every maxBulkWriteCount docs
+		// to limit memory usage
+		for i := 0; i != maxBulkWriteCount; i++ {
+			buf, err = archive.ReadBSONBuffer(rdr, buf[:cap(buf)])
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					done = true
+					break
+				}
+
+				return err
+			}
+
+			if len(sysSessToSkip) != 0 {
+				// we need to skip chunks that reference system.sessions
+				bsonDoc := bson.Raw(buf)
+				if _, uuid, ok := bsonDoc.Lookup("uuid").BinaryOK(); ok {
+					if hex.EncodeToString(uuid) == sysSessToSkip {
+						continue
+					}
+				}
+			}
+
+			doc := bson.D{}
+			if err := bson.Unmarshal(buf, &doc); err != nil {
+				return errors.Wrap(err, "unmarshal")
+			}
+
+			for i, a := range doc {
+				switch a.Key {
+				case "shard":
+					doc[i].Value = mapS(doc[i].Value.(string))
+				case "history":
+					history := doc[i].Value.(bson.A)
+					for j, b := range history {
+						c := b.(bson.D)
+						for k, d := range c {
+							if d.Key == "shard" {
+								c[k].Value = mapS(d.Value.(string))
+							}
+						}
+						history[j] = c
+					}
+					doc[i].Value = history
+				}
+			}
+
+			models = append(models, mongo.NewInsertOneModel().SetDocument(doc))
+		}
+
+		if len(models) == 0 && !done {
+			// if it's not done, we just reached maxBulkWriteCount, we need to process more
+			continue
+		} else if len(models) == 0 && done {
+			// it's done and there's nothing to update
+			return nil
+		}
+
+		_, err = r.leadConn.ConfigDatabase().Collection("chunks").BulkWrite(ctx, models)
+		if err != nil {
+			return errors.Wrap(err, "restore config.chunks")
+		}
+
+		models = models[:0]
+	}
+
+	return nil
+}
+
+// cleanUpConfigCollections deletes complete config.collections collection except
+// config.system.sessions related document.
+func (r *Restore) cleanUpConfigCollections(ctx context.Context) error {
+	excSessFilter := bson.M{
+		"_id": bson.M{"$ne": defs.ConfigSystemSessionsNS},
+	}
+	_, err := r.leadConn.ConfigDatabase().Collection("collections").DeleteMany(ctx, excSessFilter)
+	if err != nil {
+		return errors.Wrap(err, "delete all from config.collections")
+	}
+
+	return nil
+}
+
+// cleanUpConfigChunks deletes complete config.chunks collection except
+// config.system.sessions releted documents.
+// Before performing deletion, it finds out system.sessions UUID by querying
+// config.collections.
+func (r *Restore) cleanUpConfigChunks(ctx context.Context) error {
+	sessBson, err := r.leadConn.ConfigDatabase().Collection("collections").
+		FindOne(ctx, bson.D{{"_id", "config.system.sessions"}}).Raw()
+	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+		return errors.Wrap(err, "querying config.system.sessions UUID")
+	}
+
+	excSessFilter := bson.M{}
+	if sessBson != nil {
+		_, uuid := sessBson.Lookup("uuid").Binary()
+		sysSessUUID := hex.EncodeToString(uuid)
+		excSessFilter["$ne"] = sysSessUUID
+	}
+
+	_, err = r.leadConn.ConfigDatabase().Collection("chunks").
+		DeleteMany(ctx, excSessFilter)
+	if err != nil {
+		return errors.Wrap(err, "delete all from config.chunks")
+	}
+
+	return nil
+}

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -51,6 +51,10 @@ func (r *Restore) fullRestoreConfigDatabases(
 	bcp *backup.BackupMeta,
 	mapRS, mapS util.RSMapFunc,
 ) error {
+	if err := r.cleanUpConfigDatabases(ctx); err != nil {
+		return errors.Wrap(err, "cleaning up config.databases")
+	}
+
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigDatabasesNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
 	if errors.Is(err, storage.ErrNotExist) {
@@ -64,10 +68,6 @@ func (r *Restore) fullRestoreConfigDatabases(
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return errors.Wrap(err, "decompress")
-	}
-
-	if err = r.cleanUpConfigDatabases(ctx); err != nil {
-		return errors.Wrap(err, "cleaning up config.databases")
 	}
 
 	models := []mongo.WriteModel{}
@@ -128,6 +128,10 @@ func (r *Restore) fullRestoreConfigCollections(
 	bcp *backup.BackupMeta,
 	mapRS util.RSMapFunc,
 ) (string, error) {
+	if err := r.cleanUpConfigCollections(ctx); err != nil {
+		return "", errors.Wrap(err, "cleaning up config.collections")
+	}
+
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigCollectionsNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
 	if errors.Is(err, storage.ErrNotExist) {
@@ -141,10 +145,6 @@ func (r *Restore) fullRestoreConfigCollections(
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return "", errors.Wrap(err, "decompress")
-	}
-
-	if err = r.cleanUpConfigCollections(ctx); err != nil {
-		return "", errors.Wrap(err, "cleaning up config.collections")
 	}
 
 	bcpSysSessUUID := ""
@@ -211,6 +211,10 @@ func (r *Restore) fullRestoreConfigChunks(
 	mapRS,
 	mapS util.RSMapFunc,
 ) error {
+	if err := r.cleanUpConfigChunks(ctx); err != nil {
+		return errors.Wrap(err, "clean up config.chunks during full restore")
+	}
+
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigChunksNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
 	if errors.Is(err, storage.ErrNotExist) {
@@ -224,10 +228,6 @@ func (r *Restore) fullRestoreConfigChunks(
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return errors.Wrap(err, "decompress")
-	}
-
-	if err = r.cleanUpConfigChunks(ctx); err != nil {
-		return errors.Wrap(err, "clean up config.chunks during full restore")
 	}
 
 	var docInserted int64

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -6,15 +6,16 @@ import (
 	"io"
 	"path"
 
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/percona/percona-backup-mongodb/pbm/archive"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // configsvrFullRestore restores config.collections and config.chunks

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -15,6 +15,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 )
 
@@ -52,14 +53,17 @@ func (r *Restore) fullRestoreConfigDatabases(
 ) error {
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigDatabasesNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
-	if err != nil {
-		return err
+	if errors.Is(err, storage.ErrNotExist) {
+		r.log.Debug("skipping restoring config.databases, cannot find file %s", filepath)
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "decompress")
 	}
 
 	if err = r.cleanUpConfigDatabases(ctx); err != nil {
@@ -126,14 +130,17 @@ func (r *Restore) fullRestoreConfigCollections(
 ) (string, error) {
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigCollectionsNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
-	if err != nil {
-		return "", err
+	if errors.Is(err, storage.ErrNotExist) {
+		r.log.Debug("skipping restoring config.collections, cannot find file %s", filepath)
+		return "", nil
+	} else if err != nil {
+		return "", errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "decompress")
 	}
 
 	if err = r.cleanUpConfigCollections(ctx); err != nil {
@@ -206,14 +213,17 @@ func (r *Restore) fullRestoreConfigChunks(
 ) error {
 	filepath := path.Join(bcp.Name, mapRS(r.brief.SetName), defs.ConfigChunksNS+bcp.Compression.Suffix())
 	rdr, err := r.bcpStg.SourceReader(filepath)
-	if err != nil {
-		return err
+	if errors.Is(err, storage.ErrNotExist) {
+		r.log.Debug("skipping restoring config.chunks, cannot find file %s", filepath)
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "decompress")
 	}
 
 	if err = r.cleanUpConfigChunks(ctx); err != nil {

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -348,7 +348,7 @@ func (r *Restore) cleanUpConfigChunks(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "delete all from config.chunks")
 	}
-	r.log.Debug("cleaned-up config.chunks: %d", res.DeletedCount)
+	r.log.Debug("cleaned-up config.chunks (%d documents)", res.DeletedCount)
 
 	return nil
 }

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -24,23 +24,23 @@ func (r *Restore) configsvrFullRestore(
 	ctx context.Context,
 	bcp *backup.BackupMeta,
 	mapRS util.RSMapFunc,
-) error {
+) (string, error) {
 	mapS := util.MakeRSMapFunc(r.sMap)
 
 	if err := r.fullRestoreConfigDatabases(ctx, bcp, mapRS, mapS); err != nil {
-		return errors.Wrap(err, "full restore config.databases")
+		return "", errors.Wrap(err, "full restore config.databases")
 	}
 
 	bcpSysSessUUIDToSkip, err := r.fullRestoreConfigCollections(ctx, bcp, mapRS)
 	if err != nil {
-		return errors.Wrap(err, "full restore config.collections")
+		return "", errors.Wrap(err, "full restore config.collections")
 	}
 
 	if err := r.fullRestoreConfigChunks(ctx, bcp, bcpSysSessUUIDToSkip, mapRS, mapS); err != nil {
-		return errors.Wrap(err, "full restore config.chunks")
+		return "", errors.Wrap(err, "full restore config.chunks")
 	}
 
-	return nil
+	return bcpSysSessUUIDToSkip, nil
 }
 
 // fullRestoreConfigDatabases does full restore of config.databases collection.

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -287,12 +287,13 @@ func chunks(
 }
 
 type applyOplogOption struct {
-	start   *primitive.Timestamp
-	end     *primitive.Timestamp
-	nss     []string
-	cloudNS snapshot.CloneNS
-	unsafe  bool
-	filter  oplog.OpFilter
+	start    *primitive.Timestamp
+	end      *primitive.Timestamp
+	nss      []string
+	cloudNS  snapshot.CloneNS
+	unsafe   bool
+	filter   oplog.OpFilter
+	sessUUID string
 }
 
 type (
@@ -373,6 +374,7 @@ func applyOplog(
 	} else if err != nil {
 		return nil, errors.Wrap(err, "set cloning ns")
 	}
+	oplogRestore.SetSessionsToExclude(options.sessUUID)
 
 	var lts primitive.Timestamp
 	for _, oplogRange := range ranges {

--- a/pbm/restore/selective.go
+++ b/pbm/restore/selective.go
@@ -26,8 +26,8 @@ const (
 
 const maxBulkWriteCount = 500
 
-// configsvrRestore restores for selected namespaces
-func (r *Restore) configsvrRestore(
+// configsvrSelRestore restores for selected namespaces
+func (r *Restore) configsvrSelRestore(
 	ctx context.Context,
 	bcp *backup.BackupMeta,
 	nss []string,

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -109,14 +109,22 @@ func NewRestore(uri string,
 
 	nsExclude := ExcludeFromRestore
 	if excludeRouterCollections {
+		// for selective restore we'll exclude all router collections
 		configColls := []string{
 			"config.databases",
 			"config.collections",
 			"config.chunks",
 		}
-		nsExclude = make([]string, len(ExcludeFromRestore)+len(configColls))
-		n := copy(nsExclude, ExcludeFromRestore)
-		copy(nsExclude[n:], configColls)
+		nsExclude = append(nsExclude, configColls...)
+	} else {
+		// for full restore we'll restore config.databases
+		// and for config.collections and config.chunks
+		// there is special restore handling later
+		configColls := []string{
+			"config.collections",
+			"config.chunks",
+		}
+		nsExclude = append(nsExclude, configColls...)
 	}
 
 	mopts := mongorestore.Options{}

--- a/pbm/snapshot/restore.go
+++ b/pbm/snapshot/restore.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"io"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/mongodb/mongo-tools/common/options"
@@ -107,22 +108,12 @@ func NewRestore(uri string,
 		numParallelColls = 1
 	}
 
-	nsExclude := ExcludeFromRestore
+	nsExclude := slices.Clone(ExcludeFromRestore)
 	if excludeRouterCollections {
-		// for selective restore we'll exclude all router collections
 		configColls := []string{
-			"config.databases",
-			"config.collections",
-			"config.chunks",
-		}
-		nsExclude = append(nsExclude, configColls...)
-	} else {
-		// for full restore we'll restore config.databases
-		// and for config.collections and config.chunks
-		// there is special restore handling later
-		configColls := []string{
-			"config.collections",
-			"config.chunks",
+			defs.ConfigDatabasesNS,
+			defs.ConfigCollectionsNS,
+			defs.ConfigChunksNS,
 		}
 		nsExclude = append(nsExclude, configColls...)
 	}

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -101,12 +101,12 @@ func (i *NodeInfo) IsDelayed() bool {
 	return i.SecondaryDelayOld != 0 || i.SecondaryDelaySecs != 0
 }
 
-// IsSharded returns true is replset is part sharded cluster
+// IsMongoes returns true if node is mongos.
 func (i *NodeInfo) IsMongos() bool {
 	return i.Msg == "isdbgrid"
 }
 
-// IsSharded returns true is replset is part sharded cluster
+// IsSharded returns true is replset is part of sharded cluster.
 func (i *NodeInfo) IsSharded() bool {
 	return i.SetName != "" && (i.ConfigServerState != nil || i.Opts.Sharding.ClusterRole != "" || i.ConfigSvr == 2)
 }

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -101,7 +101,7 @@ func (i *NodeInfo) IsDelayed() bool {
 	return i.SecondaryDelayOld != 0 || i.SecondaryDelaySecs != 0
 }
 
-// IsMongoes returns true if node is mongos.
+// IsMongos returns true if node is mongos.
 func (i *NodeInfo) IsMongos() bool {
 	return i.Msg == "isdbgrid"
 }


### PR DESCRIPTION
[![PBM-1583](https://badgen.net/badge/JIRA/PBM-1583/green)](https://jira.percona.com/browse/PBM-1583) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After the logical restore, `mongos` might report the following issue due to the wrong version of `config.system.sessions` collection:
```
{"t":{"$date":"2025-08-07T07:49:42.739+00:00"},"s":"F",  "c":"CONTROL",  "id":6384300, "svc":"R", 
"ctx":"CatalogCache-2","msg":"Writing fatal message","attr":{"message":"DBException::toString(): Location6493100: Time monotonicity violation: lookup time { chunkVersion: { e: ObjectId('689227ae6ddc75edfc776764'), t: Timestamp(1754408878, 15), v: Timestamp(1, 0) }, forcedRefreshSequenceNum: 197, epochDisambiguatingSequenceNum: 173 } 
which is less than the earliest expected timeInStore { chunkVersion: { e: ObjectId('689458bb2a8fef762ad13bef'), t: Timestamp(1754552507, 35), v: Timestamp(1, 0) }, forcedRefreshSequenceNum: 197, epochDisambiguatingSequenceNum: 171 }.\nActual exception type: mongo::error_details::throwExceptionForStatus(mongo::Status const&)::NonspecificAssertionException\n\n"}}
```
The PR fixes the issue by changing restore procedure in the following way:
- It adds special handling for all routing collections: `config.databases`, `config.collections` and `config.chunks`.
- During collections restore preparation, it doesn't drop routing tables it just deletes all documents from them, except `config.system.sessions` related documents.
- During collection restore, it inserts all documents from the backup into routing collections except documents related to `config.system.sessions`.
- During oplog replay phase (backup and PITR), it doesn't apply documents related to `config.system.sessions` and it just ignores them. All other routing related documents, it applies with the target cluster UUID.


[PBM-1583]: https://perconadev.atlassian.net/browse/PBM-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ