### PR TITLE
PBM-1639 Improved detection of not possible shutdown

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -561,18 +561,21 @@ func (r *PhysRestore) removeFallback() error {
 	return errors.Wrap(err, "remove fallback db path")
 }
 
+func (r *PhysRestore) authEnabled() bool {
+	if r.secOpts == nil {
+		return false
+	}
+	return r.secOpts.KeyFile != "" || r.secOpts.Authorization == "enabled" || r.secOpts.ClusterAuthMode != ""
+}
+
 // checkShutdownImpossible returns an error if mongod rejects {shutdown: 1}.
 // Without auth, MongoDB only accepts shutdown from localhost connections.
 func (r *PhysRestore) checkShutdownImpossible(ctx context.Context) error {
-	authInfo, err := topo.CurrentUser(ctx, r.node)
-	if err != nil {
-		return errors.Wrap(err, "check connection auth status")
-	}
-	if len(authInfo.Users) > 0 {
+	if r.authEnabled() {
 		return nil
 	}
 
-	// Connection is unauthenticated — check if it's from localhost.
+	// Auth is not enforced — check if the connection is from localhost
 	res := r.node.Database("admin").RunCommand(ctx, bson.D{{"whatsmyuri", 1}})
 	var uri struct {
 		You string `bson:"you"`
@@ -591,7 +594,7 @@ func (r *PhysRestore) checkShutdownImpossible(ctx context.Context) error {
 		return nil
 	}
 
-	return errors.New("shutdown not possible: unauthenticated non-localhost connection")
+	return errors.New("shutdown not possible: non-localhost connection with auth disabled")
 }
 
 func nodeShutdown(ctx context.Context, m *mongo.Client) error {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -561,17 +561,33 @@ func (r *PhysRestore) removeFallback() error {
 	return errors.Wrap(err, "remove fallback db path")
 }
 
-func (r *PhysRestore) authEnabled() bool {
-	if r.secOpts == nil {
-		return false
+func (r *PhysRestore) authEnabled(ctx context.Context) (bool, error) {
+	var result struct {
+		Parsed struct {
+			Security struct {
+				Authorization   string `bson:"authorization"`
+				KeyFile         string `bson:"keyFile"`
+				ClusterAuthMode string `bson:"clusterAuthMode"`
+			} `bson:"security"`
+		} `bson:"parsed"`
 	}
-	return r.secOpts.KeyFile != "" || r.secOpts.Authorization == "enabled" || r.secOpts.ClusterAuthMode != ""
+	err := r.node.Database("admin").RunCommand(ctx, bson.D{{"getCmdLineOpts", 1}}).Decode(&result)
+	if err != nil {
+		return false, errors.Wrap(err, "get mongod auth config")
+	}
+
+	sec := result.Parsed.Security
+	return sec.KeyFile != "" || sec.Authorization == "enabled" || sec.ClusterAuthMode != "", nil
 }
 
 // checkShutdownImpossible returns an error if mongod rejects {shutdown: 1}.
 // Without auth, MongoDB only accepts shutdown from localhost connections.
 func (r *PhysRestore) checkShutdownImpossible(ctx context.Context) error {
-	if r.authEnabled() {
+	authOn, err := r.authEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if authOn {
 		return nil
 	}
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1246,16 +1246,16 @@ func (r *PhysRestore) Snapshot(
 		}
 	}
 
+	// Detect configurations where mongod shutdown is impossible.
+	if err = r.checkShutdownFails(ctx); err != nil {
+		return err
+	}
+
 	_, err = r.toState(defs.StatusStarting)
 	if err != nil {
 		return errors.Wrap(err, "move to running state")
 	}
 	l.Debug("%s", defs.StatusStarting)
-
-	// Detect configurations where mongod shutdown is impossible.
-	if err = r.checkShutdownFails(ctx); err != nil {
-		return err
-	}
 
 	logger := log.FromContext(ctx)
 	r.enableLogBuff(logger)

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -580,9 +580,9 @@ func (r *PhysRestore) authEnabled(ctx context.Context) (bool, error) {
 	return sec.KeyFile != "" || sec.Authorization == "enabled" || sec.ClusterAuthMode != "", nil
 }
 
-// checkShutdownImpossible returns an error if mongod rejects {shutdown: 1}.
+// checkShutdownFails returns an error if mongod rejects {shutdown: 1}.
 // Without auth, MongoDB only accepts shutdown from localhost connections.
-func (r *PhysRestore) checkShutdownImpossible(ctx context.Context) error {
+func (r *PhysRestore) checkShutdownFails(ctx context.Context) error {
 	authOn, err := r.authEnabled(ctx)
 	if err != nil {
 		return err
@@ -1253,7 +1253,7 @@ func (r *PhysRestore) Snapshot(
 	l.Debug("%s", defs.StatusStarting)
 
 	// Detect configurations where mongod shutdown is impossible.
-	if err = r.checkShutdownImpossible(ctx); err != nil {
+	if err = r.checkShutdownFails(ctx); err != nil {
 		return err
 	}
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1253,7 +1253,7 @@ func (r *PhysRestore) Snapshot(
 	l.Debug("%s", defs.StatusStarting)
 
 	// Detect configurations where mongod shutdown is impossible.
-	if err := r.checkShutdownImpossible(ctx); err != nil {
+	if err = r.checkShutdownImpossible(ctx); err != nil {
 		return err
 	}
 

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -561,6 +561,39 @@ func (r *PhysRestore) removeFallback() error {
 	return errors.Wrap(err, "remove fallback db path")
 }
 
+// checkShutdownImpossible returns an error if mongod rejects {shutdown: 1}.
+// Without auth, MongoDB only accepts shutdown from localhost connections.
+func (r *PhysRestore) checkShutdownImpossible(ctx context.Context) error {
+	authInfo, err := topo.CurrentUser(ctx, r.node)
+	if err != nil {
+		return errors.Wrap(err, "check connection auth status")
+	}
+	if len(authInfo.Users) > 0 {
+		return nil
+	}
+
+	// Connection is unauthenticated — check if it's from localhost.
+	res := r.node.Database("admin").RunCommand(ctx, bson.D{{"whatsmyuri", 1}})
+	var uri struct {
+		You string `bson:"you"`
+	}
+	if err := res.Decode(&uri); err != nil {
+		return errors.Wrap(err, "check connection source address")
+	}
+
+	host, _, err := net.SplitHostPort(uri.You)
+	if err != nil {
+		return errors.Wrapf(err, "parse connection address %q", uri.You)
+	}
+
+	ip := net.ParseIP(host)
+	if ip != nil && ip.IsLoopback() {
+		return nil
+	}
+
+	return errors.New("shutdown not possible: unauthenticated non-localhost connection")
+}
+
 func nodeShutdown(ctx context.Context, m *mongo.Client) error {
 	err := m.Database("admin").RunCommand(ctx, bson.D{{"shutdown", 1}}).Err()
 	if err == nil || strings.Contains(err.Error(), "socket was unexpectedly closed") {
@@ -1199,6 +1232,11 @@ func (r *PhysRestore) Snapshot(
 		return errors.Wrap(err, "move to running state")
 	}
 	l.Debug("%s", defs.StatusStarting)
+
+	// Detect configurations where mongod shutdown is impossible.
+	if err := r.checkShutdownImpossible(ctx); err != nil {
+		return err
+	}
 
 	logger := log.FromContext(ctx)
 	r.enableLogBuff(logger)

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -180,11 +180,6 @@ type MongodOptsSec struct {
 		KeyIdentifier             *string `bson:"keyIdentifier,omitempty" json:"keyIdentifier,omitempty" yaml:"keyIdentifier,omitempty"`
 		ClientCertificatePassword *string `bson:"clientCertificatePassword,omitempty" json:"-" yaml:"clientCertificatePassword,omitempty"`
 	} `bson:"kmip,omitempty" json:"kmip,omitempty" yaml:"kmip,omitempty"`
-
-	// Auth-related fields (needed for checkShutdownImpossible)
-	Authorization    string `bson:"authorization,omitempty" json:"-" yaml:"-"`
-	KeyFile          string `bson:"keyFile,omitempty" json:"-" yaml:"-"`
-	ClusterAuthMode  string `bson:"clusterAuthMode,omitempty" json:"-" yaml:"-"`
 }
 
 type ExternOpts map[string]MongodOpts

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -180,6 +180,11 @@ type MongodOptsSec struct {
 		KeyIdentifier             *string `bson:"keyIdentifier,omitempty" json:"keyIdentifier,omitempty" yaml:"keyIdentifier,omitempty"`
 		ClientCertificatePassword *string `bson:"clientCertificatePassword,omitempty" json:"-" yaml:"clientCertificatePassword,omitempty"`
 	} `bson:"kmip,omitempty" json:"kmip,omitempty" yaml:"kmip,omitempty"`
+
+	// Auth-related fields (needed for checkShutdownImpossible)
+	Authorization    string `bson:"authorization,omitempty" json:"authorization,omitempty" yaml:"authorization,omitempty"`
+	KeyFile          string `bson:"keyFile,omitempty" json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
+	ClusterAuthMode  string `bson:"clusterAuthMode,omitempty" json:"clusterAuthMode,omitempty" yaml:"clusterAuthMode,omitempty"`
 }
 
 type ExternOpts map[string]MongodOpts

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -182,9 +182,9 @@ type MongodOptsSec struct {
 	} `bson:"kmip,omitempty" json:"kmip,omitempty" yaml:"kmip,omitempty"`
 
 	// Auth-related fields (needed for checkShutdownImpossible)
-	Authorization    string `bson:"authorization,omitempty" json:"authorization,omitempty" yaml:"authorization,omitempty"`
-	KeyFile          string `bson:"keyFile,omitempty" json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
-	ClusterAuthMode  string `bson:"clusterAuthMode,omitempty" json:"clusterAuthMode,omitempty" yaml:"clusterAuthMode,omitempty"`
+	Authorization    string `bson:"authorization,omitempty" json:"-" yaml:"-"`
+	KeyFile          string `bson:"keyFile,omitempty" json:"-" yaml:"-"`
+	ClusterAuthMode  string `bson:"clusterAuthMode,omitempty" json:"-" yaml:"-"`
 }
 
 type ExternOpts map[string]MongodOpts


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1639

Size of the RS is actually not relevat. Only two things mater

- cluster authentication is NOT enabled
- client connects via non-localhost connection 

in such case, mongod will always reject shutdown command execution 