### PR TITLE
PBM-1599: fix CLI timeout when balancer stop blocks

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -342,21 +342,7 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 				return errors.Errorf("status error on %s", rs)
 			}
 		case <-ctx.Done():
-			if bmeta == nil {
-				return errors.New("no progress from leader, backup metadata not found")
-			}
-			rs := ""
-			for _, s := range bmeta.Replsets {
-				rs += fmt.Sprintf("- Backup on replicaset \"%s\" in state: %v\n", s.Name, s.Status)
-				if s.Error != "" {
-					rs += ": " + s.Error
-				}
-			}
-			if rs == "" {
-				rs = "<no replset has started backup>\n"
-			}
-
-			return errors.New("no confirmation that backup has successfully started. Replsets status:\n" + rs)
+			return ctx.Err()
 		}
 	}
 }

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -322,9 +322,6 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 			}
 			var err error
 			bmeta, err = backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
-			if errors.Is(err, errors.ErrNotFound) {
-				continue
-			}
 			if err != nil {
 				return errors.Wrap(err, "get backup metadata")
 			}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -170,9 +170,7 @@ func runBackup(
 		}
 		fmt.Printf("Starting backup %q%s", b.name, pinfo)
 	}
-	startCtx, cancel := context.WithTimeout(ctx, cfg.Backup.Timeouts.StartingStatus())
-	defer cancel()
-	err = waitForBcpStatus(startCtx, conn, b.name, showProgress)
+	err = waitForBcpStatus(ctx, conn, b.name, showProgress)
 	if err != nil {
 		return nil, errors.Wrap(err, "wait for backup status")
 	}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -278,7 +278,38 @@ func waitBackup(
 	}
 }
 
+func waitForBcpExists(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {
+	tk := time.NewTicker(time.Second)
+	defer tk.Stop()
+
+	existCtx, cancel := context.WithTimeout(ctx, defs.WaitBackupStart)
+	defer cancel()
+
+	for {
+		select {
+		case <-tk.C:
+			if showProgress {
+				fmt.Print(".")
+			}
+			_, err := backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
+			if errors.Is(err, errors.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return errors.Wrap(err, "get backup metadata")
+			}
+			return nil
+		case <-existCtx.Done():
+			return errors.New("no progress from leader, backup metadata not found")
+		}
+	}
+}
+
 func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {
+	if err := waitForBcpExists(ctx, conn, bcpName, showProgress); err != nil {
+		return err
+	}
+
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
 

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -171,6 +171,9 @@ func runBackup(
 		fmt.Printf("Starting backup %q%s", b.name, pinfo)
 	}
 	err = waitForBcpStatus(ctx, conn, b.name, showProgress)
+	if showProgress {
+		fmt.Println()
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "wait for backup status")
 	}
@@ -211,7 +214,7 @@ func runBackup(
 		}
 
 		if showProgress {
-			fmt.Printf("\nWaiting for '%s' backup...", b.name)
+			fmt.Printf("Waiting for '%s' backup...", b.name)
 		}
 		s, err := waitBackup(ctx, conn, b.name, defs.StatusDone, showProgress)
 		if s != nil && showProgress {


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1599

waitForBcpStatus now accepts StatusStarting so the CLI returns as soon as the backup is acknowledged by agents instead of waiting for StatusRunning (which requires balancer stop to complete first).

This was IMHO the cause of the error bellow (form the ticket). The code never got to executing `--wait` 

> Error: get backup metadata: get: context deadline exceeded
Starting backup '2025-08-12T00:30:03Z'..................................%

BTW: the ticket seems to present the output lines in wrong order. 


Also made the text output a bit nicer to make sense 