### PR TITLE
PBM-1490: Improve storage.GetBasePart

### DIFF
--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -13,6 +14,8 @@ const (
 	pbmPartToken = ".pbmpart."
 	GB           = 1024 * 1024 * 1024
 )
+
+var pbmPartRE = regexp.MustCompile(`\.pbmpart\.\d+$`)
 
 type SplitMergeMiddleware struct {
 	s          Storage
@@ -311,12 +314,13 @@ func GetPartIndex(fname string) (int, error) {
 // GetBasePart extract base part of the file.
 // Base part is file without .pbmpart.xy suffix.
 func GetBasePart(fname string) string {
-	base, idx, found := strings.Cut(fname, pbmPartToken)
-	if _, err := strconv.Atoi(idx); err == nil && found {
-		return base
+	base := fname
+
+	if pbmPartRE.MatchString(fname) {
+		base = strings.Split(fname, pbmPartToken)[0]
 	}
 
-	return fname
+	return base
 }
 
 func isPartFile(fname string) bool {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -311,7 +311,12 @@ func GetPartIndex(fname string) (int, error) {
 // GetBasePart extract base part of the file.
 // Base part is file without .pbmpart.xy suffix.
 func GetBasePart(fname string) string {
-	return strings.Split(fname, pbmPartToken)[0]
+	base, idx, found := strings.Cut(fname, pbmPartToken)
+	if _, err := strconv.Atoi(idx); err == nil && found {
+		return base
+	}
+
+	return fname
 }
 
 func isPartFile(fname string) bool {

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 	"io"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -312,14 +311,7 @@ func GetPartIndex(fname string) (int, error) {
 // GetBasePart extract base part of the file.
 // Base part is file without .pbmpart.xy suffix.
 func GetBasePart(fname string) string {
-	base := fname
-
-	pattern := regexp.MustCompile(`\.pbmpart\.\d+$`)
-	if pattern.MatchString(fname) {
-		base = strings.Split(fname, pbmPartToken)[0]
-	}
-
-	return base
+	return strings.Split(fname, pbmPartToken)[0]
 }
 
 func isPartFile(fname string) bool {

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -165,7 +165,12 @@ func TestGetBasePart(t *testing.T) {
 		{
 			name:  "base part with pbmpart token, without index",
 			fname: "file_name.pbmpart.",
-			want:  "file_name",
+			want:  "file_name.pbmpart.",
+		},
+		{
+			name:  "base part with pbmpart token, invalid index",
+			fname: "file_name.pbmpart.23xx",
+			want:  "file_name.pbmpart.23xx",
 		},
 		{
 			name:  "pbmpart token exists, base part doesn't",

--- a/pbm/storage/split_merge_mw_test.go
+++ b/pbm/storage/split_merge_mw_test.go
@@ -144,3 +144,42 @@ func TestGetPartIndex(t *testing.T) {
 		}
 	})
 }
+
+// TestGetBasePart tests GetBasePart function.
+func TestGetBasePart(t *testing.T) {
+	tests := []struct {
+		name  string
+		fname string
+		want  string
+	}{
+		{
+			name:  "only base part",
+			fname: "file_name",
+			want:  "file_name",
+		},
+		{
+			name:  "base part with pbmpart token and index",
+			fname: "file_name.pbmpart.15",
+			want:  "file_name",
+		},
+		{
+			name:  "base part with pbmpart token, without index",
+			fname: "file_name.pbmpart.",
+			want:  "file_name",
+		},
+		{
+			name:  "pbmpart token exists, base part doesn't",
+			fname: ".pbmpart.5",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetBasePart(tt.fname)
+			if got != tt.want {
+				t.Errorf("want=%s, got=%s", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[![PBM-1490](https://badgen.net/badge/JIRA/PBM-1490/green)](https://jira.percona.com/browse/PBM-1490) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR improves `storage.GetBasePart` function by removing unnecessary regex compilation and matching which makes the implementation simpler and more performant.

[PBM-1490]: https://perconadev.atlassian.net/browse/PBM-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ