### PR TITLE
PBM-1597 - improve version check message

### DIFF
--- a/pbm/version/version.go
+++ b/pbm/version/version.go
@@ -224,11 +224,29 @@ type FeatureSupport MongoVersion
 func (f FeatureSupport) PBMSupport() error {
 	v := MongoVersion(f)
 
-	if (v.Version[0] >= 5 && v.Version[0] <= 8) && v.Version[1] == 0 {
+	// Supported MongoDB major versions for PBM
+	supportedMajors := []int{5, 6, 7, 8}
+
+	// Happy path: supported major within range and minor is 0
+	if (v.Version[0] >= supportedMajors[0] && v.Version[0] <= supportedMajors[len(supportedMajors)-1]) && v.Version[1] == 0 {
 		return nil
 	}
 
-	return errors.New("Unsupported MongoDB version. PBM works with v5.0, v6.0, v7.0, v8.0")
+	// Render a friendly message with the supported versions and the current one
+	supported := make([]string, 0, len(supportedMajors))
+	for _, m := range supportedMajors {
+		supported = append(supported, fmt.Sprintf("v%d.0", m))
+	}
+
+	current := fmt.Sprintf("v%d.%d", v.Version[0], v.Version[1])
+
+	// If MongoDB is older than the minimum supported, suggest upgrading MongoDB
+	if v.Version[0] < supportedMajors[0] {
+		return errors.Errorf("This PBM works with %s and you are running %s. Please upgrade your MongoDB to a supported version", strings.Join(supported, ", "), current)
+	}
+
+	// Otherwise, MongoDB is newer or uses an unsupported minor → suggest upgrading PBM
+	return errors.Errorf("This PBM works with %s and you are running %s. Please upgrade your PBM package", strings.Join(supported, ", "), current)
 }
 
 func (f FeatureSupport) FullPhysicalBackup() bool {

--- a/pbm/version/version.go
+++ b/pbm/version/version.go
@@ -224,11 +224,18 @@ type FeatureSupport MongoVersion
 func (f FeatureSupport) PBMSupport() error {
 	v := MongoVersion(f)
 
+	// Ensure we have at least major and minor versions
+	if len(v.Version) < 2 {
+		return errors.New("cannot determine MongoDB major/minor version: incomplete versionArray")
+	}
+
 	// Supported MongoDB major versions for PBM
 	supportedMajors := []int{5, 6, 7, 8}
 
 	// Happy path: supported major within range and minor is 0
-	if (v.Version[0] >= supportedMajors[0] && v.Version[0] <= supportedMajors[len(supportedMajors)-1]) && v.Version[1] == 0 {
+	if (v.Version[0] >= supportedMajors[0] &&
+		v.Version[0] <= supportedMajors[len(supportedMajors)-1]) &&
+		v.Version[1] == 0 {
 		return nil
 	}
 
@@ -242,11 +249,19 @@ func (f FeatureSupport) PBMSupport() error {
 
 	// If MongoDB is older than the minimum supported, suggest upgrading MongoDB
 	if v.Version[0] < supportedMajors[0] {
-		return errors.Errorf("This PBM works with %s and you are running %s. Please upgrade your MongoDB to a supported version", strings.Join(supported, ", "), current)
+		return errors.Errorf(
+			"This PBM works with %s and you are running %s. Please upgrade your MongoDB to a supported version",
+			strings.Join(supported, ", "),
+			current,
+		)
 	}
 
 	// Otherwise, MongoDB is newer or uses an unsupported minor → suggest upgrading PBM
-	return errors.Errorf("This PBM works with %s and you are running %s. Please upgrade your PBM package", strings.Join(supported, ", "), current)
+	return errors.Errorf(
+		"This PBM works with %s and you are running %s. Please upgrade your PBM package",
+		strings.Join(supported, ", "),
+		current,
+	)
 }
 
 func (f FeatureSupport) FullPhysicalBackup() bool {

--- a/pbm/version/version_test.go
+++ b/pbm/version/version_test.go
@@ -149,8 +149,10 @@ func TestPBMSupport(t *testing.T) {
 				if tc.contains != "" && !strings.Contains(err.Error(), tc.contains) {
 					t.Fatalf("unexpected error message: %q does not contain %q", err.Error(), tc.contains)
 				}
-				if !strings.Contains(err.Error(), "This PBM works with v5.0, v6.0, v7.0, v8.0") {
-					t.Fatalf("error should list supported versions, got: %q", err.Error())
+				if tc.contains == "" || !strings.Contains(tc.contains, "incomplete versionArray") {
+					if !strings.Contains(err.Error(), "This PBM works with v5.0, v6.0, v7.0, v8.0") {
+						t.Fatalf("error should list supported versions, got: %q", err.Error())
+					}
 				}
 			}
 		})

--- a/pbm/version/version_test.go
+++ b/pbm/version/version_test.go
@@ -122,10 +122,10 @@ func TestHasPhysicalFilesMetadata(t *testing.T) {
 
 func TestPBMSupport(t *testing.T) {
 	cases := []struct {
-		name      string
-		ver       []int
-		wantErr   bool
-		contains  string
+		name     string
+		ver      []int
+		wantErr  bool
+		contains string
 	}{
 		{name: "supported 5.0.0", ver: []int{5, 0, 0}, wantErr: false},
 		{name: "supported 5.0.x", ver: []int{5, 0, 14}, wantErr: false},
@@ -136,6 +136,7 @@ func TestPBMSupport(t *testing.T) {
 		{name: "unsupported minor 5.1.0", ver: []int{5, 1, 0}, wantErr: true, contains: "upgrade your PBM"},
 		{name: "newer major 9.0.0", ver: []int{9, 0, 0}, wantErr: true, contains: "upgrade your PBM"},
 		{name: "unsupported minor 7.2.3", ver: []int{7, 2, 3}, wantErr: true, contains: "upgrade your PBM"},
+		{name: "incomplete version array", ver: []int{7}, wantErr: true, contains: "incomplete versionArray"},
 	}
 
 	for _, tc := range cases {

--- a/pbm/version/version_test.go
+++ b/pbm/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -116,5 +117,41 @@ func TestHasPhysicalFilesMetadata(t *testing.T) {
 		if expect != got {
 			t.Errorf("%q - expected %v, got %v", ver, expect, got)
 		}
+	}
+}
+
+func TestPBMSupport(t *testing.T) {
+	cases := []struct {
+		name      string
+		ver       []int
+		wantErr   bool
+		contains  string
+	}{
+		{name: "supported 5.0.0", ver: []int{5, 0, 0}, wantErr: false},
+		{name: "supported 5.0.x", ver: []int{5, 0, 14}, wantErr: false},
+		{name: "supported 6.0.x", ver: []int{6, 0, 5}, wantErr: false},
+		{name: "supported 8.0.x", ver: []int{8, 0, 1}, wantErr: false},
+
+		{name: "too old 4.4.18", ver: []int{4, 4, 18}, wantErr: true, contains: "upgrade your MongoDB"},
+		{name: "unsupported minor 5.1.0", ver: []int{5, 1, 0}, wantErr: true, contains: "upgrade your PBM"},
+		{name: "newer major 9.0.0", ver: []int{9, 0, 0}, wantErr: true, contains: "upgrade your PBM"},
+		{name: "unsupported minor 7.2.3", ver: []int{7, 2, 3}, wantErr: true, contains: "upgrade your PBM"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := FeatureSupport(MongoVersion{Version: tc.ver}).PBMSupport()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("unexpected error presence: err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if err != nil {
+				if tc.contains != "" && !strings.Contains(err.Error(), tc.contains) {
+					t.Fatalf("unexpected error message: %q does not contain %q", err.Error(), tc.contains)
+				}
+				if !strings.Contains(err.Error(), "This PBM works with v5.0, v6.0, v7.0, v8.0") {
+					t.Fatalf("error should list supported versions, got: %q", err.Error())
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
[![PBM-1597](https://badgen.net/badge/JIRA/PBM-1597/green)](https://jira.percona.com/browse/PBM-1597) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Problem description
PBM currently emits a generic incompatibility message. We need clearer guidance:

If MongoDB is below the minimum supported version, instruct users to upgrade MongoDB.

If MongoDB is newer than supported (or has an unsupported minor version), instruct users to upgrade PBM.

Always list supported versions and the detected version.

## Proposed solution
Update PBMSupport() in pbm/version/version.go to:

Centralize supported MongoDB majors: []int{5, 6, 7, 8}.

For supported versions (major in 5–8 and minor 0), return nil.

If major < 5, return error: “This PBM works with v5.0, v6.0, v7.0, v8.0 and you are running vX.Y. Please upgrade your MongoDB to a supported version”.

Otherwise (newer major or unsupported minor), return error: “This PBM works with v5.0, v6.0, v7.0, v8.0, and you are running vX.Y. Please upgrade your PBM package”.

Add table-driven unit tests covering supported, too-old, and unsupported/newer cases.

[PBM-1597]: https://perconadev.atlassian.net/browse/PBM-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ