### PR TITLE
PBM-1490: Backup with files that have reached remote storage limits

### DIFF
--- a/pbm/backup/storage.go
+++ b/pbm/backup/storage.go
@@ -11,7 +11,6 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
-	sfs "github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"github.com/percona/percona-backup-mongodb/pbm/version"
 )
@@ -201,8 +200,8 @@ func checkFile(stg storage.Storage, filename string) error {
 
 // DeleteBackupFiles removes backup's artifacts from storage
 func DeleteBackupFiles(stg storage.Storage, backupName string) error {
-	if fs, ok := stg.(*sfs.FS); ok {
-		return deleteBackupFromFS(fs, backupName)
+	if stg.Type() == storage.Filesystem {
+		return deleteBackupFromFS(stg, backupName)
 	}
 
 	files, err := stg.List(backupName, "")
@@ -254,7 +253,7 @@ func DeleteBackupFiles(stg storage.Storage, backupName string) error {
 	return errors.Join(errs...)
 }
 
-func deleteBackupFromFS(stg *sfs.FS, backupName string) error {
+func deleteBackupFromFS(stg storage.Storage, backupName string) error {
 	err1 := stg.Delete(backupName)
 	if err1 != nil && !errors.Is(err1, storage.ErrNotExist) {
 		err1 = errors.Wrapf(err1, "delete %s", backupName)

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -136,7 +136,7 @@ type Blob struct {
 	c *azblob.Client
 }
 
-func New(opts *Config, node string, l log.LogEvent) (*Blob, error) {
+func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
 	if l == nil {
 		l = log.DiscardEvent
 	}
@@ -152,7 +152,7 @@ func New(opts *Config, node string, l log.LogEvent) (*Blob, error) {
 		return nil, errors.Wrap(err, "init container")
 	}
 
-	return b, b.ensureContainer()
+	return storage.NewSplitMergeMW(b, opts.GetMaxObjSizeTB()), b.ensureContainer()
 }
 
 func (*Blob) Type() storage.Type {

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -30,6 +30,8 @@ const (
 	defaultRetries = 10
 
 	maxBlocks = 50_000
+
+	DefaultMaxObjSizeTB = 190.0
 )
 
 //nolint:lll
@@ -40,6 +42,7 @@ type Config struct {
 	EndpointURLMap map[string]string `bson:"endpointUrlMap,omitempty" json:"endpointUrlMap,omitempty" yaml:"endpointUrlMap,omitempty"`
 	Prefix         string            `bson:"prefix" json:"prefix,omitempty" yaml:"prefix,omitempty"`
 	Credentials    Credentials       `bson:"credentials" json:"-" yaml:"credentials"`
+	MaxObjSizeTB   *float64          `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
 }
 
 func (cfg *Config) Clone() *Config {
@@ -73,6 +76,9 @@ func (cfg *Config) Equal(other *Config) bool {
 		return false
 	}
 	if cfg.Credentials.Key != other.Credentials.Key {
+		return false
+	}
+	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
 		return false
 	}
 
@@ -109,6 +115,13 @@ func (cfg *Config) resolveEndpointURL(node string) string {
 		ep = fmt.Sprintf(BlobURL, cfg.Account)
 	}
 	return ep
+}
+
+func (cfg *Config) GetMaxObjSizeTB() float64 {
+	if cfg.MaxObjSizeTB != nil {
+		return *cfg.MaxObjSizeTB
+	}
+	return DefaultMaxObjSizeTB
 }
 
 type Credentials struct {

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -31,7 +31,7 @@ const (
 
 	maxBlocks = 50_000
 
-	DefaultMaxObjSizeGB = 194560 // 190 TB
+	defaultMaxObjSizeGB = 194560 // 190 TB
 )
 
 //nolint:lll
@@ -121,7 +121,7 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 	if cfg.MaxObjSizeGB != nil {
 		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeGB
+	return defaultMaxObjSizeGB
 }
 
 type Credentials struct {

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -31,7 +31,7 @@ const (
 
 	maxBlocks = 50_000
 
-	DefaultMaxObjSizeTB = 190.0
+	DefaultMaxObjSizeGB = 194560 // 190 TB
 )
 
 //nolint:lll
@@ -42,7 +42,7 @@ type Config struct {
 	EndpointURLMap map[string]string `bson:"endpointUrlMap,omitempty" json:"endpointUrlMap,omitempty" yaml:"endpointUrlMap,omitempty"`
 	Prefix         string            `bson:"prefix" json:"prefix,omitempty" yaml:"prefix,omitempty"`
 	Credentials    Credentials       `bson:"credentials" json:"-" yaml:"credentials"`
-	MaxObjSizeTB   *float64          `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
+	MaxObjSizeGB   *float64          `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 }
 
 func (cfg *Config) Clone() *Config {
@@ -78,7 +78,7 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.Credentials.Key != other.Credentials.Key {
 		return false
 	}
-	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
+	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
 		return false
 	}
 
@@ -117,11 +117,11 @@ func (cfg *Config) resolveEndpointURL(node string) string {
 	return ep
 }
 
-func (cfg *Config) GetMaxObjSizeTB() float64 {
-	if cfg.MaxObjSizeTB != nil {
-		return *cfg.MaxObjSizeTB
+func (cfg *Config) GetMaxObjSizeGB() float64 {
+	if cfg.MaxObjSizeGB != nil {
+		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeTB
+	return DefaultMaxObjSizeGB
 }
 
 type Credentials struct {
@@ -152,7 +152,7 @@ func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
 		return nil, errors.Wrap(err, "init container")
 	}
 
-	return storage.NewSplitMergeMW(b, opts.GetMaxObjSizeTB()), b.ensureContainer()
+	return storage.NewSplitMergeMW(b, opts.GetMaxObjSizeGB()), b.ensureContainer()
 }
 
 func (*Blob) Type() storage.Type {

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	DefaultMaxObjSizeTB = 5.0
-	tmpFileSuffix       = ".tmp"
+	DefaultMaxObjSizeGB = 5018 // 4.9 TB
+
+	tmpFileSuffix = ".tmp"
 )
 
 type Config struct {
 	Path         string   `bson:"path" json:"path" yaml:"path"`
-	MaxObjSizeTB *float64 `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
+	MaxObjSizeGB *float64 `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 }
 
 func (cfg *Config) Clone() *Config {
@@ -34,7 +35,7 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg == nil || other == nil {
 		return cfg == other
 	}
-	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
+	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
 		return false
 	}
 
@@ -49,11 +50,11 @@ func (cfg *Config) Cast() error {
 	return nil
 }
 
-func (cfg *Config) GetMaxObjSizeTB() float64 {
-	if cfg.MaxObjSizeTB != nil {
-		return *cfg.MaxObjSizeTB
+func (cfg *Config) GetMaxObjSizeGB() float64 {
+	if cfg.MaxObjSizeGB != nil {
+		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeTB
+	return DefaultMaxObjSizeGB
 }
 
 type FS struct {
@@ -90,7 +91,7 @@ func New(opts *Config) (storage.Storage, error) {
 	}
 
 	fs := &FS{root}
-	return storage.NewSplitMergeMW(fs, opts.GetMaxObjSizeTB()), nil
+	return storage.NewSplitMergeMW(fs, opts.GetMaxObjSizeGB()), nil
 }
 
 func (*FS) Type() storage.Type {

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -177,12 +177,12 @@ func (fs *FS) FileStat(name string) (storage.FileInfo, error) {
 	if err != nil {
 		return inf, err
 	}
-
-	inf.Size = f.Size()
-
-	if inf.Size == 0 {
+	if f.Size() == 0 {
 		return inf, storage.ErrEmpty
 	}
+
+	inf.Name = name
+	inf.Size = f.Size()
 
 	return inf, nil
 }

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultMaxObjSizeGB = 5018 // 4.9 TB
+	defaultMaxObjSizeGB = 5018 // 4.9 TB
 
 	tmpFileSuffix = ".tmp"
 )
@@ -54,7 +54,7 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 	if cfg.MaxObjSizeGB != nil {
 		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeGB
+	return defaultMaxObjSizeGB
 }
 
 type FS struct {

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -11,19 +11,6 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
-type RetryableError struct {
-	Err error
-}
-
-func (e *RetryableError) Error() string {
-	return e.Err.Error()
-}
-
-func IsRetryableError(err error) bool {
-	var e *RetryableError
-	return errors.As(err, &e)
-}
-
 const tmpFileSuffix = ".tmp"
 
 type Config struct {
@@ -114,7 +101,7 @@ func writeSync(finalpath string, data io.Reader) (err error) {
 			}
 
 			if os.IsNotExist(err) {
-				err = &RetryableError{Err: err}
+				err = &storage.RetryableError{Err: err}
 			} else {
 				os.Remove(filepath)
 			}

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -425,7 +425,7 @@ func TestSave(t *testing.T) {
 					t.Fatalf("wrong number of splitted files: want=%d, got=%d", tC.wantParts, len(files))
 				}
 
-				wantSizes := calcPartSizes(tC.partSize, tC.fileSize)
+				wantSizes := storage.CalcPartSizes(tC.partSize, tC.fileSize)
 				for i := range len(files) {
 					if wantSizes[i] != files[i].Size {
 						t.Fatalf("wrong file size for file: %s: want=%d, got=%d", files[i].Name, wantSizes[i], files[i].Size)
@@ -719,7 +719,7 @@ func TestDelete(t *testing.T) {
 				}
 
 				fileDir := path.Dir(path.Join(tmpDir, fName))
-				wantFilesInDir := len(calcPartSizes(tC.partSize, tC.totalFileSize))
+				wantFilesInDir := len(storage.CalcPartSizes(tC.partSize, tC.totalFileSize))
 				gotFilesInDir := countFilesInDir(t, fileDir)
 				if wantFilesInDir != gotFilesInDir {
 					t.Fatalf("wrong number of files within dir: want=%d, got=%d", wantFilesInDir, gotFilesInDir)
@@ -957,21 +957,6 @@ func getFileWithParts(t *testing.T, dir, name string) []storage.FileInfo {
 			}
 			res[i] = f
 		}
-	}
-
-	return res
-}
-
-func calcPartSizes(partSize, totalSize int64) []int64 {
-	padding := totalSize % partSize
-	partsCount := totalSize / partSize
-
-	res := make([]int64, partsCount)
-	for i := range partsCount {
-		res[i] = partSize
-	}
-	if padding > 0 {
-		res = append(res, padding)
 	}
 
 	return res

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -1067,6 +1067,34 @@ func TestDelete(t *testing.T) {
 				t.Fatalf("wrong number of files after deletion in sub dir: want=%d, got=%d", wantInSubDir, gotInSubDir)
 			}
 		})
+
+		t.Run("Delete dir", func(t *testing.T) {
+			tmpDir := setupTestDir(t)
+			fs := &FS{root: tmpDir}
+			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+
+			fName := "test_file_stat"
+			fNameSub := "sub/test_file_stat"
+			fSize := int64(1024)
+			createFileWithParts(t, fName, 3*fSize, smMW, "")
+			createFileWithParts(t, fNameSub, 5*fSize, smMW, "")
+			dir := "sub"
+
+			err := smMW.Delete(dir)
+			if err != nil {
+				t.Fatalf("error while invoking Delete: %v", err)
+			}
+
+			wantInDir, wantInSubDir := 3, 0
+			gotInDir := countFilesInDir(t, tmpDir)
+			if wantInDir != gotInDir {
+				t.Fatalf("wrong number of files after deletion in root dir: want=%d, got=%d", wantInDir, gotInDir)
+			}
+			gotInSubDir := countFilesInDir(t, path.Join(tmpDir, "sub"))
+			if wantInSubDir != gotInSubDir {
+				t.Fatalf("wrong number of files after deletion in sub dir: want=%d, got=%d", wantInSubDir, gotInSubDir)
+			}
+		})
 	})
 }
 

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -814,7 +814,6 @@ func TestFileStat(t *testing.T) {
 			defer file.Close()
 
 			fInfo, err := smMW.FileStat(fName)
-			// if !errors.Is(err, storage.ErrEmpty) {
 			if err != storage.ErrEmpty {
 				t.Fatalf("error while invoking FileStat: want=%v, got=%v", storage.ErrEmpty, err)
 			}

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -545,7 +545,7 @@ func TestSourceReader(t *testing.T) {
 	})
 
 	t.Run("Closing the stream when using split-merge middleware", func(t *testing.T) {
-		//todo...
+		// todo...
 	})
 }
 
@@ -993,7 +993,7 @@ func createFileWithParts(
 	}
 }
 
-func fileInfoSort(a storage.FileInfo, b storage.FileInfo) int {
+func fileInfoSort(a, b storage.FileInfo) int {
 	if a.Name < b.Name {
 		return -1
 	} else if a.Name > b.Name {

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -139,55 +140,8 @@ func TestList(t *testing.T) {
 	})
 }
 
-func setupTestFiles(t *testing.T) string {
-	tmpDir, err := os.MkdirTemp("", "fs-test-*")
-	if err != nil {
-		t.Fatalf("error while creating setup files: %v", err)
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
-
-	// tmpDir/
-	//   - file1.txt
-	//   - file2.log
-	//   - file3.txt.tmp
-	//   - subdir/
-	//     - file4.txt
-	//     - file5.log
-	//     - file6.txt.tmp
-	//   - empty/
-	createTestFile(t, filepath.Join(tmpDir, "file1.txt"), "content1")
-	createTestFile(t, filepath.Join(tmpDir, "file2.log"), "content2")
-	createTestFile(t, filepath.Join(tmpDir, "file3.txt.tmp"), "content3")
-
-	createTestDir(t, filepath.Join(tmpDir, "subdir"))
-	createTestFile(t, filepath.Join(tmpDir, "subdir", "file4.txt"), "content4")
-	createTestFile(t, filepath.Join(tmpDir, "subdir", "file5.log"), "content5")
-	createTestFile(t, filepath.Join(tmpDir, "subdir", "file6.txt.tmp"), "content6")
-
-	createTestDir(t, filepath.Join(tmpDir, "empty"))
-
-	return tmpDir
-}
-
-func createTestFile(t *testing.T, path, content string) {
-	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("error while creating file %s: %v", path, err)
-	}
-}
-
-func createTestDir(t *testing.T, path string) {
-	t.Helper()
-	if err := os.Mkdir(path, 0o755); err != nil {
-		t.Fatalf("error while creating dir %s: %v", path, err)
-	}
-}
-
 func TestSave(t *testing.T) {
-	t.Run("save with split-merge middleware", func(t *testing.T) {
+	t.Run("Save with split-merge middleware", func(t *testing.T) {
 		testCases := []struct {
 			desc      string
 			partSize  int64
@@ -237,7 +191,7 @@ func TestSave(t *testing.T) {
 				wantParts: 1,
 			},
 			{
-				desc:      "lots of files and one smaller part",
+				desc:      "lots of parts and one smaller part",
 				partSize:  7 * 1024,
 				fileSize:  490*1024 + 1,
 				wantParts: 71,
@@ -261,7 +215,7 @@ func TestSave(t *testing.T) {
 				fs := &FS{root: tmpDir}
 				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
 
-				fName := "test_file"
+				fName := "test_split"
 				fContent := make([]byte, tC.fileSize)
 				r := bytes.NewReader(fContent)
 
@@ -284,6 +238,169 @@ func TestSave(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestSourceReader(t *testing.T) {
+	t.Run("SourceReader with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc           string
+			partSize       int64
+			mergedFileSize int64
+		}{
+			{
+				desc:           "basic use case for merging parts",
+				partSize:       1024,
+				mergedFileSize: 11 * 1024,
+			},
+			{
+				desc:           "merging 100s of parts",
+				partSize:       199,
+				mergedFileSize: 300*199 + 444,
+			},
+			{
+				desc:           "merging 1000s of parts",
+				partSize:       57,
+				mergedFileSize: 57*1023 + 15,
+			},
+			{
+				desc:           "single part file smaller than part size",
+				partSize:       5 * 1024,
+				mergedFileSize: 4*1024 + 123,
+			},
+			{
+				desc:           "single part file, the same size as part size",
+				partSize:       2 * 1024 * 1024,
+				mergedFileSize: 2 * 1024 * 1024,
+			},
+			{
+				desc:           "merged file size is multiple of part size",
+				partSize:       10 * 1024 * 1024,
+				mergedFileSize: 5 * 10 * 1024 * 1024,
+			},
+			{
+				desc:           "merged file size is for single byte bigger than part",
+				partSize:       50 * 1024,
+				mergedFileSize: 50*1024 + 1,
+			},
+			{
+				desc:           "1 byte file",
+				partSize:       20 * 1024,
+				mergedFileSize: 1,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				tmpDir, _ := os.MkdirTemp("", "fs-test-*")
+				fs := &FS{root: tmpDir}
+				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+
+				fName := "test_merge"
+				var srcContent []byte
+				if tC.mergedFileSize != 0 {
+					// create test parts
+					srcContent = make([]byte, tC.mergedFileSize)
+					r := bytes.NewReader(srcContent)
+					err := smMW.Save(fName, r)
+					if err != nil {
+						t.Fatalf("error while creating test parts: %v", err)
+					}
+				} else {
+					file, err := os.Create(fName)
+					if err != nil {
+						t.Fatalf("error creating empty file: %v", err)
+					}
+					defer file.Close()
+				}
+
+				rc, err := smMW.SourceReader(fName)
+				if err != nil {
+					t.Fatalf("error while invoking SourceReader: %v", err)
+				}
+
+				dstContent, err := io.ReadAll(rc)
+				if err != nil {
+					t.Fatalf("reading merged file: %v", err)
+				}
+
+				if tC.mergedFileSize != int64(len(dstContent)) {
+					t.Fatalf("wrong file size after merge, want=%d, got=%d", tC.mergedFileSize, len(dstContent))
+				}
+
+				if !bytes.Equal(srcContent, dstContent) {
+					t.Fatal("merged file content doesn't match")
+				}
+			})
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		tmpDir, _ := os.MkdirTemp("", "fs-test-*")
+		fs := &FS{root: tmpDir}
+		smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+
+		fName := "test_merge"
+		file, err := os.Create(fName)
+		if err != nil {
+			t.Fatalf("error creating empty file: %v", err)
+		}
+		defer file.Close()
+
+		rc, err := smMW.SourceReader(fName)
+		wantErr := storage.ErrNotExist
+		if err != wantErr {
+			t.Fatalf("want err=%v, got=%v", wantErr, err)
+		}
+		if rc != nil {
+			t.Fatal("reader should be nil")
+		}
+	})
+}
+
+func setupTestFiles(t *testing.T) string {
+	tmpDir, err := os.MkdirTemp("", "fs-test-*")
+	if err != nil {
+		t.Fatalf("error while creating setup files: %v", err)
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	// tmpDir/
+	//   - file1.txt
+	//   - file2.log
+	//   - file3.txt.tmp
+	//   - subdir/
+	//     - file4.txt
+	//     - file5.log
+	//     - file6.txt.tmp
+	//   - empty/
+	createTestFile(t, filepath.Join(tmpDir, "file1.txt"), "content1")
+	createTestFile(t, filepath.Join(tmpDir, "file2.log"), "content2")
+	createTestFile(t, filepath.Join(tmpDir, "file3.txt.tmp"), "content3")
+
+	createTestDir(t, filepath.Join(tmpDir, "subdir"))
+	createTestFile(t, filepath.Join(tmpDir, "subdir", "file4.txt"), "content4")
+	createTestFile(t, filepath.Join(tmpDir, "subdir", "file5.log"), "content5")
+	createTestFile(t, filepath.Join(tmpDir, "subdir", "file6.txt.tmp"), "content6")
+
+	createTestDir(t, filepath.Join(tmpDir, "empty"))
+
+	return tmpDir
+}
+
+func createTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("error while creating file %s: %v", path, err)
+	}
+}
+
+func createTestDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("error while creating dir %s: %v", path, err)
+	}
 }
 
 func BytesToTB(bytes int64) float64 {

--- a/pbm/storage/fs/fs_test.go
+++ b/pbm/storage/fs/fs_test.go
@@ -18,7 +18,7 @@ func TestList(t *testing.T) {
 	t.Run("basic usage", func(t *testing.T) {
 		tmpDir := setupTestFiles(t)
 		var fs storage.Storage = &FS{root: tmpDir}
-		fs = storage.NewSplitMergeMW(fs, BytesToTB(5*1024*1024*1024))
+		fs = storage.NewSplitMergeMW(fs, BytesToGB(5*1024*1024*1024))
 
 		testCases := []struct {
 			desc      string
@@ -146,7 +146,7 @@ func TestList(t *testing.T) {
 		t.Run("file parts are ignored", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName := "test_parts1"
 			fSize := int64(5 * 1024)
@@ -177,7 +177,7 @@ func TestList(t *testing.T) {
 		t.Run("file parts are ignored for multiple files", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName1 := "test_parts1"
 			fSize1 := int64(1 * 1024)
@@ -213,7 +213,7 @@ func TestList(t *testing.T) {
 		t.Run("file parts are ignored within sub dir", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName1 := "sub/test_parts1"
 			fSize1 := int64(1 * 1024)
@@ -249,7 +249,7 @@ func TestList(t *testing.T) {
 		t.Run("listing files using deeper dir path", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName1 := "sub1/file_test_parts1"
 			fSize1 := int64(1 * 1024)
@@ -417,7 +417,7 @@ func TestSave(t *testing.T) {
 			t.Run(tC.desc, func(t *testing.T) {
 				tmpDir := setupTestDir(t)
 				fs := &FS{root: tmpDir}
-				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+				smMW := storage.NewSplitMergeMW(fs, BytesToGB(tC.partSize))
 
 				fName := "test_split"
 				if tC.file != "" {
@@ -449,7 +449,7 @@ func TestSave(t *testing.T) {
 		t.Run("create empty file", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 			fName := "empty"
 
 			err := smMW.Save(fName, bytes.NewReader([]byte{}))
@@ -559,7 +559,7 @@ func TestSourceReader(t *testing.T) {
 			t.Run(tC.desc, func(t *testing.T) {
 				tmpDir := setupTestDir(t)
 				fs := &FS{root: tmpDir}
-				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+				smMW := storage.NewSplitMergeMW(fs, BytesToGB(tC.partSize))
 
 				fName := "test_merge"
 				if tC.file != "" {
@@ -597,7 +597,7 @@ func TestSourceReader(t *testing.T) {
 	t.Run("file doesn't exist", func(t *testing.T) {
 		tmpDir := setupTestDir(t)
 		fs := &FS{root: tmpDir}
-		smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+		smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 		fName := "no_file"
 
@@ -611,7 +611,7 @@ func TestSourceReader(t *testing.T) {
 	t.Run("empty file", func(t *testing.T) {
 		tmpDir := setupTestDir(t)
 		fs := &FS{root: tmpDir}
-		smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+		smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 		fName := "empty"
 		createEmptyFile(t, tmpDir, fName)
@@ -632,7 +632,7 @@ func TestSourceReader(t *testing.T) {
 	t.Run("SourceReader with the same file name within sub dir", func(t *testing.T) {
 		tmpDir := setupTestDir(t)
 		fs := &FS{root: tmpDir}
-		smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+		smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 		fName := "test_merge_file"
 		fNameInSub := "sub/test_merge_file"
@@ -660,7 +660,7 @@ func TestSourceReader(t *testing.T) {
 		fs := &FS{root: tmpDir}
 		partSize := int64(1024)
 		fileSize := int64(3*1014 + 512)
-		smMW := storage.NewSplitMergeMW(fs, BytesToTB(partSize))
+		smMW := storage.NewSplitMergeMW(fs, BytesToGB(partSize))
 
 		fName := "test_merge_with_closing_stream"
 
@@ -805,7 +805,7 @@ func TestFileStat(t *testing.T) {
 			t.Run(tC.desc, func(t *testing.T) {
 				tmpDir := setupTestDir(t)
 				fs := &FS{root: tmpDir}
-				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+				smMW := storage.NewSplitMergeMW(fs, BytesToGB(tC.partSize))
 
 				fName := "test_file_stat"
 				if tC.file != "" {
@@ -836,7 +836,7 @@ func TestFileStat(t *testing.T) {
 		t.Run("FileStat with the same file within sub dir", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName := "test_file_stat"
 			fSize := int64(1024)
@@ -857,7 +857,7 @@ func TestFileStat(t *testing.T) {
 			fName := "doesnt_exist"
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			_, err := smMW.FileStat(fName)
 			if err != storage.ErrNotExist {
@@ -868,7 +868,7 @@ func TestFileStat(t *testing.T) {
 		t.Run("empty file", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName := "test_file_stat"
 			file, err := os.Create(filepath.Join(tmpDir, fName))
@@ -973,7 +973,7 @@ func TestDelete(t *testing.T) {
 			t.Run(tC.desc, func(t *testing.T) {
 				tmpDir := setupTestDir(t)
 				fs := &FS{root: tmpDir}
-				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+				smMW := storage.NewSplitMergeMW(fs, BytesToGB(tC.partSize))
 
 				fName := "test_rm_file"
 				if tC.file != "" {
@@ -1010,7 +1010,7 @@ func TestDelete(t *testing.T) {
 			partSize := int64(1024)
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(partSize))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(partSize))
 
 			fName := "test_rm_file"
 
@@ -1024,7 +1024,7 @@ func TestDelete(t *testing.T) {
 			partSize := int64(1024)
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(partSize))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(partSize))
 
 			fName := "test_rm_file"
 			createEmptyFile(t, tmpDir, fName)
@@ -1044,7 +1044,7 @@ func TestDelete(t *testing.T) {
 		t.Run("Delete file that contains the same name within sub dir", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName := "test_file_stat"
 			fNameSub := "sub/test_file_stat"
@@ -1071,7 +1071,7 @@ func TestDelete(t *testing.T) {
 		t.Run("Delete dir", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 
 			fName := "test_file_stat"
 			fNameSub := "sub/test_file_stat"
@@ -1177,7 +1177,7 @@ func TestCopy(t *testing.T) {
 			t.Run(tC.desc, func(t *testing.T) {
 				tmpDir := setupTestDir(t)
 				fs := &FS{root: tmpDir}
-				smMW := storage.NewSplitMergeMW(fs, BytesToTB(tC.partSize))
+				smMW := storage.NewSplitMergeMW(fs, BytesToGB(tC.partSize))
 
 				fNameSrc := "test_copy"
 				if tC.file != "" {
@@ -1215,7 +1215,7 @@ func TestCopy(t *testing.T) {
 		t.Run("file doesn't exist", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 			fName := "no_file"
 			fNameDst := "dst/test_copy"
 
@@ -1230,7 +1230,7 @@ func TestCopy(t *testing.T) {
 		t.Run("empty file", func(t *testing.T) {
 			tmpDir := setupTestDir(t)
 			fs := &FS{root: tmpDir}
-			smMW := storage.NewSplitMergeMW(fs, BytesToTB(1024))
+			smMW := storage.NewSplitMergeMW(fs, BytesToGB(1024))
 			fName := "empty"
 			fNameDst := "dst/test_copy"
 			createEmptyFile(t, tmpDir, fName)
@@ -1308,9 +1308,9 @@ func createTestDir(t *testing.T, path string) {
 	}
 }
 
-func BytesToTB(bytes int64) float64 {
-	const TB = 1024 * 1024 * 1024 * 1024
-	return float64(bytes) / TB
+func BytesToGB(bytes int64) float64 {
+	const GB = 1024 * 1024 * 1024
+	return float64(bytes) / GB
 }
 
 func getFileWithParts(t *testing.T, dir, name string) []storage.FileInfo {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultMaxObjSizeTB = 4.9
+	DefaultMaxObjSizeGB = 5018 // 4.9 TB
 )
 
 type Config struct {
@@ -24,7 +24,7 @@ type Config struct {
 	// The maximum number of bytes that the Writer will attempt to send in a single request.
 	// https://pkg.go.dev/cloud.google.com/go/storage#Writer
 	ChunkSize    int      `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
-	MaxObjSizeTB *float64 `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
+	MaxObjSizeGB *float64 `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 
 	Retryer *Retryer `bson:"retryer,omitempty" json:"retryer,omitempty" yaml:"retryer,omitempty"`
 }
@@ -105,7 +105,7 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.ChunkSize != other.ChunkSize {
 		return false
 	}
-	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
+	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
 		return false
 	}
 
@@ -132,11 +132,11 @@ func (cfg *Config) IsSameStorage(other *Config) bool {
 	return true
 }
 
-func (cfg *Config) GetMaxObjSizeTB() float64 {
-	if cfg.MaxObjSizeTB != nil {
-		return *cfg.MaxObjSizeTB
+func (cfg *Config) GetMaxObjSizeGB() float64 {
+	if cfg.MaxObjSizeGB != nil {
+		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeTB
+	return DefaultMaxObjSizeGB
 }
 
 func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
@@ -166,7 +166,7 @@ func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
 		cc:       1,
 	}
 
-	return storage.NewSplitMergeMW(g, opts.GetMaxObjSizeTB()), nil
+	return storage.NewSplitMergeMW(g, opts.GetMaxObjSizeGB()), nil
 }
 
 func (*GCS) Type() storage.Type {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultMaxObjSizeGB = 5018 // 4.9 TB
+	defaultMaxObjSizeGB = 5018 // 4.9 TB
 )
 
 type Config struct {
@@ -136,7 +136,7 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 	if cfg.MaxObjSizeGB != nil {
 		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeGB
+	return defaultMaxObjSizeGB
 }
 
 func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -12,6 +12,10 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
 
+const (
+	DefaultMaxObjSizeTB = 5.0
+)
+
 type Config struct {
 	Bucket      string      `bson:"bucket" json:"bucket" yaml:"bucket"`
 	Prefix      string      `bson:"prefix" json:"prefix" yaml:"prefix"`
@@ -19,7 +23,8 @@ type Config struct {
 
 	// The maximum number of bytes that the Writer will attempt to send in a single request.
 	// https://pkg.go.dev/cloud.google.com/go/storage#Writer
-	ChunkSize int `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
+	ChunkSize    int      `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
+	MaxObjSizeTB *float64 `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
 
 	Retryer *Retryer `bson:"retryer,omitempty" json:"retryer,omitempty" yaml:"retryer,omitempty"`
 }
@@ -100,6 +105,9 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.ChunkSize != other.ChunkSize {
 		return false
 	}
+	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
+		return false
+	}
 
 	if !reflect.DeepEqual(cfg.Credentials, other.Credentials) {
 		return false
@@ -122,6 +130,13 @@ func (cfg *Config) IsSameStorage(other *Config) bool {
 	}
 
 	return true
+}
+
+func (cfg *Config) GetMaxObjSizeTB() float64 {
+	if cfg.MaxObjSizeTB != nil {
+		return *cfg.MaxObjSizeTB
+	}
+	return DefaultMaxObjSizeTB
 }
 
 func New(opts *Config, node string, l log.LogEvent) (*GCS, error) {

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultMaxObjSizeTB = 5.0
+	DefaultMaxObjSizeTB = 4.9
 )
 
 type Config struct {
@@ -139,7 +139,7 @@ func (cfg *Config) GetMaxObjSizeTB() float64 {
 	return DefaultMaxObjSizeTB
 }
 
-func New(opts *Config, node string, l log.LogEvent) (*GCS, error) {
+func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
 	g := &GCS{
 		opts: opts,
 		log:  l,
@@ -166,7 +166,7 @@ func New(opts *Config, node string, l log.LogEvent) (*GCS, error) {
 		cc:       1,
 	}
 
-	return g, nil
+	return storage.NewSplitMergeMW(g, opts.GetMaxObjSizeTB()), nil
 }
 
 func (*GCS) Type() storage.Type {

--- a/pbm/storage/gcs/gcs_test.go
+++ b/pbm/storage/gcs/gcs_test.go
@@ -99,6 +99,8 @@ func TestGCS(t *testing.T) {
 	}
 
 	storage.RunStorageTests(t, stg, storage.GCS)
+	storage.RunStorageAPITests(t, stg)
+	storage.RunSplitMergeMWTests(t, stg)
 
 	t.Run("Delete fails", func(t *testing.T) {
 		name := "not_found.txt"

--- a/pbm/storage/gcs/gcs_test.go
+++ b/pbm/storage/gcs/gcs_test.go
@@ -98,7 +98,7 @@ func TestGCS(t *testing.T) {
 		t.Fatalf("failed to create gcs storage: %s", err)
 	}
 
-	storage.RunStorageTests(t, stg, storage.GCS)
+	storage.RunStorageBaseTests(t, stg, storage.GCS)
 	storage.RunStorageAPITests(t, stg)
 	storage.RunSplitMergeMWTests(t, stg)
 

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -213,7 +213,12 @@ func (g googleClient) copy(src, dst string) error {
 	srcObj := g.bucketHandle.Object(path.Join(g.opts.Prefix, src))
 	dstObj := g.bucketHandle.Object(path.Join(g.opts.Prefix, dst))
 
-	_, err := dstObj.CopierFrom(srcObj).Run(ctx)
+	_, err := g.fileStat(src)
+	if err == storage.ErrNotExist {
+		return err
+	}
+
+	_, err = dstObj.CopierFrom(srcObj).Run(ctx)
 	return err
 }
 

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -542,6 +542,10 @@ func (s *S3) FileStat(name string) (storage.FileInfo, error) {
 // Delete deletes given file.
 // It returns storage.ErrNotExist if a file isn't exists
 func (s *S3) Delete(name string) error {
+	if _, err := s.FileStat(name); err == storage.ErrNotExist {
+		return err
+	}
+
 	_, err := s.s3cli.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 		Bucket: aws.String(s.opts.Bucket),
 		Key:    aws.String(path.Join(s.opts.Prefix, name)),

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -41,7 +41,7 @@ const (
 	defaultRetryerMinRetryDelay = 30 * time.Millisecond
 	defaultRetryerMaxRetryDelay = 300 * time.Second
 
-	DefaultMaxObjSizeGB = 5018 // 4.9 TB
+	defaultMaxObjSizeGB = 5018 // 4.9 TB
 )
 
 //nolint:lll
@@ -254,7 +254,7 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 	if cfg.MaxObjSizeGB != nil {
 		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeGB
+	return defaultMaxObjSizeGB
 }
 
 // SDKLogLevel returns AWS SDK log level value from comma-separated

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -41,7 +41,7 @@ const (
 	defaultRetryerMinRetryDelay = 30 * time.Millisecond
 	defaultRetryerMaxRetryDelay = 300 * time.Second
 
-	DefaultMaxObjSizeTB = 4.9
+	DefaultMaxObjSizeGB = 5018 // 4.9 TB
 )
 
 //nolint:lll
@@ -58,7 +58,7 @@ type Config struct {
 	UploadPartSize       int               `bson:"uploadPartSize,omitempty" json:"uploadPartSize,omitempty" yaml:"uploadPartSize,omitempty"`
 	MaxUploadParts       int32             `bson:"maxUploadParts,omitempty" json:"maxUploadParts,omitempty" yaml:"maxUploadParts,omitempty"`
 	StorageClass         string            `bson:"storageClass,omitempty" json:"storageClass,omitempty" yaml:"storageClass,omitempty"`
-	MaxObjSizeTB         *float64          `bson:"maxObjSizeTB,omitempty" json:"maxObjSizeTB,omitempty" yaml:"maxObjSizeTB,omitempty"`
+	MaxObjSizeGB         *float64          `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 
 	// InsecureSkipTLSVerify disables client verification of the server's
 	// certificate chain and host name
@@ -168,7 +168,7 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.StorageClass != other.StorageClass {
 		return false
 	}
-	if cfg.MaxObjSizeTB != other.MaxObjSizeTB {
+	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
 		return false
 	}
 
@@ -250,11 +250,11 @@ func (cfg *Config) resolveEndpointURL(node string) string {
 	return ep
 }
 
-func (cfg *Config) GetMaxObjSizeTB() float64 {
-	if cfg.MaxObjSizeTB != nil {
-		return *cfg.MaxObjSizeTB
+func (cfg *Config) GetMaxObjSizeGB() float64 {
+	if cfg.MaxObjSizeGB != nil {
+		return *cfg.MaxObjSizeGB
 	}
-	return DefaultMaxObjSizeTB
+	return DefaultMaxObjSizeGB
 }
 
 // SDKLogLevel returns AWS SDK log level value from comma-separated
@@ -339,7 +339,7 @@ func New(opts *Config, node string, l log.LogEvent) (storage.Storage, error) {
 		cc:       1,
 	}
 
-	return storage.NewSplitMergeMW(s, opts.GetMaxObjSizeTB()), nil
+	return storage.NewSplitMergeMW(s, opts.GetMaxObjSizeGB()), nil
 }
 
 func (*S3) Type() storage.Type {

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -40,7 +40,7 @@ const (
 	defaultRetryerMinRetryDelay = 30 * time.Millisecond
 	defaultRetryerMaxRetryDelay = 300 * time.Second
 
-	DefaultMaxObjSizeTB = 5.0
+	DefaultMaxObjSizeTB = 4.9
 )
 
 //nolint:lll

--- a/pbm/storage/s3/s3_test.go
+++ b/pbm/storage/s3/s3_test.go
@@ -74,6 +74,7 @@ func TestS3(t *testing.T) {
 	}
 
 	storage.RunStorageTests(t, stg, storage.S3)
+	storage.RunStorageAPITests(t, stg)
 	storage.RunSplitMergeMWTests(t, stg)
 
 	t.Run("default SDKLogLevel for invalid value", func(t *testing.T) {

--- a/pbm/storage/s3/s3_test.go
+++ b/pbm/storage/s3/s3_test.go
@@ -73,7 +73,7 @@ func TestS3(t *testing.T) {
 		t.Fatalf("failed to create s3 storage: %s", err)
 	}
 
-	storage.RunStorageTests(t, stg, storage.S3)
+	storage.RunStorageBaseTests(t, stg, storage.S3)
 	storage.RunStorageAPITests(t, stg)
 	storage.RunSplitMergeMWTests(t, stg)
 

--- a/pbm/storage/s3/s3_test.go
+++ b/pbm/storage/s3/s3_test.go
@@ -74,6 +74,7 @@ func TestS3(t *testing.T) {
 	}
 
 	storage.RunStorageTests(t, stg, storage.S3)
+	storage.RunSplitMergeMWTests(t, stg)
 
 	t.Run("default SDKLogLevel for invalid value", func(t *testing.T) {
 		logLvl := SDKLogLevel("invalid", nil)

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -201,18 +201,19 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	for _, f := range fi {
 		if f.Name == src {
 			// copy base part
-			sm.s.Copy(src, dstPartName)
+			if err = sm.s.Copy(src, dstPartName); err != nil {
+				return errors.Wrap(err, "copy base part")
+			}
 		} else {
 			dstPartName, err = createNextPart(dstPartName)
 			if err != nil {
 				return errors.Wrap(err, "create next part name")
 			}
-			if err := sm.s.Copy(f.Name, dstPartName); err != nil {
+			if err = sm.s.Copy(f.Name, dstPartName); err != nil {
 				return errors.Wrapf(err, "copy %s to %s", f.Name, dstPartName)
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -193,6 +193,9 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
 	}
+	if len(fi) <= 1 {
+		return sm.s.Copy(src, dst)
+	}
 
 	dstPartName := dst
 	for _, f := range fi {
@@ -200,7 +203,7 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 			// copy base part
 			sm.s.Copy(src, dstPartName)
 		} else {
-			dstPartName, err := createNextPart(dstPartName)
+			dstPartName, err = createNextPart(dstPartName)
 			if err != nil {
 				return errors.Wrap(err, "create next part name")
 			}

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -117,7 +117,7 @@ func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
 	if err != nil {
 		return FileInfo{}, errors.Wrap(err, "list with parts for mw file stat op")
 	}
-	if len(fi) == 0 {
+	if len(fi) <= 1 {
 		// the same behaviour like without mw
 		return sm.s.FileStat(name)
 	}

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -78,7 +78,7 @@ func (sm *SpitMergeMiddleware) Save(name string, data io.Reader, options ...Opti
 }
 
 func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) {
-	fi, err := sm.FileWithParts(name)
+	fi, err := sm.fileWithParts(name)
 	if err != nil {
 		return nil, errors.Wrap(err, "list with parts for mw source reader")
 	}
@@ -112,7 +112,7 @@ func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) 
 }
 
 func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
-	fi, err := sm.FileWithParts(name)
+	fi, err := sm.fileWithParts(name)
 	if err != nil {
 		return FileInfo{}, errors.Wrap(err, "list with parts for mw file stat op")
 	}
@@ -165,7 +165,7 @@ func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
 }
 
 func (sm *SpitMergeMiddleware) Delete(name string) error {
-	fi, err := sm.FileWithParts(name)
+	fi, err := sm.fileWithParts(name)
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
 	}
@@ -183,7 +183,7 @@ func (sm *SpitMergeMiddleware) Delete(name string) error {
 }
 
 func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
-	fi, err := sm.FileWithParts(src)
+	fi, err := sm.fileWithParts(src)
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
 	}
@@ -211,8 +211,8 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	return nil
 }
 
-// FileWithParts fetches file with base name and all it's PBM parts.
-func (sm *SpitMergeMiddleware) FileWithParts(name string) ([]FileInfo, error) {
+// fileWithParts fetches file with base name and all it's PBM parts.
+func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	d, f := path.Split(name)
 	fList, err := sm.s.List(d, "")
 	if err != nil {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -125,8 +125,20 @@ func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
 }
 
 func (sm *SpitMergeMiddleware) Delete(name string) error {
-	return sm.s.Delete(name)
+	fi, err := sm.listWithParts(name)
+	if err != nil {
+		return errors.Wrap(err, "list with parts for mw delete op")
+	}
+
+	for _, f := range fi {
+		if err = sm.s.Delete(f.Name); err != nil {
+			return errors.Wrapf(err, "delete file part: %s", f.Name)
+		}
+	}
+
+	return nil
 }
+
 func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	return sm.s.Copy(src, dst)
 // listWithParts fetches file with base name and all it's PBM parts.

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -219,7 +219,7 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 // fileWithParts fetches file with base name and all it's PBM parts.
 func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	log.Printf("bi: fileWithParts: name=%s", name)
-	d, f := filepath.Split(name)
+	d, f := path.Split(name)
 	fList, err := sm.s.List(d, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "list files for mw list op")
@@ -227,7 +227,7 @@ func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 
 	fiParts := []FileInfo{}
 	for _, fi := range fList {
-		if f == GetBasePart(filepath.Base(fi.Name)) {
+		if f == GetBasePart(path.Base(fi.Name)) {
 			fiParts = append(fiParts, fi)
 		}
 	}
@@ -236,13 +236,13 @@ func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	res := make([]FileInfo, len(fiParts))
 	for _, f := range fiParts {
 		if f.Name == name {
-			res[0] = FileInfo{Name: filepath.Join(d, f.Name), Size: f.Size}
+			res[0] = FileInfo{Name: path.Join(d, f.Name), Size: f.Size}
 		} else {
 			i, err := GetPartIndex(f.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "sort file parts")
 			}
-			res[i] = FileInfo{Name: filepath.Join(d, f.Name), Size: f.Size}
+			res[i] = FileInfo{Name: path.Join(d, f.Name), Size: f.Size}
 		}
 	}
 

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	pbmPartToken = ".pbmpart."
-	TB           = 1024 * 1024 * 1024 * 1024
+	GB           = 1024 * 1024 * 1024
 )
 
 type SplitMergeMiddleware struct {
@@ -21,7 +21,7 @@ type SplitMergeMiddleware struct {
 }
 
 func NewSplitMergeMW(s Storage, maxObjSize float64) Storage {
-	maxObjSizeB := int64(maxObjSize * TB)
+	maxObjSizeB := int64(maxObjSize * GB)
 	return &SplitMergeMiddleware{
 		s:          s,
 		maxObjSize: maxObjSizeB,

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -118,7 +118,6 @@ func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
 		return FileInfo{}, errors.Wrap(err, "list with parts for mw file stat op")
 	}
 	if len(fi) <= 1 {
-		// the same behaviour like without mw
 		return sm.s.FileStat(name)
 	}
 
@@ -152,6 +151,9 @@ func (sm *SpitMergeMiddleware) Delete(name string) error {
 	fi, err := sm.fileWithParts(name)
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
+	}
+	if len(fi) <= 1 {
+		return sm.s.Delete(name)
 	}
 
 	for _, f := range fi {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+)
+
+)
+type SpitMergeMiddleware struct {
+	s Storage
+}
+
+func NewSplitMergeMW(s Storage) Storage {
+	return &SpitMergeMiddleware{
+		s: s,
+	}
+}
+
+func (sm *SpitMergeMiddleware) Type() Type {
+	return sm.s.Type()
+}
+
+func (sm *SpitMergeMiddleware) Save(name string, data io.Reader, options ...Option) error {
+	return sm.s.Save(name, data, options...)
+}
+
+func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) {
+	return sm.s.SourceReader(name)
+}
+
+func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
+	return sm.s.FileStat(name)
+}
+
+func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
+	return sm.s.List(prefix, suffix)
+}
+func (sm *SpitMergeMiddleware) Delete(name string) error {
+	return sm.s.Delete(name)
+}
+func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
+	return sm.s.Copy(src, dst)
+}
+

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -93,7 +93,21 @@ func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) 
 }
 
 func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
-	return sm.s.FileStat(name)
+	fi, err := sm.listWithParts(name)
+	if err != nil {
+		return FileInfo{}, errors.Wrap(err, "list with parts for mw file stat op")
+	}
+
+	totalSize := int64(0)
+	for _, f := range fi {
+		totalSize += f.Size
+	}
+	res := FileInfo{
+		Name: fi[0].Name, // base part has 0 index
+		Size: totalSize,
+	}
+
+	return res, nil
 }
 
 func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -37,6 +37,8 @@ type wInfo struct {
 	err error
 }
 
+// Save intercepts the data stream and splits a large file into multiple pbm parts
+// before saving them to the storage.
 func (sm *SplitMergeMiddleware) Save(name string, data io.Reader, options ...Option) error {
 	fName := name
 
@@ -80,6 +82,7 @@ func (sm *SplitMergeMiddleware) Save(name string, data io.Reader, options ...Opt
 	return nil
 }
 
+// SourceReader merges multiple pbm file parts and returns a single stream.
 func (sm *SplitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) {
 	fi, err := sm.fileWithParts(name)
 	if err != nil &&
@@ -116,6 +119,8 @@ func (sm *SplitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error)
 	return pr, nil
 }
 
+// FileStat returns the combined file information (name & total size) for a file
+// which is split into multiple pbm parts.
 func (sm *SplitMergeMiddleware) FileStat(name string) (FileInfo, error) {
 	fi, err := sm.fileWithParts(name)
 	if err != nil &&
@@ -139,6 +144,8 @@ func (sm *SplitMergeMiddleware) FileStat(name string) (FileInfo, error) {
 	return res, nil
 }
 
+// List returns a list of FileInfo for all files specified with prefix,
+// aggregating information for files split into pbm parts.
 func (sm *SplitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
 	var fi []FileInfo
 	var err error
@@ -171,6 +178,7 @@ func (sm *SplitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) 
 	return res, nil
 }
 
+// Delete handles the deletion of a file, including all of its split parts.
 func (sm *SplitMergeMiddleware) Delete(name string) error {
 	fi, err := sm.fileWithParts(name)
 	if err != nil &&
@@ -191,6 +199,7 @@ func (sm *SplitMergeMiddleware) Delete(name string) error {
 	return nil
 }
 
+// Copy handles copying a file and all its split parts to a new location.
 func (sm *SplitMergeMiddleware) Copy(src, dst string) error {
 	fi, err := sm.fileWithParts(src)
 	if err != nil &&
@@ -222,7 +231,9 @@ func (sm *SplitMergeMiddleware) Copy(src, dst string) error {
 	return nil
 }
 
-// fileWithParts fetches file with base name and all it's PBM parts.
+// fileWithParts fetches a list of FileInfo for the base file and all its PBM parts.
+// The base part has always 0 index, and all other parts have the array index the
+// same as pbm part index.
 func (sm *SplitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	res := []FileInfo{}
 
@@ -293,6 +304,7 @@ func createNextPart(fname string) (string, error) {
 	}
 }
 
+// GetPartIndex extracts the part index from a pbm part file name.
 func GetPartIndex(fname string) (int, error) {
 	partID := 0
 	if isPartFile(fname) {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -102,6 +102,7 @@ func (sm *SplitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error)
 			}
 			if _, err = io.Copy(pw, r); err != nil {
 				pw.CloseWithError(errors.Wrapf(err, "copy file stream: %s:", f.Name))
+				r.Close()
 				return
 			}
 			if err = r.Close(); err != nil {
@@ -112,7 +113,7 @@ func (sm *SplitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error)
 		pw.Close()
 	}()
 
-	return io.NopCloser(pr), nil
+	return pr, nil
 }
 
 func (sm *SplitMergeMiddleware) FileStat(name string) (FileInfo, error) {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -83,7 +83,6 @@ func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) 
 		return nil, errors.Wrap(err, "list with parts for mw source reader")
 	}
 	if len(fi) <= 1 {
-		// the same behaviour like without mw
 		return sm.s.SourceReader(name)
 	}
 

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -10,7 +10,11 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 )
 
+const (
+	pbmPartSize  = 20 * 1024 * 1024 // 20MB
+	pbmPartToken = ".pbmpart."
 )
+
 type SpitMergeMiddleware struct {
 	s Storage
 }
@@ -26,7 +30,38 @@ func (sm *SpitMergeMiddleware) Type() Type {
 }
 
 func (sm *SpitMergeMiddleware) Save(name string, data io.Reader, options ...Option) error {
-	return sm.s.Save(name, data, options...)
+	fName := name
+
+	errC := make(chan error)
+	for {
+		pr, pw := io.Pipe()
+
+		go func() {
+			_, err := io.CopyN(pw, data, pbmPartSize)
+			pw.Close()
+			errC <- err
+		}()
+
+		err := sm.s.Save(fName, pr, options...)
+		if err != nil {
+			return errors.Wrap(err, "save during split-merge mw")
+		}
+
+		wErr := <-errC
+		if wErr != nil {
+			if wErr == io.EOF {
+				break
+			}
+			return errors.Wrap(err, "write pipeline split-merge mw")
+		}
+
+		fName, err = createNextPart(fName)
+		if err != nil {
+			return errors.Wrap(err, "pbm part name creation")
+		}
+	}
+
+	return nil
 }
 
 func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) {
@@ -47,3 +82,33 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	return sm.s.Copy(src, dst)
 }
 
+// createNextPart returns file name for the next pbm part.
+// Input for the name creation is the last part name: base part or any indexed part.
+// For part names PBM uses following naming schema:
+// file_name.pbmpart.15, where:
+// - file_name is the base file name
+// - `.pbmpart.` is token that identifies PBM's multi files schema naming
+// - 15 is part index
+//
+// Example of PBM's multi-files schena on disk:
+// collection-14-4294136943066280761.wt <-- base part, it has zero-based index which is omitted
+// collection-14-4294136943066280761.wt.pbmpart.1 <-- second part (part index 1)
+// collection-14-4294136943066280761.wt.pbmpart.2 <-- third part (part index 2)
+// collection-14-4294136943066280761.wt.pbmpart.3 <-- the last part
+func createNextPart(fname string) (string, error) {
+	if strings.Contains(fname, pbmPartToken) {
+		fileParts := strings.Split(fname, ".")
+
+		partID, err := strconv.Atoi(fileParts[len(fileParts)-1])
+		if err != nil {
+			return "", errors.Wrap(err, "parsing id pbm part")
+		}
+		partID++
+
+		fNewName := fmt.Sprintf("%s.%d", strings.Join(fileParts[:len(fileParts)-1], "."), partID)
+		return fNewName, nil
+	} else {
+		// creating part name based on base part: e.g. base-file.pbmpart.1
+		return fmt.Sprintf("%s%s1", fname, pbmPartToken), nil
+	}
+}

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -73,8 +73,19 @@ func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
 }
 
 func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
-	return sm.s.List(prefix, suffix)
+	fi, err := sm.s.List(prefix, suffix)
+	if err != nil {
+		return nil, errors.Wrap(err, "list files")
+	}
+
+	res := slices.DeleteFunc(
+		fi,
+		func(f FileInfo) bool { return strings.Contains(f.Name, pbmPartToken) },
+	)
+
+	return res, nil
 }
+
 func (sm *SpitMergeMiddleware) Delete(name string) error {
 	return sm.s.Delete(name)
 }

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -262,17 +262,6 @@ func (sm *SplitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	return res, nil
 }
 
-// setPartsSize set pbm part size (in bytes) for the purpose of unit testing.
-func (sm *SplitMergeMiddleware) setPartsSize(maxObjSize int64) {
-	sm.maxObjSize = maxObjSize
-}
-
-// getStorage returns Storage object that MW is based on.
-// The only purpose for this method is unit testing.
-func (sm *SplitMergeMiddleware) getStorage() Storage {
-	return sm.s
-}
-
 // createNextPart returns file name for the next pbm part.
 // Input for the name creation is the last part name: base part or any indexed part.
 // For part names PBM uses following naming schema:
@@ -327,8 +316,7 @@ func GetBasePart(fname string) string {
 
 	pattern := regexp.MustCompile(`\.pbmpart\.\d+$`)
 	if pattern.MatchString(fname) {
-		fileParts := strings.Split(fname, ".")
-		base = strings.Join(fileParts[:len(fileParts)-2], ".")
+		base = strings.Split(fname, pbmPartToken)[0]
 	}
 
 	return base

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -78,7 +78,7 @@ func (sm *SpitMergeMiddleware) Save(name string, data io.Reader, options ...Opti
 }
 
 func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) {
-	fi, err := sm.fileWithParts(name)
+	fi, err := sm.FileWithParts(name)
 	if err != nil {
 		return nil, errors.Wrap(err, "list with parts for mw source reader")
 	}
@@ -112,7 +112,7 @@ func (sm *SpitMergeMiddleware) SourceReader(name string) (io.ReadCloser, error) 
 }
 
 func (sm *SpitMergeMiddleware) FileStat(name string) (FileInfo, error) {
-	fi, err := sm.fileWithParts(name)
+	fi, err := sm.FileWithParts(name)
 	if err != nil {
 		return FileInfo{}, errors.Wrap(err, "list with parts for mw file stat op")
 	}
@@ -165,7 +165,7 @@ func (sm *SpitMergeMiddleware) List(prefix, suffix string) ([]FileInfo, error) {
 }
 
 func (sm *SpitMergeMiddleware) Delete(name string) error {
-	fi, err := sm.fileWithParts(name)
+	fi, err := sm.FileWithParts(name)
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
 	}
@@ -183,7 +183,7 @@ func (sm *SpitMergeMiddleware) Delete(name string) error {
 }
 
 func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
-	fi, err := sm.fileWithParts(src)
+	fi, err := sm.FileWithParts(src)
 	if err != nil {
 		return errors.Wrap(err, "list with parts for mw delete op")
 	}
@@ -211,8 +211,8 @@ func (sm *SpitMergeMiddleware) Copy(src, dst string) error {
 	return nil
 }
 
-// fileWithParts fetches file with base name and all it's PBM parts.
-func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
+// FileWithParts fetches file with base name and all it's PBM parts.
+func (sm *SpitMergeMiddleware) FileWithParts(name string) ([]FileInfo, error) {
 	d, f := path.Split(name)
 	fList, err := sm.s.List(d, "")
 	if err != nil {
@@ -241,6 +241,11 @@ func (sm *SpitMergeMiddleware) fileWithParts(name string) ([]FileInfo, error) {
 	}
 
 	return res, nil
+}
+
+// setPartsSize set pbm part size (in bytes) for the purpose of unit testing.
+func (sm *SpitMergeMiddleware) setPartsSize(maxObjSize int64) {
+	sm.maxObjSize = maxObjSize
 }
 
 // createNextPart returns file name for the next pbm part.

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -91,7 +91,7 @@ func TestGetPartIndex(t *testing.T) {
 		fname := "file_name"
 		want := 0
 
-		got, err := getPartIndex(fname)
+		got, err := GetPartIndex(fname)
 
 		if err != nil {
 			t.Errorf("got error: %v", err)
@@ -105,7 +105,7 @@ func TestGetPartIndex(t *testing.T) {
 		fname := "file_name.pbmpart.15"
 		want := 15
 
-		got, err := getPartIndex(fname)
+		got, err := GetPartIndex(fname)
 
 		if err != nil {
 			t.Errorf("got error: %v", err)
@@ -118,7 +118,7 @@ func TestGetPartIndex(t *testing.T) {
 	t.Run("error while parsing index", func(t *testing.T) {
 		fname := "file_name.pbmpart.X"
 
-		got, err := getPartIndex(fname)
+		got, err := GetPartIndex(fname)
 
 		if err == nil {
 			t.Error("want error, get nil")
@@ -132,7 +132,7 @@ func TestGetPartIndex(t *testing.T) {
 		fname := ".pbmpart.5"
 		want := 5
 
-		got, err := getPartIndex(fname)
+		got, err := GetPartIndex(fname)
 
 		if err != nil {
 			t.Errorf("got error: %v", err)
@@ -145,7 +145,7 @@ func TestGetPartIndex(t *testing.T) {
 	t.Run("token exists, index doesn't", func(t *testing.T) {
 		fname := "file_name.pbmpart."
 
-		got, err := getPartIndex(fname)
+		got, err := GetPartIndex(fname)
 
 		if err == nil {
 			t.Error("want error, get nil")

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -1,0 +1,87 @@
+package storage
+
+import "testing"
+
+func TestCreateNextPart(t *testing.T) {
+	t.Run("next part for base file", func(t *testing.T) {
+		fname := "file_name"
+		want := "file_name.pbmpart.1"
+
+		got, err := createNextPart(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%s, got=%v", want, got)
+		}
+	})
+
+	t.Run("next part for the first part", func(t *testing.T) {
+		fname := "file_name.pbmpart.1"
+		want := "file_name.pbmpart.2"
+
+		got, err := createNextPart(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%s, got=%v", want, got)
+		}
+	})
+
+	t.Run("next part for index 9", func(t *testing.T) {
+		fname := "file_name.pbmpart.9"
+		want := "file_name.pbmpart.10"
+
+		got, err := createNextPart(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%s, got=%v", want, got)
+		}
+	})
+
+	t.Run("error while parsing index", func(t *testing.T) {
+		fname := "file_name.pbmpart.X"
+
+		got, err := createNextPart(fname)
+
+		if err == nil {
+			t.Error("want error, get nil")
+		}
+		if got != "" {
+			t.Error("file name should be empty string")
+		}
+	})
+
+	t.Run("token exists, base part doesn't", func(t *testing.T) {
+		fname := ".pbmpart.5"
+		want := ".pbmpart.6"
+
+		got, err := createNextPart(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%s, got=%v", want, got)
+		}
+	})
+
+	t.Run("token exists, index doesn't", func(t *testing.T) {
+		fname := "file_name.pbmpart."
+
+		got, err := createNextPart(fname)
+
+		if err == nil {
+			t.Error("want error, get nil")
+		}
+		if got != "" {
+			t.Error("file name should be empty string")
+		}
+	})
+}

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -8,7 +8,6 @@ func TestCreateNextPart(t *testing.T) {
 		want := "file_name.pbmpart.1"
 
 		got, err := createNextPart(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -22,7 +21,6 @@ func TestCreateNextPart(t *testing.T) {
 		want := "file_name.pbmpart.2"
 
 		got, err := createNextPart(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -36,7 +34,6 @@ func TestCreateNextPart(t *testing.T) {
 		want := "file_name.pbmpart.10"
 
 		got, err := createNextPart(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -49,7 +46,6 @@ func TestCreateNextPart(t *testing.T) {
 		fname := "file_name.pbmpart.X"
 
 		got, err := createNextPart(fname)
-
 		if err == nil {
 			t.Error("want error, get nil")
 		}
@@ -63,7 +59,6 @@ func TestCreateNextPart(t *testing.T) {
 		want := ".pbmpart.6"
 
 		got, err := createNextPart(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -76,7 +71,6 @@ func TestCreateNextPart(t *testing.T) {
 		fname := "file_name.pbmpart."
 
 		got, err := createNextPart(fname)
-
 		if err == nil {
 			t.Error("want error, get nil")
 		}
@@ -92,7 +86,6 @@ func TestGetPartIndex(t *testing.T) {
 		want := 0
 
 		got, err := GetPartIndex(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -106,7 +99,6 @@ func TestGetPartIndex(t *testing.T) {
 		want := 15
 
 		got, err := GetPartIndex(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -119,7 +111,6 @@ func TestGetPartIndex(t *testing.T) {
 		fname := "file_name.pbmpart.X"
 
 		got, err := GetPartIndex(fname)
-
 		if err == nil {
 			t.Error("want error, get nil")
 		}
@@ -133,7 +124,6 @@ func TestGetPartIndex(t *testing.T) {
 		want := 5
 
 		got, err := GetPartIndex(fname)
-
 		if err != nil {
 			t.Errorf("got error: %v", err)
 		}
@@ -146,7 +136,6 @@ func TestGetPartIndex(t *testing.T) {
 		fname := "file_name.pbmpart."
 
 		got, err := GetPartIndex(fname)
-
 		if err == nil {
 			t.Error("want error, get nil")
 		}

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -13,7 +13,7 @@ func TestCreateNextPart(t *testing.T) {
 			t.Errorf("got error: %v", err)
 		}
 		if got != want {
-			t.Errorf("want=%s, got=%v", want, got)
+			t.Errorf("want=%s, got=%s", want, got)
 		}
 	})
 
@@ -27,7 +27,7 @@ func TestCreateNextPart(t *testing.T) {
 			t.Errorf("got error: %v", err)
 		}
 		if got != want {
-			t.Errorf("want=%s, got=%v", want, got)
+			t.Errorf("want=%s, got=%s", want, got)
 		}
 	})
 
@@ -41,7 +41,7 @@ func TestCreateNextPart(t *testing.T) {
 			t.Errorf("got error: %v", err)
 		}
 		if got != want {
-			t.Errorf("want=%s, got=%v", want, got)
+			t.Errorf("want=%s, got=%s", want, got)
 		}
 	})
 
@@ -68,7 +68,7 @@ func TestCreateNextPart(t *testing.T) {
 			t.Errorf("got error: %v", err)
 		}
 		if got != want {
-			t.Errorf("want=%s, got=%v", want, got)
+			t.Errorf("want=%s, got=%s", want, got)
 		}
 	})
 
@@ -82,6 +82,76 @@ func TestCreateNextPart(t *testing.T) {
 		}
 		if got != "" {
 			t.Error("file name should be empty string")
+		}
+	})
+}
+
+func TestGetPartIndex(t *testing.T) {
+	t.Run("index for base file", func(t *testing.T) {
+		fname := "file_name"
+		want := 0
+
+		got, err := getPartIndex(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%d, got=%d", want, got)
+		}
+	})
+
+	t.Run("index for file which has it", func(t *testing.T) {
+		fname := "file_name.pbmpart.15"
+		want := 15
+
+		got, err := getPartIndex(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%d, got=%d", want, got)
+		}
+	})
+
+	t.Run("error while parsing index", func(t *testing.T) {
+		fname := "file_name.pbmpart.X"
+
+		got, err := getPartIndex(fname)
+
+		if err == nil {
+			t.Error("want error, get nil")
+		}
+		if got != 0 {
+			t.Error("index should be 0")
+		}
+	})
+
+	t.Run("token exists, base part doesn't", func(t *testing.T) {
+		fname := ".pbmpart.5"
+		want := 5
+
+		got, err := getPartIndex(fname)
+
+		if err != nil {
+			t.Errorf("got error: %v", err)
+		}
+		if got != want {
+			t.Errorf("want=%d, got=%d", want, got)
+		}
+	})
+
+	t.Run("token exists, index doesn't", func(t *testing.T) {
+		fname := "file_name.pbmpart."
+
+		got, err := getPartIndex(fname)
+
+		if err == nil {
+			t.Error("want error, get nil")
+		}
+		if got != 0 {
+			t.Error("index should be 0")
 		}
 	})
 }

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -298,9 +298,7 @@ func ComputePartSize(fileSize, defaultSize, minSize, maxParts, userSize int64) i
 
 	if userSize > 0 {
 		partSize = userSize
-		if partSize < minSize {
-			partSize = minSize
-		}
+		partSize = max(partSize, minSize)
 	}
 
 	if fileSize > 0 {

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -338,4 +339,28 @@ func PrettySize(size int64) string {
 		return fmt.Sprintf("%.2fKB", s/KB)
 	}
 	return fmt.Sprintf("%.2fB", s)
+}
+
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string {
+	return e.Err.Error()
+}
+
+func IsRetryableError(err error) bool {
+	var e *RetryableError
+	return errors.As(err, &e)
+}
+
+func RetryableWrite(stg Storage, name string, data []byte) error {
+	err := stg.Save(name, bytes.NewBuffer(data), Size(int64(len(data))))
+	if err != nil && stg.Type() == Filesystem {
+		if IsRetryableError(err) {
+			err = stg.Save(name, bytes.NewBuffer(data), Size(int64(len(data))))
+		}
+	}
+
+	return err
 }

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -158,7 +158,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 	t.Helper()
 
 	// remove MW
-	stg = stg.(*SplitMergeMiddleware).getStorage()
+	stg = stg.(*SplitMergeMiddleware).s
 
 	t.Run("storage api", func(t *testing.T) {
 		t.Run("Save", func(t *testing.T) {
@@ -362,7 +362,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
 				mw := stg.(*SplitMergeMiddleware)
-				mw.setPartsSize(tC.partSize)
+				mw.maxObjSize = tC.partSize
 
 				fName := "test_split" + randomSuffix()
 				if tC.file != "" {
@@ -395,7 +395,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 
 		t.Run("empty file", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			mw.setPartsSize(1024)
+			mw.maxObjSize = 1024
 			name := "empty" + randomSuffix()
 
 			err := mw.Save(name, strings.NewReader(""))
@@ -467,7 +467,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
 				mw := stg.(*SplitMergeMiddleware)
-				mw.setPartsSize(tC.partSize)
+				mw.maxObjSize = tC.partSize
 
 				fName := "test_merge" + randomSuffix()
 				if tC.file != "" {
@@ -503,7 +503,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 
 		t.Run("file doesn't exist", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			mw.setPartsSize(1024)
+			mw.maxObjSize = 1024
 			name := "doesnt_exist"
 
 			_, err := mw.SourceReader(name)
@@ -514,7 +514,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 
 		t.Run("empty file", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			mw.setPartsSize(1024)
+			mw.maxObjSize = 1024
 			fName := "empty" + randomSuffix()
 
 			err := mw.Save(fName, strings.NewReader(""))
@@ -531,7 +531,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		t.Run("closing the stream when using split-merge middleware", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
 			partSize := int64(1024)
-			mw.setPartsSize(partSize)
+			mw.maxObjSize = partSize
 			fileSize := int64(3*1014 + 512)
 
 			fName := "test_merge_with_closing_stream" + randomSuffix()
@@ -642,7 +642,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
 				mw := stg.(*SplitMergeMiddleware)
-				mw.setPartsSize(tC.partSize)
+				mw.maxObjSize = tC.partSize
 
 				fName := "test_file_stat" + randomSuffix()
 				if tC.file != "" {
@@ -745,7 +745,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
 				mw := stg.(*SplitMergeMiddleware)
-				mw.setPartsSize(tC.partSize)
+				mw.maxObjSize = tC.partSize
 
 				dir := randomSuffix()
 				fName := "test_rm_file"
@@ -848,7 +848,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
 				mw := stg.(*SplitMergeMiddleware)
-				mw.setPartsSize(tC.partSize)
+				mw.maxObjSize = tC.partSize
 
 				fNameSrc := "test_copy" + randomSuffix()
 				if tC.file != "" {
@@ -885,7 +885,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 
 		t.Run("file doesn't exist", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			mw.setPartsSize(1024)
+			mw.maxObjSize = 1024
 
 			name := "doesnt_exist" + randomSuffix()
 			dstName := "dst/" + name
@@ -898,7 +898,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 
 		t.Run("empty file", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			mw.setPartsSize(1024)
+			mw.maxObjSize = 1024
 
 			name := "empty" + randomSuffix()
 			dstName := "dst/" + name

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -158,7 +158,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 	t.Helper()
 
 	// remove MW
-	stg = stg.(*SpitMergeMiddleware).getStorage()
+	stg = stg.(*SplitMergeMiddleware).getStorage()
 
 	t.Run("storage api", func(t *testing.T) {
 		t.Run("Save", func(t *testing.T) {
@@ -329,7 +329,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
-				mw := stg.(*SpitMergeMiddleware)
+				mw := stg.(*SplitMergeMiddleware)
 				mw.setPartsSize(tC.partSize)
 
 				fName := "test_split" + randomSuffix()
@@ -362,7 +362,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 
 		t.Run("empty file", func(t *testing.T) {
-			mw := stg.(*SpitMergeMiddleware)
+			mw := stg.(*SplitMergeMiddleware)
 			mw.setPartsSize(1024)
 			name := "empty"
 
@@ -434,7 +434,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
-				mw := stg.(*SpitMergeMiddleware)
+				mw := stg.(*SplitMergeMiddleware)
 				mw.setPartsSize(tC.partSize)
 
 				fName := "test_merge" + randomSuffix()
@@ -538,7 +538,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
-				mw := stg.(*SpitMergeMiddleware)
+				mw := stg.(*SplitMergeMiddleware)
 				mw.setPartsSize(tC.partSize)
 
 				fName := "test_file_stat" + randomSuffix()
@@ -568,7 +568,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 
 		t.Run("file doesn't exist", func(t *testing.T) {
-			mw := stg.(*SpitMergeMiddleware)
+			mw := stg.(*SplitMergeMiddleware)
 			fName := "test_fs" + randomSuffix()
 
 			_, err := mw.FileStat(fName)
@@ -578,7 +578,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		})
 
 		t.Run("empty file", func(t *testing.T) {
-			mw := stg.(*SpitMergeMiddleware)
+			mw := stg.(*SplitMergeMiddleware)
 			fName := "empty" + randomSuffix()
 			err := stg.Save(fName, strings.NewReader(""))
 			if err != nil {
@@ -641,7 +641,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
-				mw := stg.(*SpitMergeMiddleware)
+				mw := stg.(*SplitMergeMiddleware)
 				mw.setPartsSize(tC.partSize)
 
 				dir := randomSuffix()
@@ -676,7 +676,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 
 		t.Run("file doesn't exist", func(t *testing.T) {
-			mw := stg.(*SpitMergeMiddleware)
+			mw := stg.(*SplitMergeMiddleware)
 			fName := "test_rm_file" + randomSuffix()
 
 			err := mw.Delete(fName)
@@ -686,7 +686,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		})
 
 		t.Run("empty file", func(t *testing.T) {
-			mw := stg.(*SpitMergeMiddleware)
+			mw := stg.(*SplitMergeMiddleware)
 			fName := "empty"
 			err := stg.Save(fName, strings.NewReader(""))
 			if err != nil {
@@ -741,7 +741,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		}
 		for _, tC := range testCases {
 			t.Run(tC.desc, func(t *testing.T) {
-				mw := stg.(*SpitMergeMiddleware)
+				mw := stg.(*SplitMergeMiddleware)
 				mw.setPartsSize(tC.partSize)
 
 				fNameSrc := "test_copy" + randomSuffix()

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -248,7 +248,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 					t.Fatalf("error while saving file: %v", err)
 				}
 
-				fi, err := mw.FileWithParts(fName)
+				fi, err := mw.fileWithParts(fName)
 				if err != nil {
 					t.Fatalf("error while getting parts: %v", err)
 				}

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -623,5 +623,4 @@ func randomSuffix() string {
 	randomBytes := make([]byte, 8)
 	_, _ = rand.Read(randomBytes)
 	return hex.EncodeToString(randomBytes)
-
 }

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -163,7 +163,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 	t.Run("storage api", func(t *testing.T) {
 		t.Run("Save", func(t *testing.T) {
 			t.Run("create empty file", func(t *testing.T) {
-				name := "empty"
+				name := "empty" + randomSuffix()
 
 				err := stg.Save(name, strings.NewReader(""))
 				if err != nil {
@@ -179,7 +179,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 
 		t.Run("SourceReader", func(t *testing.T) {
 			t.Run("file doesn't exist", func(t *testing.T) {
-				name := "doesnt_exist"
+				name := "doesnt_exist" + randomSuffix()
 
 				_, err := stg.SourceReader(name)
 				if !errors.Is(err, ErrNotExist) {
@@ -188,7 +188,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 			})
 
 			t.Run("empty file", func(t *testing.T) {
-				fName := "empty"
+				fName := "empty" + randomSuffix()
 				err := stg.Save(fName, strings.NewReader(""))
 				if err != nil {
 					t.Fatalf("Save failed: %s", err)
@@ -203,16 +203,18 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 
 		t.Run("Delete", func(t *testing.T) {
 			t.Run("file doesn't exist", func(t *testing.T) {
-				name := "doesnt_exist"
+				name := "doesnt_exist" + randomSuffix()
 
 				err := stg.Delete(name)
-				if err != nil {
-					t.Fatalf("error reported while invoking Delete on non-existing file: %v", err)
+
+				wantErr := ErrNotExist
+				if err != wantErr {
+					t.Fatalf("error reported while invoking Delete on non-existing file: want=%v, got=%v", wantErr, err)
 				}
 			})
 
 			t.Run("empty file", func(t *testing.T) {
-				fName := "empty"
+				fName := "empty" + randomSuffix()
 				err := stg.Save(fName, strings.NewReader(""))
 				if err != nil {
 					t.Fatalf("Save failed: %s", err)
@@ -227,7 +229,7 @@ func RunStorageAPITests(t *testing.T, stg Storage) {
 
 		t.Run("FileStat", func(t *testing.T) {
 			t.Run("file doesn't exist", func(t *testing.T) {
-				name := "doesnt_exist"
+				name := "doesnt_exist" + randomSuffix()
 
 				_, err := stg.FileStat(name)
 				if err != ErrNotExist {
@@ -364,7 +366,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		t.Run("empty file", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
 			mw.setPartsSize(1024)
-			name := "empty"
+			name := "empty" + randomSuffix()
 
 			err := mw.Save(name, strings.NewReader(""))
 			if err != nil {
@@ -479,7 +481,7 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 		})
 
 		t.Run("empty file", func(t *testing.T) {
-			fName := "empty"
+			fName := "empty" + randomSuffix()
 			err := stg.Save(fName, strings.NewReader(""))
 			if err != nil {
 				t.Fatalf("Save failed: %s", err)
@@ -680,14 +682,16 @@ func RunSplitMergeMWTests(t *testing.T, stg Storage) {
 			fName := "test_rm_file" + randomSuffix()
 
 			err := mw.Delete(fName)
-			if err != nil {
-				t.Fatalf("error reported while invoking Delete non-existing file: %v", err)
+
+			wantErr := ErrNotExist
+			if err != wantErr {
+				t.Fatalf("error reported while invoking Delete on non-existing file: want=%v, got=%v", wantErr, err)
 			}
 		})
 
 		t.Run("empty file", func(t *testing.T) {
 			mw := stg.(*SplitMergeMiddleware)
-			fName := "empty"
+			fName := "empty" + randomSuffix()
 			err := stg.Save(fName, strings.NewReader(""))
 			if err != nil {
 				t.Fatalf("Save failed: %s", err)

--- a/pbm/storage/storage_test_helpers.go
+++ b/pbm/storage/storage_test_helpers.go
@@ -1,7 +1,11 @@
 package storage
 
 import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"io"
+	"path"
 	"strings"
 	"testing"
 )
@@ -146,4 +150,478 @@ func RunStorageTests(t *testing.T, stg Storage, stgType Type) {
 			t.Errorf("expected content %s, got %s", content, string(data))
 		}
 	})
+}
+
+func RunSplitMergeMWTests(t *testing.T, stg Storage) {
+	t.Helper()
+
+	t.Run("Save with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc      string
+			partSize  int64
+			fileSize  int64
+			file      string
+			wantParts int
+		}{
+			{
+				desc:      "basic use case for splitting files",
+				partSize:  10 * 1024,
+				fileSize:  23 * 1024,
+				wantParts: 3,
+			},
+			{
+				desc:      "splitting 100s of files",
+				partSize:  1 * 1024,
+				fileSize:  220*1024 + 555,
+				wantParts: 221,
+			},
+			{
+				desc:      "splitting 1000s of files",
+				partSize:  1 * 512,
+				fileSize:  1100*1024 + 1,
+				wantParts: 2201,
+			},
+			{
+				desc:      "file of the same size as part",
+				partSize:  5 * 1024 * 1024,
+				fileSize:  5 * 1024 * 1024,
+				wantParts: 1,
+			},
+			{
+				desc:      "file size is a multiple of part",
+				partSize:  12 * 1024 * 1024,
+				fileSize:  48 * 1024 * 1024,
+				wantParts: 4,
+			},
+			{
+				desc:      "single file little bit bigger than part",
+				partSize:  15 * 1024 * 1024,
+				fileSize:  15*1024*1024 + 2,
+				wantParts: 2,
+			},
+			{
+				desc:      "single file that's a bit smaller than part",
+				partSize:  7 * 1024 * 1024,
+				fileSize:  7*1024*1024 - 1,
+				wantParts: 1,
+			},
+			{
+				desc:      "lots of parts and one smaller part",
+				partSize:  7 * 1024,
+				fileSize:  490*1024 + 1,
+				wantParts: 71,
+			},
+			{
+				desc:      "empty file",
+				partSize:  10 * 1024,
+				fileSize:  0,
+				wantParts: 0,
+			},
+			{
+				desc:      "1 byte file",
+				partSize:  14 * 1024,
+				fileSize:  1,
+				wantParts: 1,
+			},
+			{
+				desc:      "file in sub dir",
+				partSize:  1024,
+				fileSize:  3*1024 + 1,
+				file:      "sub/file_in_sub",
+				wantParts: 4,
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				mw := stg.(*SpitMergeMiddleware)
+				mw.setPartsSize(tC.partSize)
+
+				fName := "test_split" + randomSuffix()
+				if tC.file != "" {
+					fName = tC.file
+				}
+				fContent := make([]byte, tC.fileSize)
+				r := bytes.NewReader(fContent)
+
+				err := mw.Save(fName, r)
+				if err != nil {
+					t.Fatalf("error while saving file: %v", err)
+				}
+
+				fi, err := mw.FileWithParts(fName)
+				if err != nil {
+					t.Fatalf("error while getting parts: %v", err)
+				}
+				if len(fi) != tC.wantParts {
+					t.Fatalf("wrong number of splitted files: want=%d, got=%d", tC.wantParts, len(fi))
+				}
+
+				wantSizes := CalcPartSizes(tC.partSize, tC.fileSize)
+				for i := range len(fi) {
+					if wantSizes[i] != fi[i].Size {
+						t.Fatalf("wrong file size for file: %s: want=%d, got=%d", fi[i].Name, wantSizes[i], fi[i].Size)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("SourceReader with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc           string
+			partSize       int64
+			mergedFileSize int64
+			file           string
+		}{
+			{
+				desc:           "basic use case for merging parts",
+				partSize:       1024,
+				mergedFileSize: 11 * 1024,
+			},
+			{
+				desc:           "merging 100s of parts",
+				partSize:       199,
+				mergedFileSize: 300*199 + 444,
+			},
+			{
+				desc:           "merging 1000s of parts",
+				partSize:       57,
+				mergedFileSize: 57*1023 + 15,
+			},
+			{
+				desc:           "single part file smaller than part size",
+				partSize:       5 * 1024,
+				mergedFileSize: 4*1024 + 123,
+			},
+			{
+				desc:           "single part file, the same size as part size",
+				partSize:       2 * 1024 * 1024,
+				mergedFileSize: 2 * 1024 * 1024,
+			},
+			{
+				desc:           "merged file size is multiple of part size",
+				partSize:       10 * 1024 * 1024,
+				mergedFileSize: 5 * 10 * 1024 * 1024,
+			},
+			{
+				desc:           "merged file size is for single byte bigger than part",
+				partSize:       50 * 1024,
+				mergedFileSize: 50*1024 + 1,
+			},
+			{
+				desc:           "1 byte file",
+				partSize:       20 * 1024,
+				mergedFileSize: 1,
+			},
+			{
+				desc:           "file within dir",
+				partSize:       1024,
+				mergedFileSize: 4 * 1024,
+				file:           "sub/test_merge_in_sub",
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				mw := stg.(*SpitMergeMiddleware)
+				mw.setPartsSize(tC.partSize)
+
+				fName := "test_merge" + randomSuffix()
+				if tC.file != "" {
+					fName = tC.file + randomSuffix()
+				}
+				// create test parts
+				srcContent := make([]byte, tC.mergedFileSize)
+				r := bytes.NewReader(srcContent)
+				err := mw.Save(fName, r)
+				if err != nil {
+					t.Fatalf("error while creating test parts: %v", err)
+				}
+
+				rc, err := mw.SourceReader(fName)
+				if err != nil {
+					t.Fatalf("error while invoking SourceReader: %v", err)
+				}
+
+				dstContent, err := io.ReadAll(rc)
+				if err != nil {
+					t.Fatalf("reading merged file: %v", err)
+				}
+
+				if tC.mergedFileSize != int64(len(dstContent)) {
+					t.Fatalf("wrong file size after merge, want=%d, got=%d", tC.mergedFileSize, len(dstContent))
+				}
+
+				if !bytes.Equal(srcContent, dstContent) {
+					t.Fatal("merged file content doesn't match")
+				}
+			})
+		}
+	})
+
+	t.Run("FileStat with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc          string
+			partSize      int64
+			totalFileSize int64
+			file          string
+		}{
+			{
+				desc:          "basic use caser for FileStat",
+				partSize:      5 * 1024,
+				totalFileSize: 10*5*1024 + 456,
+			},
+			{
+				desc:          "stat for 100s of parts",
+				partSize:      456,
+				totalFileSize: 123*456 + 789,
+			},
+			{
+				desc:          "stat for 1000s of parts",
+				partSize:      123,
+				totalFileSize: 4567*123 + 1,
+			},
+			{
+				desc:          "single part",
+				partSize:      1024 * 1024,
+				totalFileSize: 1024 * 1024,
+			},
+			{
+				desc:          "two parts",
+				partSize:      1024 * 1024,
+				totalFileSize: 2 * 1024 * 1024,
+			},
+			{
+				desc:          "1 byte file",
+				partSize:      20 * 1024,
+				totalFileSize: 1,
+			},
+			{
+				desc:          "file in dir",
+				partSize:      4 * 1024,
+				totalFileSize: 4*1024 + 456,
+				file:          "sub/test_stat_in_dir",
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				mw := stg.(*SpitMergeMiddleware)
+				mw.setPartsSize(tC.partSize)
+
+				fName := "test_file_stat" + randomSuffix()
+				if tC.file != "" {
+					fName = tC.file + randomSuffix()
+				}
+				// create test parts
+				srcContent := make([]byte, tC.totalFileSize)
+				r := bytes.NewReader(srcContent)
+				err := mw.Save(fName, r)
+				if err != nil {
+					t.Fatalf("error while creating test parts: %v", err)
+				}
+
+				fInfo, err := mw.FileStat(fName)
+				if err != nil {
+					t.Fatalf("error while invoking FileStat: %v", err)
+				}
+
+				if fInfo.Name != fName {
+					t.Fatalf("wrong file name, want=%s, got=%s", fName, fInfo.Name)
+				}
+				if fInfo.Size != tC.totalFileSize {
+					t.Fatalf("wrong file size, want=%d, got=%d", tC.totalFileSize, fInfo.Size)
+				}
+			})
+		}
+	})
+
+	t.Run("Delete with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc          string
+			partSize      int64
+			totalFileSize int64
+			file          string
+		}{
+			{
+				desc:          "basic use caser for Delete",
+				partSize:      5 * 1024,
+				totalFileSize: 10*5*1024 + 456,
+			},
+			{
+				desc:          "stat for 100s of parts",
+				partSize:      456,
+				totalFileSize: 123*456 + 789,
+			},
+			{
+				desc:          "stat for 1000s of parts",
+				partSize:      123,
+				totalFileSize: 4567*123 + 1,
+			},
+			{
+				desc:          "single part",
+				partSize:      1024 * 1024,
+				totalFileSize: 1024 * 1024,
+			},
+			{
+				desc:          "two parts",
+				partSize:      1024 * 1024,
+				totalFileSize: 2 * 1024 * 1024,
+			},
+			{
+				desc:          "1 byte file",
+				partSize:      20 * 1024,
+				totalFileSize: 1,
+			},
+			{
+				desc:          "file within dir",
+				partSize:      5 * 1024,
+				totalFileSize: 5*1024 + 456,
+				file:          "dub/test_rm_in_dir",
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				mw := stg.(*SpitMergeMiddleware)
+				mw.setPartsSize(tC.partSize)
+
+				dir := randomSuffix()
+				fName := "test_rm_file"
+				if tC.file != "" {
+					fName = tC.file
+				}
+				fName = path.Join(dir, fName)
+
+				// create test parts
+				srcContent := make([]byte, tC.totalFileSize)
+				r := bytes.NewReader(srcContent)
+				err := mw.Save(fName, r)
+				if err != nil {
+					t.Fatalf("error while creating test parts: %v", err)
+				}
+
+				err = mw.Delete(fName)
+				if err != nil {
+					t.Fatalf("error while invoking Delete: %v", err)
+				}
+
+				fi, err := mw.List(dir, "")
+				if err != nil {
+					t.Fatalf("error while invoking List: %v", err)
+				}
+
+				if len(fi) != 0 {
+					t.Fatalf("all files should be deleted, got %d files in dir", len(fi))
+				}
+			})
+		}
+
+		t.Run("Delete with split-merge middleware - file doesn't exist", func(t *testing.T) {
+			mw := stg.(*SpitMergeMiddleware)
+			fName := "test_rm_file" + randomSuffix()
+
+			err := mw.Delete(fName)
+			if err != nil {
+				t.Fatalf("error while invoking Delete: %v", err)
+			}
+		})
+	})
+
+	t.Run("Copy with split-merge middleware", func(t *testing.T) {
+		testCases := []struct {
+			desc          string
+			partSize      int64
+			totalFileSize int64
+			file          string
+		}{
+			{
+				desc:          "basic use caser for Copy",
+				partSize:      5 * 1024,
+				totalFileSize: 10*5*1024 + 456,
+			},
+			{
+				desc:          "stat for 100s of parts",
+				partSize:      456,
+				totalFileSize: 123*456 + 789,
+			},
+			{
+				desc:          "single part",
+				partSize:      1024 * 1024,
+				totalFileSize: 1024 * 1024,
+			},
+			{
+				desc:          "two parts",
+				partSize:      1024 * 1024,
+				totalFileSize: 2 * 1024 * 1024,
+			},
+			{
+				desc:          "1 byte file",
+				partSize:      20 * 1024,
+				totalFileSize: 1,
+			},
+			{
+				desc:          "copy from sub dir",
+				partSize:      5 * 1024,
+				totalFileSize: 4*5*1024 + 456,
+				file:          "sub/test_copy_from_sub",
+			},
+		}
+		for _, tC := range testCases {
+			t.Run(tC.desc, func(t *testing.T) {
+				mw := stg.(*SpitMergeMiddleware)
+				mw.setPartsSize(tC.partSize)
+
+				fNameSrc := "test_copy" + randomSuffix()
+				if tC.file != "" {
+					fNameSrc = tC.file + randomSuffix()
+				}
+				// create test parts
+				srcContent := make([]byte, tC.totalFileSize)
+				r := bytes.NewReader(srcContent)
+				err := mw.Save(fNameSrc, r)
+				if err != nil {
+					t.Fatalf("error while creating test parts: %v", err)
+				}
+
+				fNameDst := "dst/test_file_stat" + randomSuffix()
+
+				err = mw.Copy(fNameSrc, fNameDst)
+				if err != nil {
+					t.Fatalf("error while copying: %v", err)
+				}
+
+				fInfoDst, err := mw.FileStat(fNameDst)
+				if err != nil {
+					t.Fatalf("error while invoking FileStat: %v", err)
+				}
+
+				if fInfoDst.Name != fNameDst {
+					t.Fatalf("wrong file name, want=%s, got=%s", fNameDst, fInfoDst.Name)
+				}
+				if fInfoDst.Size != tC.totalFileSize {
+					t.Fatalf("wrong file size, want=%d, got=%d", tC.totalFileSize, fInfoDst.Size)
+				}
+			})
+		}
+	})
+}
+
+func CalcPartSizes(partSize, totalSize int64) []int64 {
+	padding := totalSize % partSize
+	partsCount := totalSize / partSize
+
+	res := make([]int64, partsCount)
+	for i := range partsCount {
+		res[i] = partSize
+	}
+	if padding > 0 {
+		res = append(res, padding)
+	}
+
+	return res
+}
+
+func randomSuffix() string {
+	randomBytes := make([]byte, 8)
+	_, _ = rand.Read(randomBytes)
+	return hex.EncodeToString(randomBytes)
+
 }

--- a/pbm/util/storage.go
+++ b/pbm/util/storage.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/percona/percona-backup-mongodb/pbm/config"
@@ -57,7 +56,7 @@ func GetStorage(ctx context.Context, m connect.Client, node string, l log.LogEve
 //
 // It does not handle "file already exists" error.
 func Initialize(ctx context.Context, stg storage.Storage) error {
-	err := RetryableWrite(stg, defs.StorInitFile, []byte(version.Current().Version))
+	err := storage.RetryableWrite(stg, defs.StorInitFile, []byte(version.Current().Version))
 	if err != nil {
 		return errors.Wrap(err, "write init file")
 	}
@@ -75,15 +74,4 @@ func Reinitialize(ctx context.Context, stg storage.Storage) error {
 	}
 
 	return Initialize(ctx, stg)
-}
-
-func RetryableWrite(stg storage.Storage, name string, data []byte) error {
-	err := stg.Save(name, bytes.NewBuffer(data), storage.Size(int64(len(data))))
-	if err != nil && stg.Type() == storage.Filesystem {
-		if fs.IsRetryableError(err) {
-			err = stg.Save(name, bytes.NewBuffer(data), storage.Size(int64(len(data))))
-		}
-	}
-
-	return err
 }


### PR DESCRIPTION
[![PBM-1490](https://badgen.net/badge/JIRA/PBM-1490/green)](https://jira.percona.com/browse/PBM-1490) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR implements solution for handling backup files that exceed remote storage size limits by introducing a `split-merge` middleware. The middleware automatically splits large files into smaller parts during the backup procedure and merges them back during restore procedure. 

The file size threshold is set by default for each storage service, or it can be optionally set by configuration parameter:
| Storage        | Default Size | Config Param |
|-------------|--------------|--------------|
| AWS S3       |  4.9 TB           |  storage.s3.maxObjSizeGB |
| GCS             |  4.9 TB           |  storage.gcs.maxObjSizeGB |
| Azure Blob  |  190 TB             |  storage.azure.maxObjSizeGB            |
| File storage |  4.9 TB              |  storage.filesystem.maxObjSizeGB |

At the storage level, any file that exceeds the storage limit is named according to the following schema:
```
2025-09-04T09:09:47Z
│   └── rs1
│       ├── WiredTiger
│       ...
│       ├── collection-113-10993150527740990612.wt
│       ├── collection-119-10993150527740990612.wt
│       ├── collection-119-10993150527740990612.wt.pbmpart.1
│       ├── collection-119-10993150527740990612.wt.pbmpart.2
│       ├── collection-119-10993150527740990612.wt.pbmpart.3
│       ├── collection-119-10993150527740990612.wt.pbmpart.4
```

[PBM-1490]: https://perconadev.atlassian.net/browse/PBM-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ