### PR TITLE
PBM-1591: Logical backup fails if collection name repeats for time series collections

### DIFF
--- a/pbm/archive/conv.go
+++ b/pbm/archive/conv.go
@@ -74,6 +74,7 @@ func convertMetaToV1(metaV2 *ArchiveMetaV2) (*archiveMeta, error) {
 	for _, coll := range metaV2.Namespaces {
 		if coll.DB != "admin" && coll.DB != "config" &&
 			coll.IsSystemCollection() && coll.Name != "system.js" {
+			// in case of user db (non admin/config) skip sys collections
 			continue
 		}
 
@@ -84,10 +85,10 @@ func convertMetaToV1(metaV2 *ArchiveMetaV2) (*archiveMeta, error) {
 
 		if coll.IsTimeseries() {
 			bucketName := "system.buckets." + coll.Name
-			for _, coll := range metaV2.Namespaces {
-				if coll.Name == bucketName {
-					ns.CRC = coll.CRC
-					ns.Size = coll.Size
+			for _, fColl := range metaV2.Namespaces {
+				if fColl.DB == coll.DB && fColl.Name == bucketName {
+					ns.CRC = fColl.CRC
+					ns.Size = fColl.Size
 					break
 				}
 			}


### PR DESCRIPTION
[![PBM-1591](https://badgen.net/badge/JIRA/PBM-1591/green)](https://jira.percona.com/browse/PBM-1591) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When performing logical backup for time series collections PBM might fail with the following error:
```
E [backup/2025-09-11T08:27:34Z] backup: check backup files: file "2025-09-11T08:27:34Z/rs1/db.coll": no such file
```
where `db.coll` is time series collection.

PR fixes the query for getting the metadata for time series types of collections.

[PBM-1591]: https://perconadev.atlassian.net/browse/PBM-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ