### PR TITLE
PBM-1574: PBM restore with -w doesn't wait till the end of failed restore

### DIFF
--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -217,12 +217,12 @@ func runRestore(
 	}
 
 	if errors.Is(err, restoreFailedError{}) {
-		return restoreRet{err: err.Error()}, nil
+		return restoreRet{err: err.Error()}, err
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = errWaitTimeout
 	}
-	return restoreRet{err: fmt.Sprintf("%s.\n Try to check logs on node %s", err.Error(), m.Leader)}, nil
+	return restoreRet{err: fmt.Sprintf("%s.\n Try to check logs on node %s", err.Error(), m.Leader)}, err
 }
 
 // We rely on heartbeats in error detection in case of all nodes failed,


### PR DESCRIPTION
[![PBM-1574](https://badgen.net/badge/JIRA/PBM-1574/green)](https://jira.percona.com/browse/PBM-1574) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR is addition to #1187, and it adds following missing logic:
- handling for `--wait` flag in case of restore with error
- `pbm-cli` returns 1 in case of failed restore

[PBM-1574]: https://perconadev.atlassian.net/browse/PBM-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ