### PR TITLE
PBM-1598: Add configurable timeout for balancer stop command

### DIFF
--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -113,17 +113,14 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 
 		if bs.IsOn() {
-			balancerCtx := ctx
-			balancerTimeout := cfg.BalancerWaitTimeout()
-			if balancerTimeout > 0 {
-				var cancel context.CancelFunc
-				balancerCtx, cancel = context.WithTimeout(ctx, balancerTimeout)
-				defer cancel()
-
-				l.Debug("stopping balancer with timeout %s", balancerTimeout)
+			t := cfg.Restore.Timeouts.BalancerStop()
+			if t > 0 {
+				l.Debug("stopping balancer with timeout %s", t)
+			} else {
+				l.Debug("stopping balancer")
 			}
 
-			err := topo.SetBalancerStatus(balancerCtx, a.leadConn, topo.BalancerModeOff)
+			err := topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff, t.Milliseconds())
 			if err != nil {
 				l.Error("set balancer off: %v", err)
 			}

--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -98,6 +98,12 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		return
 	}
 
+	cfg, err := config.GetConfig(ctx, a.leadConn)
+	if err != nil {
+		l.Error("get PBM configuration: %v", err)
+		return
+	}
+
 	// stop balancer during the restore
 	if a.brief.Sharded && nodeInfo.IsClusterLeader() {
 		bs, err := topo.GetBalancerStatus(ctx, a.leadConn)
@@ -107,7 +113,17 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 
 		if bs.IsOn() {
-			err := topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
+			balancerCtx := ctx
+			balancerTimeout := cfg.BalancerWaitTimeout()
+			if balancerTimeout > 0 {
+				var cancel context.CancelFunc
+				balancerCtx, cancel = context.WithTimeout(ctx, balancerTimeout)
+				defer cancel()
+
+				l.Debug("stopping balancer with timeout %s", balancerTimeout)
+			}
+
+			err := topo.SetBalancerStatus(balancerCtx, a.leadConn, topo.BalancerModeOff)
 			if err != nil {
 				l.Error("set balancer off: %v", err)
 			}
@@ -154,12 +170,6 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 		bcpType = bcp.Type
 		r.BackupName = bcp.Name
-	}
-
-	cfg, err := config.GetConfig(ctx, a.leadConn)
-	if err != nil {
-		l.Error("get PBM configuration: %v", err)
-		return
 	}
 
 	l.Info("recovery started")

--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -116,11 +116,11 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 			t := cfg.Restore.Timeouts.BalancerStop()
 			if t > 0 {
 				l.Debug("stopping balancer with timeout %s", t)
+				err = topo.StopBalancer(ctx, a.leadConn, t.Milliseconds())
 			} else {
 				l.Debug("stopping balancer")
+				err = topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
 			}
-
-			err := topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff, t.Milliseconds())
 			if err != nil {
 				l.Error("set balancer off: %v", err)
 			}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -288,7 +288,17 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 
 	if inf.IsSharded() && inf.IsLeader() {
 		if bcpm.BalancerStatus == topo.BalancerModeOn {
-			err = topo.SetBalancerStatus(ctx, b.leadConn, topo.BalancerModeOff)
+			balancerCtx := ctx
+			balancerTimeout := b.config.BalancerWaitTimeout()
+			if balancerTimeout > 0 {
+				var cancel context.CancelFunc
+				balancerCtx, cancel = context.WithTimeout(ctx, balancerTimeout)
+				defer cancel()
+
+				l.Debug("stopping balancer with timeout %s", balancerTimeout)
+			}
+
+			err = topo.SetBalancerStatus(balancerCtx, b.leadConn, topo.BalancerModeOff)
 			if err != nil {
 				return errors.Wrap(err, "set balancer OFF")
 			}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -291,11 +291,11 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 			t := b.timeouts.BalancerStop()
 			if t > 0 {
 				l.Debug("stopping balancer with timeout %s", t)
+				err = topo.StopBalancer(ctx, b.leadConn, t.Milliseconds())
 			} else {
 				l.Debug("stopping balancer")
+				err = topo.SetBalancerStatus(ctx, b.leadConn, topo.BalancerModeOff)
 			}
-
-			err = topo.SetBalancerStatus(ctx, b.leadConn, topo.BalancerModeOff, t.Milliseconds())
 			if err != nil {
 				return errors.Wrap(err, "set balancer OFF")
 			}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -288,17 +288,14 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 
 	if inf.IsSharded() && inf.IsLeader() {
 		if bcpm.BalancerStatus == topo.BalancerModeOn {
-			balancerCtx := ctx
-			balancerTimeout := b.config.BalancerWaitTimeout()
-			if balancerTimeout > 0 {
-				var cancel context.CancelFunc
-				balancerCtx, cancel = context.WithTimeout(ctx, balancerTimeout)
-				defer cancel()
-
-				l.Debug("stopping balancer with timeout %s", balancerTimeout)
+			t := b.timeouts.BalancerStop()
+			if t > 0 {
+				l.Debug("stopping balancer with timeout %s", t)
+			} else {
+				l.Debug("stopping balancer")
 			}
 
-			err = topo.SetBalancerStatus(balancerCtx, b.leadConn, topo.BalancerModeOff)
+			err = topo.SetBalancerStatus(ctx, b.leadConn, topo.BalancerModeOff, t.Milliseconds())
 			if err != nil {
 				return errors.Wrap(err, "set balancer OFF")
 			}
@@ -311,7 +308,6 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 				l.Warning("balancer is not disabled: balancer mode: %s, in balancer round: %t",
 					bs.Mode, bs.InBalancerRound)
 			}
-
 		}
 	}
 

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -446,18 +446,18 @@ func (cfg *RestoreConf) Clone() *RestoreConf {
 //nolint:lll
 type RestoreTimeouts struct {
 	// BalancerStopMin is timeout (in minutes) to wait for the balancer to stop.
-	// 0 or nil means wait indefinitely (default).
-	BalancerStopMin *uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
+	// 0 means wait indefinitely (default).
+	BalancerStopMin uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
 }
 
 // BalancerStop returns timeout duration for waiting for the balancer to stop.
 // Returns 0 if not set, meaning PBM will wait indefinitely.
 func (t *RestoreTimeouts) BalancerStop() time.Duration {
-	if t == nil || t.BalancerStopMin == nil || *t.BalancerStopMin == 0 {
+	if t == nil {
 		return 0
 	}
 
-	return time.Duration(*t.BalancerStopMin) * time.Minute
+	return time.Duration(t.BalancerStopMin) * time.Minute
 }
 
 // GetFallbackEnabled gets config's or default value for fallbackEnabled
@@ -515,8 +515,8 @@ type BackupTimeouts struct {
 	Starting *uint32 `bson:"startingStatus,omitempty" json:"startingStatus,omitempty" yaml:"startingStatus,omitempty"`
 
 	// BalancerStopMin is timeout (in minutes) to wait for the balancer to stop.
-	// 0 or nil means wait indefinitely (default).
-	BalancerStopMin *uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
+	// 0 means wait indefinitely (default).
+	BalancerStopMin uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
 }
 
 // StartingStatus returns timeout duration for .
@@ -532,11 +532,11 @@ func (t *BackupTimeouts) StartingStatus() time.Duration {
 // BalancerStop returns timeout duration for waiting for the balancer to stop.
 // Returns 0 if not set, meaning PBM will wait indefinitely.
 func (t *BackupTimeouts) BalancerStop() time.Duration {
-	if t == nil || t.BalancerStopMin == nil || *t.BalancerStopMin == 0 {
+	if t == nil {
 		return 0
 	}
 
-	return time.Duration(*t.BalancerStopMin) * time.Minute
+	return time.Duration(t.BalancerStopMin) * time.Minute
 }
 
 func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -80,6 +80,10 @@ type Config struct {
 	Backup  *BackupConf  `bson:"backup,omitempty" json:"backup,omitempty" yaml:"backup,omitempty"`
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
 
+	// BalancerWait is timeout (in minutes) to wait for the balancer to stop
+	// during backup or restore. 0 means wait indefinitely (default).
+	BalancerWait uint32 `bson:"balancerWait,omitempty" json:"balancerWait,omitempty" yaml:"balancerWait,omitempty"`
+
 	Epoch primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
 }
 
@@ -499,6 +503,12 @@ func (t *BackupTimeouts) StartingStatus() time.Duration {
 	}
 
 	return time.Duration(*t.Starting) * time.Second
+}
+
+// BalancerWaitTimeout returns the timeout duration for waiting for the balancer to stop.
+// Returns 0 if not set, meaning PBM will wait indefinitely.
+func (c *Config) BalancerWaitTimeout() time.Duration {
+	return time.Duration(c.BalancerWait) * time.Minute
 }
 
 func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -80,10 +80,6 @@ type Config struct {
 	Backup  *BackupConf  `bson:"backup,omitempty" json:"backup,omitempty" yaml:"backup,omitempty"`
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
 
-	// BalancerWait is timeout (in minutes) to wait for the balancer to stop
-	// during backup or restore. 0 means wait indefinitely (default).
-	BalancerWait uint32 `bson:"balancerWait,omitempty" json:"balancerWait,omitempty" yaml:"balancerWait,omitempty"`
-
 	Epoch primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
 }
 
@@ -422,6 +418,8 @@ type RestoreConf struct {
 
 	FallbackEnabled *bool `bson:"fallbackEnabled,omitempty" json:"fallbackEnabled,omitempty" yaml:"fallbackEnabled,omitempty"`
 	AllowPartlyDone *bool `bson:"allowPartlyDone,omitempty" json:"allowPartlyDone,omitempty" yaml:"allowPartlyDone,omitempty"`
+
+	Timeouts *RestoreTimeouts `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
 }
 
 func (cfg *RestoreConf) Clone() *RestoreConf {
@@ -436,8 +434,30 @@ func (cfg *RestoreConf) Clone() *RestoreConf {
 			rv.MongodLocationMap[k] = v
 		}
 	}
+	if cfg.Timeouts != nil {
+		rv.Timeouts = &RestoreTimeouts{
+			BalancerStopMin: cfg.Timeouts.BalancerStopMin,
+		}
+	}
 
 	return &rv
+}
+
+//nolint:lll
+type RestoreTimeouts struct {
+	// BalancerStopMin is timeout (in minutes) to wait for the balancer to stop.
+	// 0 or nil means wait indefinitely (default).
+	BalancerStopMin *uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
+}
+
+// BalancerStop returns timeout duration for waiting for the balancer to stop.
+// Returns 0 if not set, meaning PBM will wait indefinitely.
+func (t *RestoreTimeouts) BalancerStop() time.Duration {
+	if t == nil || t.BalancerStopMin == nil || *t.BalancerStopMin == 0 {
+		return 0
+	}
+
+	return time.Duration(*t.BalancerStopMin) * time.Minute
 }
 
 // GetFallbackEnabled gets config's or default value for fallbackEnabled
@@ -476,10 +496,9 @@ func (cfg *BackupConf) Clone() *BackupConf {
 
 	rv.Priority = maps.Clone(cfg.Priority)
 	if cfg.Timeouts != nil {
-		if cfg.Timeouts.Starting != nil {
-			rv.Timeouts = &BackupTimeouts{
-				Starting: cfg.Timeouts.Starting,
-			}
+		rv.Timeouts = &BackupTimeouts{
+			Starting:        cfg.Timeouts.Starting,
+			BalancerStopMin: cfg.Timeouts.BalancerStopMin,
 		}
 	}
 	if cfg.CompressionLevel != nil {
@@ -490,9 +509,14 @@ func (cfg *BackupConf) Clone() *BackupConf {
 	return &rv
 }
 
+//nolint:lll
 type BackupTimeouts struct {
 	// Starting is timeout (in seconds) to wait for a backup to start.
 	Starting *uint32 `bson:"startingStatus,omitempty" json:"startingStatus,omitempty" yaml:"startingStatus,omitempty"`
+
+	// BalancerStopMin is timeout (in minutes) to wait for the balancer to stop.
+	// 0 or nil means wait indefinitely (default).
+	BalancerStopMin *uint32 `bson:"balancerStopMin,omitempty" json:"balancerStopMin,omitempty" yaml:"balancerStopMin,omitempty"`
 }
 
 // StartingStatus returns timeout duration for .
@@ -505,10 +529,14 @@ func (t *BackupTimeouts) StartingStatus() time.Duration {
 	return time.Duration(*t.Starting) * time.Second
 }
 
-// BalancerWaitTimeout returns the timeout duration for waiting for the balancer to stop.
+// BalancerStop returns timeout duration for waiting for the balancer to stop.
 // Returns 0 if not set, meaning PBM will wait indefinitely.
-func (c *Config) BalancerWaitTimeout() time.Duration {
-	return time.Duration(c.BalancerWait) * time.Minute
+func (t *BackupTimeouts) BalancerStop() time.Duration {
+	if t == nil || t.BalancerStopMin == nil || *t.BalancerStopMin == 0 {
+		return 0
+	}
+
+	return time.Duration(*t.BalancerStopMin) * time.Minute
 }
 
 func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {

--- a/pbm/topo/cluster.go
+++ b/pbm/topo/cluster.go
@@ -220,9 +220,7 @@ func (b *BalancerStatus) IsDisabled() bool {
 }
 
 // SetBalancerStatus sets balancer status.
-// For BalancerModeOff, an optional maxTimeMS can be provided to limit how long
-// the server waits for the current balancer round to finish.
-func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode, maxTimeMS ...int64) error {
+func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode) error {
 	var cmd string
 
 	switch mode {
@@ -234,9 +232,19 @@ func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode,
 		return errors.Errorf("unknown mode %s", mode)
 	}
 
-	doc := bson.D{{cmd, 1}}
-	if mode == BalancerModeOff && len(maxTimeMS) > 0 && maxTimeMS[0] > 0 {
-		doc = append(doc, bson.E{Key: "maxTimeMS", Value: maxTimeMS[0]})
+	err := m.AdminCommand(ctx, bson.D{{cmd, 1}}).Err()
+	if err != nil {
+		return errors.Wrap(err, "run mongo command")
+	}
+	return nil
+}
+
+// StopBalancer stops the balancer with a maxTimeMS limit on how long
+// the server waits for the current balancer round to finish.
+func StopBalancer(ctx context.Context, m connect.Client, maxTimeMS int64) error {
+	doc := bson.D{{"_configsvrBalancerStop", 1}}
+	if maxTimeMS > 0 {
+		doc = append(doc, bson.E{Key: "maxTimeMS", Value: maxTimeMS})
 	}
 
 	err := m.AdminCommand(ctx, doc).Err()

--- a/pbm/topo/cluster.go
+++ b/pbm/topo/cluster.go
@@ -219,7 +219,7 @@ func (b *BalancerStatus) IsDisabled() bool {
 	return b.Mode == BalancerModeOff && !b.InBalancerRound
 }
 
-// SetBalancerStatus sets balancer status.
+// SetBalancerStatus sets balancer status
 func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode) error {
 	var cmd string
 

--- a/pbm/topo/cluster.go
+++ b/pbm/topo/cluster.go
@@ -219,8 +219,10 @@ func (b *BalancerStatus) IsDisabled() bool {
 	return b.Mode == BalancerModeOff && !b.InBalancerRound
 }
 
-// SetBalancerStatus sets balancer status
-func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode) error {
+// SetBalancerStatus sets balancer status.
+// For BalancerModeOff, an optional maxTimeMS can be provided to limit how long
+// the server waits for the current balancer round to finish.
+func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode, maxTimeMS ...int64) error {
 	var cmd string
 
 	switch mode {
@@ -232,7 +234,12 @@ func SetBalancerStatus(ctx context.Context, m connect.Client, mode BalancerMode)
 		return errors.Errorf("unknown mode %s", mode)
 	}
 
-	err := m.AdminCommand(ctx, bson.D{{cmd, 1}}).Err()
+	doc := bson.D{{cmd, 1}}
+	if mode == BalancerModeOff && len(maxTimeMS) > 0 && maxTimeMS[0] > 0 {
+		doc = append(doc, bson.E{Key: "maxTimeMS", Value: maxTimeMS[0]})
+	}
+
+	err := m.AdminCommand(ctx, doc).Err()
 	if err != nil {
 		return errors.Wrap(err, "run mongo command")
 	}


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1598

The _configsvrBalancerStop admin command can block for hours when a chunk migration is in progress. This causes backups and restores to hang indefinitely while waiting for the balancer to stop.

Add a new backup.timeouts.balancerWait config parameter (in minutes) that limits how long PBM will wait for the balancer to stop. When the timeout is reached, the operation fails with a clear error. If unset or zero, PBM waits indefinitely (preserving current behavior).