### PR TITLE
PBM-1599: CLI fails with timeout when stopping the balancer takes longer

### DIFF
--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -342,21 +342,7 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 				return errors.Errorf("status error on %s", rs)
 			}
 		case <-ctx.Done():
-			if bmeta == nil {
-				return errors.New("no progress from leader, backup metadata not found")
-			}
-			rs := ""
-			for _, s := range bmeta.Replsets {
-				rs += fmt.Sprintf("- Backup on replicaset \"%s\" in state: %v\n", s.Name, s.Status)
-				if s.Error != "" {
-					rs += ": " + s.Error
-				}
-			}
-			if rs == "" {
-				rs = "<no replset has started backup>\n"
-			}
-
-			return errors.New("no confirmation that backup has successfully started. Replsets status:\n" + rs)
+			return ctx.Err()
 		}
 	}
 }

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -316,15 +316,13 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
 
-	var bmeta *backup.BackupMeta
 	for {
 		select {
 		case <-tk.C:
 			if showProgress {
 				fmt.Print(".")
 			}
-			var err error
-			bmeta, err = backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
+			bmeta, err := backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
 			if err != nil {
 				return errors.Wrap(err, "get backup metadata")
 			}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -322,9 +322,6 @@ func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, 
 			}
 			var err error
 			bmeta, err = backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
-			if errors.Is(err, errors.ErrNotFound) {
-				continue
-			}
 			if err != nil {
 				return errors.Wrap(err, "get backup metadata")
 			}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -170,9 +170,7 @@ func runBackup(
 		}
 		fmt.Printf("Starting backup %q%s", b.name, pinfo)
 	}
-	startCtx, cancel := context.WithTimeout(ctx, cfg.Backup.Timeouts.StartingStatus())
-	defer cancel()
-	err = waitForBcpStatus(startCtx, conn, b.name, showProgress)
+	err = waitForBcpStatus(ctx, conn, b.name, showProgress)
 	if err != nil {
 		return nil, errors.Wrap(err, "wait for backup status")
 	}

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -278,7 +278,38 @@ func waitBackup(
 	}
 }
 
+func waitForBcpExists(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {
+	tk := time.NewTicker(time.Second)
+	defer tk.Stop()
+
+	existCtx, cancel := context.WithTimeout(ctx, defs.WaitBackupStart)
+	defer cancel()
+
+	for {
+		select {
+		case <-tk.C:
+			if showProgress {
+				fmt.Print(".")
+			}
+			_, err := backup.NewDBManager(conn).GetBackupByName(ctx, bcpName)
+			if errors.Is(err, errors.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return errors.Wrap(err, "get backup metadata")
+			}
+			return nil
+		case <-existCtx.Done():
+			return errors.New("no progress from leader, backup metadata not found")
+		}
+	}
+}
+
 func waitForBcpStatus(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {
+	if err := waitForBcpExists(ctx, conn, bcpName, showProgress); err != nil {
+		return err
+	}
+
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
 

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -171,6 +171,9 @@ func runBackup(
 		fmt.Printf("Starting backup %q%s", b.name, pinfo)
 	}
 	err = waitForBcpStatus(ctx, conn, b.name, showProgress)
+	if showProgress {
+		fmt.Println()
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "wait for backup status")
 	}
@@ -211,7 +214,7 @@ func runBackup(
 		}
 
 		if showProgress {
-			fmt.Printf("\nWaiting for '%s' backup...", b.name)
+			fmt.Printf("Waiting for '%s' backup...", b.name)
 		}
 		s, err := waitBackup(ctx, conn, b.name, defs.StatusDone, showProgress)
 		if s != nil && showProgress {

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -284,9 +284,7 @@ func waitBackup(
 func waitForBcpExists(ctx context.Context, conn connect.Client, bcpName string, showProgress bool) error {
 	tk := time.NewTicker(time.Second)
 	defer tk.Stop()
-
-	existCtx, cancel := context.WithTimeout(ctx, defs.WaitBackupStart)
-	defer cancel()
+	to := time.After(defs.WaitBackupStart)
 
 	for {
 		select {
@@ -302,7 +300,7 @@ func waitForBcpExists(ctx context.Context, conn connect.Client, bcpName string, 
 				return errors.Wrap(err, "get backup metadata")
 			}
 			return nil
-		case <-existCtx.Done():
+		case <-to:
 			return errors.New("no progress from leader, backup metadata not found")
 		}
 	}


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1599


Changes made:

- Running `pbm backup` now: 
    - first waits up to `defs.WaitBackupStart` to confirm backup meta vas saved
    - then waits for backup to reach StatusRunning without any timeout
- Running `pbm backup -w` remains unchanged 
- minor cosmetic tweak to print errors on new lines consistently with and w/o `-w`