### PR TITLE
PBM-1586, PBM-1648: Fix infinite cli wait on agent crush

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -274,22 +274,8 @@ func waitBackup(
 				return &bcp.Status, bcp.Error()
 			}
 
-			// Check if the backup has stuck (leader agent crashed).
-			clusterTime, err := topo.GetClusterTime(ctx, conn)
-			if err != nil {
-				return nil, errors.Wrap(err, "read cluster time")
-			}
-			if bcp.Hb.T+defs.StaleFrameSec < clusterTime.T {
-				rs := ""
-				for _, s := range bcp.Replsets {
-					rs += fmt.Sprintf("\n- %s: %v", s.Name, s.Status)
-					if s.Error != "" {
-						rs += ": " + s.Error
-					}
-				}
-				return &bcp.Status, errors.Errorf(
-					"backup stuck at %q status, last heartbeat: %d%s",
-					bcp.Status, bcp.Hb.T, rs)
+			if err := checkBackupStale(ctx, conn, bcp); err != nil {
+				return &bcp.Status, err
 			}
 		}
 
@@ -297,6 +283,26 @@ func waitBackup(
 			fmt.Print(".")
 		}
 	}
+}
+
+func checkBackupStale(ctx context.Context, conn connect.Client, bcp *backup.BackupMeta) error {
+	clusterTime, err := topo.GetClusterTime(ctx, conn)
+	if err != nil {
+		return errors.Wrap(err, "read cluster time")
+	}
+	if bcp.Hb.T+defs.StaleFrameSec < clusterTime.T {
+		rs := ""
+		for _, s := range bcp.Replsets {
+			rs += fmt.Sprintf("\n- %s: %v", s.Name, s.Status)
+			if s.Error != "" {
+				rs += ": " + s.Error
+			}
+		}
+		return errors.Errorf(
+			"backup stuck at %q status, last heartbeat: %d%s",
+			bcp.Status, bcp.Hb.T, rs)
+	}
+	return nil
 }
 
 func waitForBcpExists(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -273,6 +273,24 @@ func waitBackup(
 			case defs.StatusError:
 				return &bcp.Status, bcp.Error()
 			}
+
+			// Check if the backup has stuck (leader agent crashed).
+			clusterTime, err := topo.GetClusterTime(ctx, conn)
+			if err != nil {
+				return nil, errors.Wrap(err, "read cluster time")
+			}
+			if bcp.Hb.T+defs.StaleFrameSec < clusterTime.T {
+				rs := ""
+				for _, s := range bcp.Replsets {
+					rs += fmt.Sprintf("\n- %s: %v", s.Name, s.Status)
+					if s.Error != "" {
+						rs += ": " + s.Error
+					}
+				}
+				return &bcp.Status, errors.Errorf(
+					"backup stuck at %q status, last heartbeat: %d%s",
+					bcp.Status, bcp.Hb.T, rs)
+			}
 		}
 
 		if showProgress {

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -364,6 +364,10 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 				}
 				return errors.Errorf("status error on %s", rs)
 			}
+
+			if err := checkBackupStale(ctx, conn, bmeta); err != nil {
+				return err
+			}
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -538,8 +538,8 @@ func (b *Backup) converged(
 				})
 
 				// nodes are cleaning its locks moving to the done status
-				// so no lock is ok and no need to ckech the heartbeats
-				if status != defs.StatusDone && !errors.Is(err, mongo.ErrNoDocuments) {
+				// so no lock is ok and no need to check the heartbeats
+				if shard.Status != defs.StatusDone && !errors.Is(err, mongo.ErrNoDocuments) {
 					if err != nil {
 						return false, errors.Wrapf(err, "unable to read lock for shard %s", shard.Name)
 					}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -537,9 +537,10 @@ func (b *Backup) converged(
 					Replset: shard.Name,
 				})
 
-				// nodes are cleaning its locks moving to the done status
-				// so no lock is ok and no need to check the heartbeats
-				if shard.Status != defs.StatusDone && !errors.Is(err, mongo.ErrNoDocuments) {
+				// Nodes in terminal states (done, error, cancelled) may have
+				// already released their locks. Their status is handled by
+				// the switch below.
+				if shard.Status.IsRunning() && !errors.Is(err, mongo.ErrNoDocuments) {
 					if err != nil {
 						return false, errors.Wrapf(err, "unable to read lock for shard %s", shard.Name)
 					}

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -530,22 +530,23 @@ func (b *Backup) converged(
 	for _, sh := range shards {
 		for _, shard := range bmeta.Replsets {
 			if shard.Name == sh.RS {
-				// check if node alive
-				lck, err := lock.GetLockData(ctx, b.leadConn, &lock.LockHeader{
-					Type:    ctrl.CmdBackup,
-					OPID:    opid,
-					Replset: shard.Name,
-				})
-
+				// Check if node is alive.
 				// Nodes in terminal states (done, error, cancelled) may have
 				// already released their locks. Their status is handled by
 				// the switch below.
-				if shard.Status.IsRunning() && !errors.Is(err, mongo.ErrNoDocuments) {
-					if err != nil {
-						return false, errors.Wrapf(err, "unable to read lock for shard %s", shard.Name)
-					}
-					if lck.Heartbeat.T+defs.StaleFrameSec < clusterTime.T {
-						return false, errors.Errorf("lost shard %s, last beat ts: %d", shard.Name, lck.Heartbeat.T)
+				if shard.Status.IsRunning() {
+					lck, err := lock.GetLockData(ctx, b.leadConn, &lock.LockHeader{
+						Type:    ctrl.CmdBackup,
+						OPID:    opid,
+						Replset: shard.Name,
+					})
+					if !errors.Is(err, mongo.ErrNoDocuments) {
+						if err != nil {
+							return false, errors.Wrapf(err, "unable to read lock for shard %s", shard.Name)
+						}
+						if lck.Heartbeat.T+defs.StaleFrameSec < clusterTime.T {
+							return false, errors.Errorf("lost shard %s, last beat ts: %d", shard.Name, lck.Heartbeat.T)
+						}
 					}
 				}
 


### PR DESCRIPTION
Tickets:
- https://perconadev.atlassian.net/browse/PBM-1586
- https://perconadev.atlassian.net/browse/PBM-1648


pbm backup hangs forever when the backup leader agent crashes mid-backup because waitBackup() only checks the cluster-level status field, which nobody updates after the leader dies. This adds a stale heartbeat check — if the leader's heartbeat is older than 30 seconds, the CLI reports the backup as stuck with per-RS status detail, matching the detection already used by pbm status and agent-side waitForStatus.


```
dpbm backup -w
Starting backup "2026-03-12T10:16:39Z"....
Waiting for '2026-03-12T10:16:39Z' backup.............................. running
Error: backup stuck at "running" status, last heartbeat: 1773310600
- rs1: dumpDone
- rs2: dumpDone
- cfg: dumpDone
```

The PR also addresses a scenario when non-leader (shard) agent is the one that crushed -- which previously caused the leader to hang in waiting for cluster to converge to StatusDone