### PR TITLE
PBM-1574: PBM restore with -w doesn't wait till the end of restore

### DIFF
--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -263,7 +263,9 @@ func waitRestore(
 
 		switch rmeta.Status {
 		case status, defs.StatusDone, defs.StatusPartlyDone:
-			if m.Type == defs.PhysicalBackup || m.Type == defs.IncrementalBackup {
+			if status != defs.StatusCopyReady &&
+				(m.Type == defs.PhysicalBackup || m.Type == defs.IncrementalBackup) {
+				// apply cleanup waiting logic only for physical/inc backups, and not external
 				alive, err := restore.IsCleanupHbAlive(m.Name, stg, tskew)
 				if err != nil {
 					return errors.Wrap(err, "checking cleanup hb")

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -266,10 +266,6 @@ func waitRestore(
 			if m.Type == defs.PhysicalBackup || m.Type == defs.IncrementalBackup {
 				alive, err := restore.IsCleanupHbAlive(m.Name, stg, tskew)
 				if err != nil {
-					if errors.Is(err, storage.ErrNotExist) ||
-						errors.Is(err, storage.ErrEmpty) {
-						continue
-					}
 					return errors.Wrap(err, "checking cleanup hb")
 				}
 				if alive {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -669,10 +669,10 @@ func (r *PhysRestore) waitToBecomePrimary(ctx context.Context, m *mongo.Client) 
 //
 //		.pbm.restore/<restore-name>
 //			rs.<rs-name>/
-//				node.<node-name>.hb			// hearbeats. last beat ts inside.
+//				node.<node-name>.hb			// heartbeats. last beat ts inside.
 //				node.<node-name>.<status>	// node's PBM status. Inside is the ts of the transition. In case of error, file contains an error text.
 //				rs.<status>					// replicaset's PBM status. Inside is the ts of the transition. In case of error, file contains an error text.
-//			cluster.hb						// hearbeats. last beat ts inside.
+//			cluster.hb						// heartbeats. last beat ts inside.
 //			cluster.<status>				// cluster's PBM status. Inside is the ts of the transition. In case of error, file contains an error text.
 //
 //	 For example:
@@ -2245,7 +2245,7 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 		tk := time.NewTicker(time.Second * hbFrameSec)
 		defer func() {
 			tk.Stop()
-			l.Debug("hearbeats stopped")
+			l.Debug("heartbeats stopped")
 		}()
 
 		for {
@@ -2296,7 +2296,7 @@ func (r *PhysRestore) hbCleanup() error {
 	return nil
 }
 
-// startCleanupHb genereates cleanup hb for the purpose of detecting physical restore
+// startCleanupHb generates cleanup hb for the purpose of detecting physical restore
 // cleanup activity.
 func (r *PhysRestore) startCleanupHb() {
 	if r.stopHB == nil {
@@ -2311,7 +2311,7 @@ func (r *PhysRestore) startCleanupHb() {
 	tk := time.NewTicker(hbCleanupFrame)
 	defer func() {
 		tk.Stop()
-		r.log.Debug("cleaning hearbeats stopped")
+		r.log.Debug("cleaning heartbeats stopped")
 	}()
 
 	for {

--- a/pbm/restore/storage.go
+++ b/pbm/restore/storage.go
@@ -282,7 +282,7 @@ func parsePhysRestoreCond(stg storage.Storage, fname, restoreName string) (*Cond
 
 // IsCleanupHbAlive returns true if cleanup hb is active on any agent during physical restore.
 // It reads timestamp from file and takes into account potential time skew.
-// When hb excides timeout, means that cleanup is done, false is returned.
+// When hb exceeds timeout, means that cleanup is done, false is returned.
 func IsCleanupHbAlive(restoreName string, stg storage.Storage, tskew int64) (bool, error) {
 	file := path.Join(defs.PhysRestoresDir, restoreName, fmt.Sprintf("cluster.%s", syncHbCleanupSuffix))
 	_, err := stg.FileStat(file)

--- a/pbm/restore/storage.go
+++ b/pbm/restore/storage.go
@@ -287,6 +287,11 @@ func IsCleanupHbAlive(restoreName string, stg storage.Storage, tskew int64) (boo
 	file := path.Join(defs.PhysRestoresDir, restoreName, fmt.Sprintf("cluster.%s", syncHbCleanupSuffix))
 	_, err := stg.FileStat(file)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotExist) ||
+			errors.Is(err, storage.ErrEmpty) {
+			// HB hasn't been created yet
+			return true, nil
+		}
 		return false, errors.Wrap(err, "get cleanup hb file stat")
 	}
 

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -362,7 +362,7 @@ func (c *Client) Restore(ctx context.Context, backupName string, clusterTS Times
 	return NoOpID, ErrNotImplemented
 }
 
-var ErrStaleHearbeat = errors.New("stale heartbeat")
+var ErrStaleHeartbeat = errors.New("stale heartbeat")
 
 func (c *Client) OpLocks(ctx context.Context) ([]OpLock, error) {
 	locks, err := lock.GetLocks(ctx, c.conn, &lock.LockHeader{})
@@ -388,7 +388,7 @@ func (c *Client) OpLocks(ctx context.Context) ([]OpLock, error) {
 		rv[i].Heartbeat = locks[i].Heartbeat
 
 		if rv[i].Heartbeat.T+defs.StaleFrameSec < clusterTime.T {
-			rv[i].err = ErrStaleHearbeat
+			rv[i].err = ErrStaleHeartbeat
 		}
 	}
 	return rv, nil


### PR DESCRIPTION
[![PBM-1574](https://badgen.net/badge/JIRA/PBM-1574/green)](https://jira.percona.com/browse/PBM-1574) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Physical restore includes a `cleaning up` phase at the end of the restore procedure (after it reaches final status: `Done`, `PartlyDone` or `Error` ). 
This PR fixes the issue when restore command is invoked with `--wait` option for the physical restore:
```
pbm restore --wait <backup-id>
```
and the `--wait` option doesn't include the cleaning up phase as part of the waiting.

PR expands the restore procedure to wait during the cleanup phase as well. To achieve this effectively, PBM emits a cleanup heartbeat during the cleanup procedure period, enabling the detection of activity of any node during the cleanup phase.

[PBM-1574]: https://perconadev.atlassian.net/browse/PBM-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ