### PR TITLE
PBM-1657  Reject mongodb+srv:// URI scheme with a clear error message

### DIFF
--- a/pbm/connect/connect.go
+++ b/pbm/connect/connect.go
@@ -106,13 +106,19 @@ func ServerSelectionTimeout(d time.Duration) MongoOption {
 	}
 }
 
+// ensureMongoScheme ensures the URI has a mongodb:// scheme prefix.
+func ensureMongoScheme(uri string) string {
+	if !strings.HasPrefix(uri, "mongodb://") {
+		uri = "mongodb://" + uri
+	}
+	return uri
+}
+
 func MongoConnectWithOpts(ctx context.Context,
 	uri string,
 	mongoOptions ...MongoOption,
 ) (*mongo.Client, *options.ClientOptions, error) {
-	if !strings.HasPrefix(uri, "mongodb://") {
-		uri = "mongodb://" + uri
-	}
+	uri = ensureMongoScheme(uri)
 
 	// default options
 	mopts := options.Client().

--- a/pbm/connect/connect.go
+++ b/pbm/connect/connect.go
@@ -107,18 +107,25 @@ func ServerSelectionTimeout(d time.Duration) MongoOption {
 }
 
 // ensureMongoScheme ensures the URI has a mongodb:// scheme prefix.
-func ensureMongoScheme(uri string) string {
+// Returns an error if mongodb+srv:// scheme is used.
+func ensureMongoScheme(uri string) (string, error) {
+	if strings.HasPrefix(uri, "mongodb+srv://") {
+		return "", errors.New("mongodb+srv:// URI scheme is not supported, use mongodb:// instead")
+	}
 	if !strings.HasPrefix(uri, "mongodb://") {
 		uri = "mongodb://" + uri
 	}
-	return uri
+	return uri, nil
 }
 
 func MongoConnectWithOpts(ctx context.Context,
 	uri string,
 	mongoOptions ...MongoOption,
 ) (*mongo.Client, *options.ClientOptions, error) {
-	uri = ensureMongoScheme(uri)
+	uri, err := ensureMongoScheme(uri)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// default options
 	mopts := options.Client().

--- a/pbm/connect/connect_test.go
+++ b/pbm/connect/connect_test.go
@@ -1,0 +1,38 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureMongoScheme(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "with scheme",
+			uri:  "mongodb://user:pass@host:27017",
+			want: "mongodb://user:pass@host:27017",
+		},
+		{
+			name: "host only",
+			uri:  "host:27017",
+			want: "mongodb://host:27017",
+		},
+		{
+			name: "with credentials",
+			uri:  "user:pass@host:27017",
+			want: "mongodb://user:pass@host:27017",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureMongoScheme(tt.uri)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pbm/connect/connect_test.go
+++ b/pbm/connect/connect_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureMongoScheme(t *testing.T) {
 	tests := []struct {
-		name string
-		uri  string
-		want string
+		name    string
+		uri     string
+		want    string
+		wantErr string
 	}{
 		{
 			name: "with scheme",
@@ -27,12 +29,23 @@ func TestEnsureMongoScheme(t *testing.T) {
 			uri:  "user:pass@host:27017",
 			want: "mongodb://user:pass@host:27017",
 		},
+		{
+			name:    "srv scheme",
+			uri:     "mongodb+srv://user:pass@cluster.example.com",
+			wantErr: "mongodb+srv:// URI scheme is not supported",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ensureMongoScheme(tt.uri)
-			assert.Equal(t, tt.want, got)
+			got, err := ensureMongoScheme(tt.uri)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1657

```sh
pbm s --mongodb-uri mongodb+srv://host
Error: connect to mongodb: create mongo connection: mongodb+srv:// URI scheme is not supported, use mongodb:// instead
```

Same message will be presented if agent gets configured with `+srv` (previously  code progressed to option validation since `mognodb+srv://host` was transformed into `mongodb://mongodb+srv://host`). 

A shorter error message was used compared to the ticket as that one was too long. 