### PR TITLE
PBM-1490: Fix IsSameStorage check for incremental backup

### DIFF
--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -291,8 +291,7 @@ func (s *StorageConf) IsSameStorage(other *StorageConf) bool {
 	case storage.GCS:
 		return s.GCS.IsSameStorage(other.GCS)
 	case storage.Filesystem:
-		// FS is the same if it's equal
-		return s.Filesystem.Equal(other.Filesystem)
+		return s.Filesystem.IsSameStorage(other.Filesystem)
 	case storage.Blackhole:
 		return true
 	}

--- a/pbm/config/config_test.go
+++ b/pbm/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/percona/percona-backup-mongodb/pbm/storage/azure"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/gcs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
 )
@@ -121,6 +122,33 @@ func TestIsSameStorage(t *testing.T) {
 		neq.Prefix = "p2"
 		if cfg.IsSameStorage(neq) {
 			t.Errorf("storage instances has different prefix: cfg=%+v, eq=%+v", cfg, neq)
+		}
+	})
+
+	t.Run("FS", func(t *testing.T) {
+		maxObjSizeGB := 5.5
+		cfg := &fs.Config{
+			Path:         "a/b/c",
+			MaxObjSizeGB: &maxObjSizeGB,
+		}
+
+		eq := &fs.Config{
+			Path: "a/b/c",
+		}
+		if !cfg.IsSameStorage(eq) {
+			t.Errorf("config storage should identify the same instance: cfg=%+v, eq=%+v", cfg, eq)
+		}
+
+		maxObjSizeGB = 2.2
+		eq.MaxObjSizeGB = &maxObjSizeGB
+		if !cfg.IsSameStorage(eq) {
+			t.Errorf("config storage should identify the same instance: cfg=%+v, eq=%+v", cfg, eq)
+		}
+
+		neq := cfg.Clone()
+		neq.Path = "z/y/x"
+		if cfg.IsSameStorage(neq) {
+			t.Errorf("storage instances has different bucket: cfg=%+v, eq=%+v", cfg, neq)
 		}
 	})
 }

--- a/pbm/storage/azure/azure.go
+++ b/pbm/storage/azure/azure.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"path"
+	"reflect"
 	"runtime"
 	"strings"
 	"time"
@@ -52,6 +53,10 @@ func (cfg *Config) Clone() *Config {
 
 	rv := *cfg
 	rv.EndpointURLMap = maps.Clone(cfg.EndpointURLMap)
+	if cfg.MaxObjSizeGB != nil {
+		v := *cfg.MaxObjSizeGB
+		rv.MaxObjSizeGB = &v
+	}
 	return &rv
 }
 
@@ -78,7 +83,7 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.Credentials.Key != other.Credentials.Key {
 		return false
 	}
-	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
+	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
 		return false
 	}
 

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
@@ -28,6 +29,10 @@ func (cfg *Config) Clone() *Config {
 	}
 
 	rv := *cfg
+	if cfg.MaxObjSizeGB != nil {
+		v := *cfg.MaxObjSizeGB
+		rv.MaxObjSizeGB = &v
+	}
 	return &rv
 }
 
@@ -35,11 +40,14 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg == nil || other == nil {
 		return cfg == other
 	}
-	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
+	if cfg.Path != other.Path {
+		return false
+	}
+	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
 		return false
 	}
 
-	return cfg.Path == other.Path
+	return true
 }
 
 // IsSameStorage identifies the same instance of the FS storage.

--- a/pbm/storage/fs/fs.go
+++ b/pbm/storage/fs/fs.go
@@ -42,6 +42,19 @@ func (cfg *Config) Equal(other *Config) bool {
 	return cfg.Path == other.Path
 }
 
+// IsSameStorage identifies the same instance of the FS storage.
+func (cfg *Config) IsSameStorage(other *Config) bool {
+	if cfg == nil || other == nil {
+		return cfg == other
+	}
+
+	if cfg.Path != other.Path {
+		return false
+	}
+
+	return true
+}
+
 func (cfg *Config) Cast() error {
 	if cfg.Path == "" {
 		return errors.New("path can't be empty")

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -88,6 +88,15 @@ func (cfg *Config) Clone() *Config {
 	}
 
 	rv := *cfg
+	if cfg.MaxObjSizeGB != nil {
+		v := *cfg.MaxObjSizeGB
+		rv.MaxObjSizeGB = &v
+	}
+	if cfg.Retryer != nil {
+		v := *cfg.Retryer
+		rv.Retryer = &v
+	}
+
 	return &rv
 }
 
@@ -105,10 +114,9 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.ChunkSize != other.ChunkSize {
 		return false
 	}
-	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
+	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
 		return false
 	}
-
 	if !reflect.DeepEqual(cfg.Credentials, other.Credentials) {
 		return false
 	}

--- a/pbm/storage/s3/s3.go
+++ b/pbm/storage/s3/s3.go
@@ -168,26 +168,15 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.StorageClass != other.StorageClass {
 		return false
 	}
-	if cfg.MaxObjSizeGB != other.MaxObjSizeGB {
+	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
 		return false
 	}
-
-	lhs, rhs := true, true
-	if cfg.ForcePathStyle != nil {
-		lhs = *cfg.ForcePathStyle
-	}
-	if other.ForcePathStyle != nil {
-		rhs = *other.ForcePathStyle
-	}
-	if lhs != rhs {
+	if !reflect.DeepEqual(cfg.ForcePathStyle, other.ForcePathStyle) {
 		return false
 	}
-
-	// TODO: check only required fields
 	if !reflect.DeepEqual(cfg.Credentials, other.Credentials) {
 		return false
 	}
-	// TODO: check only required fields
 	if !reflect.DeepEqual(cfg.ServerSideEncryption, other.ServerSideEncryption) {
 		return false
 	}


### PR DESCRIPTION
[![PBM-1490](https://badgen.net/badge/JIRA/PBM-1490/green)](https://jira.percona.com/browse/PBM-1490) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is additional fix for #1183.

It fixes missing `IsSameStorage` check during performing incremental backup for FS.

[PBM-1490]: https://perconadev.atlassian.net/browse/PBM-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ