### PR TITLE
PBM-1731: Add backup lifecycle management with GFS rotation to pbm

### DIFF
--- a/cmd/pbm-agent/profile.go
+++ b/cmd/pbm-agent/profile.go
@@ -112,7 +112,8 @@ func (a *Agent) handleAddConfigProfile(
 		Storage:   cmd.Storage,
 	}
 	if cmd.Lifecycle != nil {
-		profile.Lifecycle = *cmd.Lifecycle
+		l := *cmd.Lifecycle
+		profile.Lifecycle = &l
 	}
 	err = config.AddProfile(ctx, a.leadConn, profile)
 	if err != nil {

--- a/cmd/pbm-agent/profile.go
+++ b/cmd/pbm-agent/profile.go
@@ -111,6 +111,9 @@ func (a *Agent) handleAddConfigProfile(
 		IsProfile: true,
 		Storage:   cmd.Storage,
 	}
+	if cmd.Lifecycle != nil {
+		profile.Lifecycle = *cmd.Lifecycle
+	}
 	err = config.AddProfile(ctx, a.leadConn, profile)
 	if err != nil {
 		err = errors.Wrap(err, "add profile config")

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -123,25 +123,56 @@ func (app *pbmApp) validateEnum(fieldName, value string, valid []string) error {
 
 func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 	var dryRun *bool
+	var profile string
 
 	lifecycleCmd := &cobra.Command{
 		Use:   "lifecycle",
 		Short: "Manage backup retention and rotation lifecycle",
 		RunE: app.wrapRunE(func(cmd *cobra.Command, args []string) (fmt.Stringer, error) {
-			cfg, err := config.GetConfig(app.ctx, app.conn)
-			if err != nil {
-				return nil, errors.Wrap(err, "get config")
+
+			var cfg *config.Config
+			var err error
+
+			// 1. Fetch the correct configuration
+			if profile != "" {
+				cfg, err = config.GetProfileConfig(app.ctx, app.conn, profile)
+				if err != nil {
+					return nil, errors.Wrap(err, "get profile config")
+				}
+			} else {
+				cfg, err = config.GetConfig(app.ctx, app.conn)
+				if err != nil {
+					return nil, errors.Wrap(err, "get config")
+				}
 			}
 
+			// 2. Fetch all backups
 			bcps, err := backup.BackupsList(app.ctx, app.conn, 0)
 			if err != nil {
 				return nil, errors.Wrap(err, "fetch backups")
 			}
 
-			report := lifecycle.Evaluate(cfg.Lifecycle, bcps, *dryRun, time.Now().UTC())
+			// 3. Filter backups to strictly match the targeted profile
+			var targetBcps []backup.BackupMeta
+			for _, b := range bcps {
+
+				storageProfile := b.Store.Name
+
+				if profile != "" && storageProfile != profile {
+					continue // Skip backups belonging to other profiles
+				}
+				if profile == "" && b.Store.IsProfile {
+					// Using b.Store.IsProfile is a bit safer than just checking if the name is blank,
+					// as it perfectly aligns with PBM's internal logic for identifying external profiles.
+					continue // If running default lifecycle, skip profile-specific backups
+				}
+				targetBcps = append(targetBcps, b)
+			}
+
+			// 4. Evaluate using only the targeted backups and config
+			report := lifecycle.Evaluate(cfg.Lifecycle, targetBcps, *dryRun, time.Now().UTC())
 			isJSON := app.pbmOutF == outJSON || app.pbmOutF == outJSONpretty
 
-			// 1. Text mode: Print report first so user sees what will be purged
 			if !isJSON {
 				fmt.Println(report.String())
 			}
@@ -154,7 +185,6 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 				return lifecycleResult{Report: report, Msg: "No backups to purge.", Aborted: false}, nil
 			}
 
-			// 2. Safety Check & Prompt Logic
 			minKeep := 1
 			if cfg.Lifecycle.MinKeep != nil {
 				minKeep = *cfg.Lifecycle.MinKeep
@@ -165,7 +195,6 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 				shouldPrompt = *cfg.Lifecycle.Prompt
 			}
 
-			// Force-disable prompt if outputting JSON to prevent pipeline hanging
 			if isJSON {
 				shouldPrompt = false
 			}
@@ -208,7 +237,6 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 				fmt.Println("Starting deletion...")
 			}
 
-			// 3. Deletion loop
 			for i := len(report.BackupsPurged) - 1; i >= 0; i-- {
 				name := report.BackupsPurged[i]
 
@@ -231,6 +259,11 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 	}
 
 	dryRun = lifecycleCmd.Flags().Bool("dry-run", false, "Report but do not delete")
+
+	// Register the profile flag
+	lifecycleCmd.Flags().StringVar(
+		&profile, "profile", "", "Config profile name to apply specific lifecycle rules",
+	)
 
 	return lifecycleCmd
 }

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -14,9 +15,11 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/config"
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/lifecycle"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
@@ -72,6 +75,18 @@ type pbmApp struct {
 	node    string
 }
 
+type lifecycleResult struct {
+	Report  *lifecycle.Report `json:"report"`
+	Msg     string            `json:"msg"`
+	Aborted bool              `json:"aborted"`
+}
+
+func (r lifecycleResult) String() string {
+	// In text mode, the report is progressively printed to stdout.
+	// This stringer just returns the final exit message.
+	return r.Msg
+}
+
 func main() {
 	app := newPbmApp()
 	if err := app.rootCmd.Execute(); err != nil {
@@ -104,6 +119,120 @@ func (app *pbmApp) validateEnum(fieldName, value string, valid []string) error {
 	}
 
 	return errors.New(fmt.Sprintf("invalid %s value: %q (must be one of %v)", fieldName, value, valid))
+}
+
+func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
+	var dryRun *bool
+
+	lifecycleCmd := &cobra.Command{
+		Use:   "lifecycle",
+		Short: "Manage backup retention and rotation lifecycle",
+		RunE: app.wrapRunE(func(cmd *cobra.Command, args []string) (fmt.Stringer, error) {
+			cfg, err := config.GetConfig(app.ctx, app.conn)
+			if err != nil {
+				return nil, errors.Wrap(err, "get config")
+			}
+
+			bcps, err := backup.BackupsList(app.ctx, app.conn, 0)
+			if err != nil {
+				return nil, errors.Wrap(err, "fetch backups")
+			}
+
+			report := lifecycle.Evaluate(cfg.Lifecycle, bcps, *dryRun, time.Now().UTC())
+			isJSON := app.pbmOutF == outJSON || app.pbmOutF == outJSONpretty
+
+			// 1. Text mode: Print report first so user sees what will be purged
+			if !isJSON {
+				fmt.Println(report.String())
+			}
+
+			if *dryRun || !cfg.Lifecycle.Enabled {
+				return lifecycleResult{Report: report}, nil
+			}
+
+			if len(report.BackupsPurged) == 0 {
+				return lifecycleResult{Report: report, Msg: "No backups to purge.", Aborted: false}, nil
+			}
+
+			// 2. Safety Check & Prompt Logic
+			minKeep := 1
+			if cfg.Lifecycle.MinKeep != nil {
+				minKeep = *cfg.Lifecycle.MinKeep
+			}
+
+			shouldPrompt := true
+			if cfg.Lifecycle.Prompt != nil {
+				shouldPrompt = *cfg.Lifecycle.Prompt
+			}
+
+			// Force-disable prompt if outputting JSON to prevent pipeline hanging
+			if isJSON {
+				shouldPrompt = false
+			}
+
+			if len(report.BackupsKept) < minKeep {
+				if !isJSON {
+					fmt.Printf("\nWARNING: This rotation would leave you with %d backup(s), which is below the safety threshold of %d (minKeep).\n", len(report.BackupsKept), minKeep)
+				}
+
+				if shouldPrompt {
+					fmt.Print("Do you want to FORCE the deletion anyway and bypass this safety threshold? [y/N]: ")
+					reader := bufio.NewReader(os.Stdin)
+					response, err := reader.ReadString('\n')
+					if err != nil {
+						return nil, errors.Wrap(err, "read prompt response")
+					}
+
+					response = strings.ToLower(strings.TrimSpace(response))
+					if response != "y" && response != "yes" {
+						return lifecycleResult{Report: report, Msg: "Operation cancelled by user to protect backups.", Aborted: true}, nil
+					}
+				} else {
+					return lifecycleResult{Report: report, Msg: "Automated run (prompt: false) detected. Purge aborted to protect your backups.", Aborted: true}, nil
+				}
+			} else if shouldPrompt {
+				fmt.Print("Are you sure you want to permanently delete the purged backups? [y/N]: ")
+				reader := bufio.NewReader(os.Stdin)
+				response, err := reader.ReadString('\n')
+				if err != nil {
+					return nil, errors.Wrap(err, "read prompt response")
+				}
+
+				response = strings.ToLower(strings.TrimSpace(response))
+				if response != "y" && response != "yes" {
+					return lifecycleResult{Report: report, Msg: "Operation cancelled by user.", Aborted: true}, nil
+				}
+			}
+
+			if !isJSON {
+				fmt.Println("Starting deletion...")
+			}
+
+			// 3. Deletion loop
+			for i := len(report.BackupsPurged) - 1; i >= 0; i-- {
+				name := report.BackupsPurged[i]
+
+				if app.ctx.Err() != nil {
+					return lifecycleResult{Report: report, Msg: "Operation cancelled by user.", Aborted: true}, nil
+				}
+
+				if !isJSON {
+					fmt.Printf("Purging backup %s...\n", name)
+				}
+
+				err := backup.DeleteBackup(app.ctx, app.conn, name, app.node)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to delete %s: %v\n", name, err)
+				}
+			}
+
+			return lifecycleResult{Report: report, Msg: "Lifecycle rotation complete.", Aborted: false}, nil
+		}),
+	}
+
+	dryRun = lifecycleCmd.Flags().Bool("dry-run", false, "Report but do not delete")
+
+	return lifecycleCmd
 }
 
 func newPbmApp() *pbmApp {
@@ -150,6 +279,7 @@ func newPbmApp() *pbmApp {
 	app.rootCmd.AddCommand(app.buildStatusCmd())
 	app.rootCmd.AddCommand(app.buildVersionCmd())
 	app.rootCmd.AddCommand(util.CompletionCommand())
+	app.rootCmd.AddCommand(app.buildLifecycleCmd())
 
 	return app
 }

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -135,7 +135,7 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 
 			// 1. Fetch the correct configuration
 			if profile != "" {
-				cfg, err = config.GetProfileConfig(app.ctx, app.conn, profile)
+				cfg, err = config.GetProfile(app.ctx, app.conn, profile)
 				if err != nil {
 					return nil, errors.Wrap(err, "get profile config")
 				}
@@ -170,7 +170,7 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 			}
 
 			// 4. Evaluate using only the targeted backups and config
-			report := lifecycle.Evaluate(cfg.Lifecycle, targetBcps, *dryRun, time.Now().UTC())
+			report := lifecycle.Evaluate(*cfg.Lifecycle, targetBcps, *dryRun, time.Now().UTC())
 			isJSON := app.pbmOutF == outJSON || app.pbmOutF == outJSONpretty
 
 			if !isJSON {
@@ -178,11 +178,18 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 			}
 
 			if *dryRun || !cfg.Lifecycle.Enabled {
-				return lifecycleResult{Report: report}, nil
+				if isJSON {
+					return lifecycleResult{Report: report}, nil
+				}
+				return nil, nil
 			}
 
 			if len(report.BackupsPurged) == 0 {
-				return lifecycleResult{Report: report, Msg: "No backups to purge.", Aborted: false}, nil
+				if isJSON {
+					return lifecycleResult{Report: report, Msg: "No backups to purge.", Aborted: false}, nil
+				}
+				fmt.Println("No backups to purge.")
+				return nil, nil
 			}
 
 			minKeep := 1
@@ -214,10 +221,20 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 
 					response = strings.ToLower(strings.TrimSpace(response))
 					if response != "y" && response != "yes" {
-						return lifecycleResult{Report: report, Msg: "Operation cancelled by user to protect backups.", Aborted: true}, nil
+						msg := "Operation cancelled by user to protect backups."
+						if isJSON {
+							return lifecycleResult{Report: report, Msg: msg, Aborted: true}, nil
+						}
+						fmt.Println(msg)
+						return nil, nil
 					}
 				} else {
-					return lifecycleResult{Report: report, Msg: "Automated run (prompt: false) detected. Purge aborted to protect your backups.", Aborted: true}, nil
+					msg := "Automated run (prompt: false) detected. Purge aborted to protect your backups."
+					if isJSON {
+						return lifecycleResult{Report: report, Msg: msg, Aborted: true}, nil
+					}
+					fmt.Println(msg)
+					return nil, nil
 				}
 			} else if shouldPrompt {
 				fmt.Print("Are you sure you want to permanently delete the purged backups? [y/N]: ")
@@ -229,7 +246,12 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 
 				response = strings.ToLower(strings.TrimSpace(response))
 				if response != "y" && response != "yes" {
-					return lifecycleResult{Report: report, Msg: "Operation cancelled by user.", Aborted: true}, nil
+					msg := "Operation cancelled by user."
+					if isJSON {
+						return lifecycleResult{Report: report, Msg: msg, Aborted: true}, nil
+					}
+					fmt.Println(msg)
+					return nil, nil
 				}
 			}
 
@@ -254,7 +276,12 @@ func (app *pbmApp) buildLifecycleCmd() *cobra.Command {
 				}
 			}
 
-			return lifecycleResult{Report: report, Msg: "Lifecycle rotation complete.", Aborted: false}, nil
+			msg := "Lifecycle rotation complete."
+			if isJSON {
+				return lifecycleResult{Report: report, Msg: msg, Aborted: false}, nil
+			}
+			fmt.Println(msg)
+			return nil, nil
 		}),
 	}
 

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -70,6 +70,22 @@ func validateConfigKey(k string) bool {
 	return ok
 }
 
+// LifecycleConf defines the backup rotation and retention policy rules.
+type LifecycleConf struct {
+	Enabled     bool   `bson:"enabled" json:"enabled" yaml:"enabled"`
+	Strategy    string `bson:"strategy,omitempty" json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	PurgeFailed bool   `bson:"purgeFailed" json:"purgeFailed" yaml:"purgeFailed"`
+	Prompt      *bool  `bson:"prompt,omitempty" json:"prompt,omitempty" yaml:"prompt,omitempty"`
+
+	MinKeep *int `bson:"minKeep,omitempty" json:"minKeep,omitempty" yaml:"minKeep,omitempty"`
+
+	DailyRetention   int `bson:"dailyRetention" json:"dailyRetention" yaml:"dailyRetention"`
+	WeeklyRetention  int `bson:"weeklyRetention" json:"weeklyRetention" yaml:"weeklyRetention"`
+	WeeklyDay        int `bson:"weeklyDay" json:"weeklyDay" yaml:"weeklyDay"`
+	MonthlyRetention int `bson:"monthlyRetention" json:"monthlyRetention" yaml:"monthlyRetention"`
+	MonthlyDay       int `bson:"monthlyDay" json:"monthlyDay" yaml:"monthlyDay"`
+}
+
 // Config is a pbm config
 type Config struct {
 	Name      string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
@@ -80,7 +96,8 @@ type Config struct {
 	Backup  *BackupConf  `bson:"backup,omitempty" json:"backup,omitempty" yaml:"backup,omitempty"`
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
 
-	Epoch primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
+	Epoch     primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
+	Lifecycle LifecycleConf       `bson:"lifecycle,omitempty" json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 }
 
 func Parse(r io.Reader) (*Config, error) {

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -97,7 +97,7 @@ type Config struct {
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
 
 	Epoch     primitive.Timestamp `bson:"epoch" json:"-" yaml:"-"`
-	Lifecycle LifecycleConf       `bson:"lifecycle,omitempty" json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
+	Lifecycle *LifecycleConf      `bson:"lifecycle,omitempty" json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 }
 
 func Parse(r io.Reader) (*Config, error) {
@@ -131,6 +131,10 @@ func (c *Config) Clone() *Config {
 		Restore:   c.Restore.Clone(),
 		Backup:    c.Backup.Clone(),
 		Epoch:     c.Epoch,
+	}
+	if c.Lifecycle != nil {
+		l := *c.Lifecycle
+		rv.Lifecycle = &l
 	}
 
 	return rv
@@ -576,6 +580,9 @@ func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {
 	if cfg.Restore == nil {
 		cfg.Restore = &RestoreConf{}
 	}
+	if cfg.Lifecycle == nil {
+		cfg.Lifecycle = &LifecycleConf{}
+	}
 
 	if cfg.Backup.Compression == "" {
 		cfg.Backup.Compression = defs.DefaultCompression
@@ -585,35 +592,6 @@ func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {
 	}
 	if cfg.PITR.CompressionLevel == nil {
 		cfg.PITR.CompressionLevel = cfg.Backup.CompressionLevel
-	}
-
-	return cfg, nil
-}
-
-// GetProfileConfig fetches a specific configuration profile from the database
-func GetProfileConfig(ctx context.Context, m connect.Client, name string) (*Config, error) {
-	res := m.ConfigCollection().FindOne(ctx, bson.D{{"name", name}, {"profile", true}})
-	if err := res.Err(); err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, errors.Wrapf(ErrMissedConfigProfile, "profile '%s' not found", name)
-		}
-		return nil, errors.Wrap(err, "get profile")
-	}
-
-	cfg := &Config{}
-	if err := res.Decode(&cfg); err != nil {
-		return nil, errors.Wrap(err, "decode profile config")
-	}
-
-	// Apply base struct defaults
-	if cfg.PITR == nil {
-		cfg.PITR = &PITRConf{}
-	}
-	if cfg.Backup == nil {
-		cfg.Backup = &BackupConf{}
-	}
-	if cfg.Restore == nil {
-		cfg.Restore = &RestoreConf{}
 	}
 
 	return cfg, nil

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -590,6 +590,35 @@ func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {
 	return cfg, nil
 }
 
+// GetProfileConfig fetches a specific configuration profile from the database
+func GetProfileConfig(ctx context.Context, m connect.Client, name string) (*Config, error) {
+	res := m.ConfigCollection().FindOne(ctx, bson.D{{"name", name}, {"profile", true}})
+	if err := res.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, errors.Wrapf(ErrMissedConfigProfile, "profile '%s' not found", name)
+		}
+		return nil, errors.Wrap(err, "get profile")
+	}
+
+	cfg := &Config{}
+	if err := res.Decode(&cfg); err != nil {
+		return nil, errors.Wrap(err, "decode profile config")
+	}
+
+	// Apply base struct defaults
+	if cfg.PITR == nil {
+		cfg.PITR = &PITRConf{}
+	}
+	if cfg.Backup == nil {
+		cfg.Backup = &BackupConf{}
+	}
+	if cfg.Restore == nil {
+		cfg.Restore = &RestoreConf{}
+	}
+
+	return cfg, nil
+}
+
 // SetConfig stores config doc within the database.
 // It also applies main storage parameters depending on the type of storage
 // and assigns those possible default values to the cfg parameter.

--- a/pbm/config/profile.go
+++ b/pbm/config/profile.go
@@ -50,6 +50,19 @@ func GetProfile(ctx context.Context, m connect.Client, name string) (*Config, er
 		return nil, errors.Wrap(err, "decode")
 	}
 
+	if profile.PITR == nil {
+		profile.PITR = &PITRConf{}
+	}
+	if profile.Backup == nil {
+		profile.Backup = &BackupConf{}
+	}
+	if profile.Restore == nil {
+		profile.Restore = &RestoreConf{}
+	}
+	if profile.Lifecycle == nil {
+		profile.Lifecycle = &LifecycleConf{}
+	}
+
 	return profile, nil
 }
 

--- a/pbm/config/util.go
+++ b/pbm/config/util.go
@@ -35,6 +35,7 @@ func GetProfiledConfig(ctx context.Context, conn connect.Client, profile string)
 		cfg.Storage = custom.Storage
 		cfg.Name = custom.Name
 		cfg.IsProfile = true
+		cfg.Lifecycle = custom.Lifecycle
 	}
 
 	if storage.ParseType(string(cfg.Storage.Type)) == storage.Undefined {

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -115,9 +115,10 @@ func (c Cmd) String() string {
 }
 
 type ProfileCmd struct {
-	Name      string             `bson:"name"`
-	IsProfile bool               `bson:"profile"`
-	Storage   config.StorageConf `bson:"storage"`
+	Name      string                `bson:"name"`
+	IsProfile bool                  `bson:"profile"`
+	Storage   config.StorageConf    `bson:"storage"`
+	Lifecycle *config.LifecycleConf `bson:"lifecycle,omitempty"`
 }
 
 type ResyncCmd struct {

--- a/pbm/ctrl/send.go
+++ b/pbm/ctrl/send.go
@@ -75,6 +75,7 @@ func SendAddConfigProfile(
 	m connect.Client,
 	name string,
 	storage config.StorageConf,
+	lifecycle *config.LifecycleConf,
 ) (OPID, error) {
 	cmd := Cmd{
 		Cmd: CmdAddConfigProfile,
@@ -82,6 +83,7 @@ func SendAddConfigProfile(
 			Name:      name,
 			IsProfile: true,
 			Storage:   storage,
+			Lifecycle: lifecycle,
 		},
 	}
 	return sendCommand(ctx, m, cmd)

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -1,0 +1,206 @@
+package lifecycle
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/percona/percona-backup-mongodb/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/pbm/config"
+	"github.com/percona/percona-backup-mongodb/pbm/defs"
+)
+
+type Report struct {
+	DryRun        bool
+	ConfigUsed    config.LifecycleConf
+	BackupsKept   []string
+	BackupsPurged []string
+}
+
+func (r *Report) String() string {
+	strategy := strings.ToLower(r.ConfigUsed.Strategy)
+	if strategy == "" {
+		strategy = "rolling" // Default
+	}
+
+	weeklyStr := "Auto (Newest in bucket)"
+	monthlyStr := "Auto (Newest in bucket)"
+
+	if strategy == "calendar" {
+		weeklyStr = fmt.Sprintf("Target Day: %d", r.ConfigUsed.WeeklyDay)
+		monthlyStr = fmt.Sprintf("Target Date: %d", r.ConfigUsed.MonthlyDay)
+	}
+
+	minKeep := 1
+	if r.ConfigUsed.MinKeep != nil {
+		minKeep = *r.ConfigUsed.MinKeep
+	}
+
+	res := fmt.Sprintf("Lifecycle Report (Dry Run: %v)\n", r.DryRun)
+	res += fmt.Sprintf("Enabled: %v | Strategy: %s | Purge Failed: %v | Min Keep: %d\n", r.ConfigUsed.Enabled, strings.ToUpper(strategy), r.ConfigUsed.PurgeFailed, minKeep)
+	res += fmt.Sprintf("Daily: %d | Weekly: %d [%s] | Monthly: %d [%s]\n\n",
+		r.ConfigUsed.DailyRetention,
+		r.ConfigUsed.WeeklyRetention, weeklyStr,
+		r.ConfigUsed.MonthlyRetention, monthlyStr)
+
+	res += fmt.Sprintf("Backups to KEEP (%d):\n", len(r.BackupsKept))
+	for _, b := range r.BackupsKept {
+		res += fmt.Sprintf("  - %s\n", b)
+	}
+
+	res += fmt.Sprintf("\nBackups to PURGE (%d):\n", len(r.BackupsPurged))
+	for _, b := range r.BackupsPurged {
+		res += fmt.Sprintf("  - %s\n", b)
+	}
+	return res
+}
+
+// Evaluate determines which backups to keep and which to purge based on the config.
+func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool, now time.Time) *Report {
+	report := &Report{
+		DryRun:     dryRun,
+		ConfigUsed: cfg,
+	}
+
+	// Exit early if disabled and not a dry run.
+	if !cfg.Enabled && !dryRun {
+		return report
+	}
+
+	isCalendar := strings.ToLower(cfg.Strategy) == "calendar"
+
+	keepMap := make(map[string]bool)
+
+	dailyCutoff := now.AddDate(0, 0, -cfg.DailyRetention)
+	weeklyCutoff := now.AddDate(0, 0, -(cfg.WeeklyRetention * 7))
+	monthlyCutoff := now.AddDate(0, -cfg.MonthlyRetention, 0)
+
+	weeklyCandidates := make(map[string][]backup.BackupMeta)
+	monthlyCandidates := make(map[string][]backup.BackupMeta)
+
+	// 1. Bucketing phase
+	for _, bcp := range backups {
+		// ALWAYS protect in-progress backups. They are never purged.
+		if bcp.Status.IsRunning() {
+			keepMap[bcp.Name] = true
+			continue
+		}
+
+		bcpTime := time.Unix(bcp.StartTS, 0).UTC()
+		ageInDays := int(now.Sub(bcpTime).Hours() / 24)
+
+		// Handle Failed/Cancelled backups
+		if bcp.Status == defs.StatusError || bcp.Status == defs.StatusCancelled {
+			if !cfg.PurgeFailed {
+				keepMap[bcp.Name] = true // Protect failed backups if PurgeFailed is false
+			} else {
+				// If PurgeFailed is true, only keep them if they fall into the Daily window
+				if cfg.DailyRetention > 0 && bcpTime.After(dailyCutoff) {
+					keepMap[bcp.Name] = true
+				}
+			}
+			continue // Do not evaluate failed backups for Weekly/Monthly
+		}
+
+		// Daily Retention (Completed Backups)
+		if cfg.DailyRetention > 0 && !bcpTime.Before(dailyCutoff) {
+			keepMap[bcp.Name] = true
+			continue
+		}
+
+		// Weekly Retention Bucket
+		if cfg.WeeklyRetention > 0 && !bcpTime.Before(weeklyCutoff) {
+			if isCalendar {
+				year, week := bcpTime.ISOWeek()
+				weekKey := fmt.Sprintf("calendar-week-%d-W%02d", year, week)
+				weeklyCandidates[weekKey] = append(weeklyCandidates[weekKey], bcp)
+			} else {
+				weekBucket := ageInDays / 7
+				weekKey := fmt.Sprintf("rolling-week-%d", weekBucket)
+				weeklyCandidates[weekKey] = append(weeklyCandidates[weekKey], bcp)
+			}
+		}
+
+		// Monthly Retention Bucket
+		if cfg.MonthlyRetention > 0 && !bcpTime.Before(monthlyCutoff) {
+			if isCalendar {
+				monthKey := bcpTime.Format("2006-01")
+				monthlyCandidates[monthKey] = append(monthlyCandidates[monthKey], bcp)
+			} else {
+				monthBucket := ageInDays / 30
+				monthKey := fmt.Sprintf("rolling-month-%d", monthBucket)
+				monthlyCandidates[monthKey] = append(monthlyCandidates[monthKey], bcp)
+			}
+		}
+	}
+
+	// 2. Select best candidates for Weekly & Monthly
+	for _, candidates := range weeklyCandidates {
+		bestBcp := findBestCandidate(candidates, cfg.WeeklyDay, false, isCalendar)
+		if bestBcp != nil {
+			keepMap[bestBcp.Name] = true
+		}
+	}
+
+	for _, candidates := range monthlyCandidates {
+		bestBcp := findBestCandidate(candidates, cfg.MonthlyDay, true, isCalendar)
+		if bestBcp != nil {
+			keepMap[bestBcp.Name] = true
+		}
+	}
+
+	// 3. Finalize Lists
+	for _, bcp := range backups {
+		if bcp.Status.IsRunning() {
+			continue // Hide in-progress backups from the Keep/Purge report
+		}
+
+		if keepMap[bcp.Name] {
+			report.BackupsKept = append(report.BackupsKept, bcp.Name)
+		} else {
+			report.BackupsPurged = append(report.BackupsPurged, bcp.Name)
+		}
+	}
+
+	return report
+}
+
+// findBestCandidate selects the optimal backup from a bucket.
+func findBestCandidate(candidates []backup.BackupMeta, targetDayInt int, isMonthly bool, isCalendar bool) *backup.BackupMeta {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	var best *backup.BackupMeta
+
+	if !isCalendar {
+		// Rolling Option: Pick the newest backup in this bucket
+		for i := range candidates {
+			if best == nil || candidates[i].StartTS > best.StartTS {
+				best = &candidates[i]
+			}
+		}
+		return best
+	}
+
+	// Calendar Option: Find the backup closest to the targeted day
+	minDiff := 31 // Max possible difference
+	for i, bcp := range candidates {
+		bcpTime := time.Unix(bcp.StartTS, 0).UTC()
+		diff := 0
+
+		if isMonthly {
+			diff = int(math.Abs(float64(bcpTime.Day() - targetDayInt)))
+		} else {
+			diff = int(math.Abs(float64(bcpTime.Weekday() - time.Weekday(targetDayInt))))
+		}
+
+		if diff < minDiff {
+			minDiff = diff
+			best = &candidates[i]
+		}
+	}
+
+	return best
+}

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -62,7 +62,6 @@ func (r *Report) String() string {
 	return res
 }
 
-// Replace the Evaluate function (~ line 50) with this:
 func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool, now time.Time) *Report {
 	report := &Report{
 		DryRun:      dryRun,
@@ -71,7 +70,6 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 		BackupTypes: make(map[string]string),
 	}
 
-	// BUG FIX: If Disabled, go to sleep. Keep everything.
 	if !cfg.Enabled {
 		for _, bcp := range backups {
 			if bcp.Status.IsRunning() {
@@ -189,7 +187,6 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 		}
 	}
 
-	// BUG FIX: 4. Enforce Min Keep (Rescue backups from PURGE)
 	minKeep := 1
 	if cfg.MinKeep != nil {
 		minKeep = *cfg.MinKeep

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -61,7 +62,7 @@ func (r *Report) String() string {
 	return res
 }
 
-// Evaluate determines which backups to keep and which to purge based on the config.
+// Replace the Evaluate function (~ line 50) with this:
 func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool, now time.Time) *Report {
 	report := &Report{
 		DryRun:      dryRun,
@@ -70,12 +71,20 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 		BackupTypes: make(map[string]string),
 	}
 
-	if !cfg.Enabled && !dryRun {
+	// BUG FIX: If Disabled, go to sleep. Keep everything.
+	if !cfg.Enabled {
+		for _, bcp := range backups {
+			if bcp.Status.IsRunning() {
+				continue
+			}
+			report.BackupTypes[bcp.Name] = string(bcp.Type)
+			report.BackupsKept = append(report.BackupsKept, bcp.Name)
+			report.KeepReasons[bcp.Name] = []string{"Lifecycle Disabled"}
+		}
 		return report
 	}
 
 	isCalendar := strings.ToLower(cfg.Strategy) == "calendar"
-
 	keepMap := make(map[string][]string)
 
 	addReason := func(name, reason string) {
@@ -161,10 +170,9 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 	// 3. Finalize Lists
 	for _, bcp := range backups {
 		if bcp.Status.IsRunning() {
-			continue // Hide in-progress backups from the Keep/Purge report
+			continue
 		}
 
-		// Capture the type for every completed backup evaluated
 		report.BackupTypes[bcp.Name] = string(bcp.Type)
 
 		if len(keepMap[bcp.Name]) > 0 {
@@ -172,6 +180,45 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 			report.KeepReasons[bcp.Name] = keepMap[bcp.Name]
 		} else {
 			report.BackupsPurged = append(report.BackupsPurged, bcp.Name)
+		}
+	}
+
+	// BUG FIX: 4. Enforce Min Keep (Rescue backups from PURGE)
+	minKeep := 1
+	if cfg.MinKeep != nil {
+		minKeep = *cfg.MinKeep
+	}
+
+	if minKeep > 0 && len(report.BackupsKept) < minKeep {
+		var rescue []backup.BackupMeta
+		for _, bcp := range backups {
+			if bcp.Status == defs.StatusDone && len(keepMap[bcp.Name]) == 0 {
+				rescue = append(rescue, bcp)
+			}
+		}
+
+		// Sort newest first to rescue the most recent ones
+		slices.SortFunc(rescue, func(a, b backup.BackupMeta) int {
+			if a.StartTS > b.StartTS {
+				return -1
+			}
+			if a.StartTS < b.StartTS {
+				return 1
+			}
+			return 0
+		})
+
+		for _, bcp := range rescue {
+			if len(report.BackupsKept) >= minKeep {
+				break
+			}
+			report.BackupsKept = append(report.BackupsKept, bcp.Name)
+			report.KeepReasons[bcp.Name] = []string{"Min Keep"}
+
+			// Remove from Purged list safely
+			report.BackupsPurged = slices.DeleteFunc(report.BackupsPurged, func(name string) bool {
+				return name == bcp.Name
+			})
 		}
 	}
 

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -12,10 +12,12 @@ import (
 )
 
 type Report struct {
-	DryRun        bool
-	ConfigUsed    config.LifecycleConf
-	BackupsKept   []string
-	BackupsPurged []string
+	DryRun        bool                 `json:"dryRun"`
+	ConfigUsed    config.LifecycleConf `json:"configUsed"`
+	BackupsKept   []string             `json:"backupsKept"`
+	BackupsPurged []string             `json:"backupsPurged"`
+	KeepReasons   map[string][]string  `json:"keepReasons"`
+	BackupTypes   map[string]string    `json:"backupTypes"`
 }
 
 func (r *Report) String() string {
@@ -46,12 +48,15 @@ func (r *Report) String() string {
 
 	res += fmt.Sprintf("Backups to KEEP (%d):\n", len(r.BackupsKept))
 	for _, b := range r.BackupsKept {
-		res += fmt.Sprintf("  - %s\n", b)
+		reasons := strings.Join(r.KeepReasons[b], ", ")
+		bType := r.BackupTypes[b] // Fetch the type
+		res += fmt.Sprintf("  - %s <%s> [%s]\n", b, bType, reasons)
 	}
 
 	res += fmt.Sprintf("\nBackups to PURGE (%d):\n", len(r.BackupsPurged))
 	for _, b := range r.BackupsPurged {
-		res += fmt.Sprintf("  - %s\n", b)
+		bType := r.BackupTypes[b] // Fetch the type
+		res += fmt.Sprintf("  - %s <%s>\n", b, bType)
 	}
 	return res
 }
@@ -59,18 +64,28 @@ func (r *Report) String() string {
 // Evaluate determines which backups to keep and which to purge based on the config.
 func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool, now time.Time) *Report {
 	report := &Report{
-		DryRun:     dryRun,
-		ConfigUsed: cfg,
+		DryRun:      dryRun,
+		ConfigUsed:  cfg,
+		KeepReasons: make(map[string][]string),
+		BackupTypes: make(map[string]string),
 	}
 
-	// Exit early if disabled and not a dry run.
 	if !cfg.Enabled && !dryRun {
 		return report
 	}
 
 	isCalendar := strings.ToLower(cfg.Strategy) == "calendar"
 
-	keepMap := make(map[string]bool)
+	keepMap := make(map[string][]string)
+
+	addReason := func(name, reason string) {
+		for _, r := range keepMap[name] {
+			if r == reason {
+				return
+			}
+		}
+		keepMap[name] = append(keepMap[name], reason)
+	}
 
 	dailyCutoff := now.AddDate(0, 0, -cfg.DailyRetention)
 	weeklyCutoff := now.AddDate(0, 0, -(cfg.WeeklyRetention * 7))
@@ -81,35 +96,30 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 
 	// 1. Bucketing phase
 	for _, bcp := range backups {
-		// ALWAYS protect in-progress backups. They are never purged.
 		if bcp.Status.IsRunning() {
-			keepMap[bcp.Name] = true
+			addReason(bcp.Name, "In-Progress")
 			continue
 		}
 
 		bcpTime := time.Unix(bcp.StartTS, 0).UTC()
 		ageInDays := int(now.Sub(bcpTime).Hours() / 24)
 
-		// Handle Failed/Cancelled backups
 		if bcp.Status == defs.StatusError || bcp.Status == defs.StatusCancelled {
 			if !cfg.PurgeFailed {
-				keepMap[bcp.Name] = true // Protect failed backups if PurgeFailed is false
+				addReason(bcp.Name, "Failed (Protected)")
 			} else {
-				// If PurgeFailed is true, only keep them if they fall into the Daily window
-				if cfg.DailyRetention > 0 && bcpTime.After(dailyCutoff) {
-					keepMap[bcp.Name] = true
+				if cfg.DailyRetention > 0 && !bcpTime.Before(dailyCutoff) {
+					addReason(bcp.Name, "Failed (Inside Daily Window)")
 				}
 			}
-			continue // Do not evaluate failed backups for Weekly/Monthly
-		}
-
-		// Daily Retention (Completed Backups)
-		if cfg.DailyRetention > 0 && !bcpTime.Before(dailyCutoff) {
-			keepMap[bcp.Name] = true
 			continue
 		}
 
-		// Weekly Retention Bucket
+		if cfg.DailyRetention > 0 && !bcpTime.Before(dailyCutoff) {
+			addReason(bcp.Name, "Daily")
+			continue
+		}
+
 		if cfg.WeeklyRetention > 0 && !bcpTime.Before(weeklyCutoff) {
 			if isCalendar {
 				year, week := bcpTime.ISOWeek()
@@ -122,7 +132,6 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 			}
 		}
 
-		// Monthly Retention Bucket
 		if cfg.MonthlyRetention > 0 && !bcpTime.Before(monthlyCutoff) {
 			if isCalendar {
 				monthKey := bcpTime.Format("2006-01")
@@ -135,18 +144,17 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 		}
 	}
 
-	// 2. Select best candidates for Weekly & Monthly
 	for _, candidates := range weeklyCandidates {
 		bestBcp := findBestCandidate(candidates, cfg.WeeklyDay, false, isCalendar)
 		if bestBcp != nil {
-			keepMap[bestBcp.Name] = true
+			addReason(bestBcp.Name, "Weekly")
 		}
 	}
 
 	for _, candidates := range monthlyCandidates {
 		bestBcp := findBestCandidate(candidates, cfg.MonthlyDay, true, isCalendar)
 		if bestBcp != nil {
-			keepMap[bestBcp.Name] = true
+			addReason(bestBcp.Name, "Monthly")
 		}
 	}
 
@@ -156,8 +164,12 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 			continue // Hide in-progress backups from the Keep/Purge report
 		}
 
-		if keepMap[bcp.Name] {
+		// Capture the type for every completed backup evaluated
+		report.BackupTypes[bcp.Name] = string(bcp.Type)
+
+		if len(keepMap[bcp.Name]) > 0 {
 			report.BackupsKept = append(report.BackupsKept, bcp.Name)
+			report.KeepReasons[bcp.Name] = keepMap[bcp.Name]
 		} else {
 			report.BackupsPurged = append(report.BackupsPurged, bcp.Name)
 		}

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -129,25 +129,31 @@ func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool
 			continue
 		}
 
+		// Weekly Retention Bucket
 		if cfg.WeeklyRetention > 0 && !bcpTime.Before(weeklyCutoff) {
 			if isCalendar {
 				year, week := bcpTime.ISOWeek()
-				weekKey := fmt.Sprintf("calendar-week-%d-W%02d", year, week)
+				// Append the backup Type to the bucket key
+				weekKey := fmt.Sprintf("calendar-week-%d-W%02d-%s", year, week, bcp.Type)
 				weeklyCandidates[weekKey] = append(weeklyCandidates[weekKey], bcp)
 			} else {
 				weekBucket := ageInDays / 7
-				weekKey := fmt.Sprintf("rolling-week-%d", weekBucket)
+				// Append the backup Type to the bucket key
+				weekKey := fmt.Sprintf("rolling-week-%d-%s", weekBucket, bcp.Type)
 				weeklyCandidates[weekKey] = append(weeklyCandidates[weekKey], bcp)
 			}
 		}
 
+		// Monthly Retention Bucket
 		if cfg.MonthlyRetention > 0 && !bcpTime.Before(monthlyCutoff) {
 			if isCalendar {
-				monthKey := bcpTime.Format("2006-01")
+				// Append the backup Type to the bucket key
+				monthKey := fmt.Sprintf("%s-%s", bcpTime.Format("2006-01"), bcp.Type)
 				monthlyCandidates[monthKey] = append(monthlyCandidates[monthKey], bcp)
 			} else {
 				monthBucket := ageInDays / 30
-				monthKey := fmt.Sprintf("rolling-month-%d", monthBucket)
+				// Append the backup Type to the bucket key
+				monthKey := fmt.Sprintf("rolling-month-%d-%s", monthBucket, bcp.Type)
 				monthlyCandidates[monthKey] = append(monthlyCandidates[monthKey], bcp)
 			}
 		}

--- a/pbm/lifecycle/manager.go
+++ b/pbm/lifecycle/manager.go
@@ -62,6 +62,8 @@ func (r *Report) String() string {
 	return res
 }
 
+// Evaluate analyzes backups according to the lifecycle configuration and
+// returns a report describing which backups should be kept or purged.
 func Evaluate(cfg config.LifecycleConf, backups []backup.BackupMeta, dryRun bool, now time.Time) *Report {
 	report := &Report{
 		DryRun:      dryRun,

--- a/pbm/lifecycle/manager_test.go
+++ b/pbm/lifecycle/manager_test.go
@@ -199,12 +199,10 @@ func TestEvaluate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			report := Evaluate(tt.cfg, tt.backups, tt.dryRun, tt.mockNow)
 
-			// Assert DryRun property is set correctly
 			if report.DryRun != tt.dryRun {
 				t.Errorf("Report.DryRun = %v, want %v", report.DryRun, tt.dryRun)
 			}
 
-			// Sort slices to ensure deterministic DeepEqual comparisons
 			sort.Strings(report.BackupsKept)
 			sort.Strings(tt.expectedKept)
 			sort.Strings(report.BackupsPurged)

--- a/pbm/lifecycle/manager_test.go
+++ b/pbm/lifecycle/manager_test.go
@@ -22,6 +22,13 @@ func mockBcp(name string, daysAgo int, baseTime time.Time, status defs.Status) b
 	}
 }
 
+// mockTypedBcp is a helper to generate fake backups with a specific Type.
+func mockTypedBcp(name string, daysAgo int, baseTime time.Time, status defs.Status, bcpType defs.BackupType) backup.BackupMeta {
+	bcp := mockBcp(name, daysAgo, baseTime, status)
+	bcp.Type = bcpType
+	return bcp
+}
+
 func TestEvaluate(t *testing.T) {
 	// Define a few specific dates we want to test against
 	standardDate := time.Date(2026, time.March, 26, 12, 0, 0, 0, time.UTC)     // A normal Thursday
@@ -164,6 +171,27 @@ func TestEvaluate(t *testing.T) {
 			dryRun:         false,
 			expectedKept:   []string{"bcp-error-recent"},
 			expectedPurged: []string{"bcp-error-old"},
+		},
+		{
+			name: "Type-Aware Bucketing - Keeps both Physical and Logical for the same week",
+			cfg: config.LifecycleConf{
+				Enabled:         true,
+				Strategy:        "rolling",
+				DailyRetention:  0, // Disable daily to force Weekly evaluation
+				WeeklyRetention: 2,
+			},
+			mockNow: standardDate,
+			backups: []backup.BackupMeta{
+				// Week 1 Bucket (7-13 days ago)
+				mockTypedBcp("phys-newer", 9, standardDate, defs.StatusDone, defs.PhysicalBackup),
+				mockTypedBcp("phys-older", 12, standardDate, defs.StatusDone, defs.PhysicalBackup), // Loses to phys-newer
+
+				// Same Week 1 Bucket, but Logical
+				mockTypedBcp("logical-only", 11, standardDate, defs.StatusDone, defs.LogicalBackup), // Wins its own logical bucket
+			},
+			dryRun:         false,
+			expectedKept:   []string{"phys-newer", "logical-only"},
+			expectedPurged: []string{"phys-older"},
 		},
 	}
 

--- a/pbm/lifecycle/manager_test.go
+++ b/pbm/lifecycle/manager_test.go
@@ -39,7 +39,7 @@ func TestEvaluate(t *testing.T) {
 	}{
 		// --- STANDARD DATE SCENARIOS ---
 		{
-			name: "Feature Disabled BUT Dry Run is True (Bypass enabled flag)",
+			name: "Feature Disabled (Dry run or not, it sleeps)",
 			cfg: config.LifecycleConf{
 				Enabled:        false,
 				DailyRetention: 1,
@@ -50,8 +50,8 @@ func TestEvaluate(t *testing.T) {
 				mockBcp("bcp-old", 10, standardDate, defs.StatusDone),
 			},
 			dryRun:         true,
-			expectedKept:   []string{"bcp-today"},
-			expectedPurged: []string{"bcp-old"},
+			expectedKept:   []string{"bcp-today", "bcp-old"},
+			expectedPurged: []string{},
 		},
 		{
 			name: "Rolling Strategy - Basic GFS (7 Daily, 4 Weekly)",
@@ -133,19 +133,21 @@ func TestEvaluate(t *testing.T) {
 
 		// --- STATE HANDLING SCENARIOS ---
 		{
-			name: "In-Progress Backups are ALWAYS protected",
+			name: "In-Progress Backups are ALWAYS protected (and MinKeep rescues the last safe base)",
 			cfg: config.LifecycleConf{
 				Enabled:        true,
 				DailyRetention: 1,
 			},
 			mockNow: standardDate,
 			backups: []backup.BackupMeta{
-				mockBcp("bcp-running", 50, standardDate, defs.StatusRunning),
-				mockBcp("bcp-done-old", 50, standardDate, defs.StatusDone),
+				mockBcp("bcp-running", 0, standardDate, defs.StatusRunning), // In-progress today
+				mockBcp("bcp-done-old", 50, standardDate, defs.StatusDone),  // 50 days old, normally purged
 			},
-			dryRun:         false,
-			expectedKept:   nil,
-			expectedPurged: []string{"bcp-done-old"},
+			dryRun: false,
+			// bcp-running is implicitly protected (hidden from purge).
+			// bcp-done-old is expired, but rescued because MinKeep defaults to 1 and the running backup doesn't count yet!
+			expectedKept:   []string{"bcp-done-old"},
+			expectedPurged: []string{},
 		},
 		{
 			name: "Failed Backups - PurgeFailed is TRUE",

--- a/pbm/lifecycle/manager_test.go
+++ b/pbm/lifecycle/manager_test.go
@@ -1,0 +1,196 @@
+package lifecycle
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/percona/percona-backup-mongodb/pbm/backup"
+	"github.com/percona/percona-backup-mongodb/pbm/config"
+	"github.com/percona/percona-backup-mongodb/pbm/defs"
+)
+
+// mockBcp is a helper to generate fake backups.
+// daysAgo subtracts from the baseTime (our frozen mockNow).
+func mockBcp(name string, daysAgo int, baseTime time.Time, status defs.Status) backup.BackupMeta {
+	bcpTime := baseTime.AddDate(0, 0, -daysAgo)
+	return backup.BackupMeta{
+		Name:    name,
+		StartTS: bcpTime.Unix(),
+		Status:  status,
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	// Define a few specific dates we want to test against
+	standardDate := time.Date(2026, time.March, 26, 12, 0, 0, 0, time.UTC)     // A normal Thursday
+	leapYearDate := time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC)  // Leap Day
+	endOfYearDate := time.Date(2025, time.December, 31, 12, 0, 0, 0, time.UTC) // Dec 31st
+
+	tests := []struct {
+		name           string
+		cfg            config.LifecycleConf
+		backups        []backup.BackupMeta
+		dryRun         bool
+		mockNow        time.Time
+		expectedKept   []string
+		expectedPurged []string
+	}{
+		// --- STANDARD DATE SCENARIOS ---
+		{
+			name: "Feature Disabled BUT Dry Run is True (Bypass enabled flag)",
+			cfg: config.LifecycleConf{
+				Enabled:        false,
+				DailyRetention: 1,
+			},
+			mockNow: standardDate,
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-today", 0, standardDate, defs.StatusDone),
+				mockBcp("bcp-old", 10, standardDate, defs.StatusDone),
+			},
+			dryRun:         true,
+			expectedKept:   []string{"bcp-today"},
+			expectedPurged: []string{"bcp-old"},
+		},
+		{
+			name: "Rolling Strategy - Basic GFS (7 Daily, 4 Weekly)",
+			cfg: config.LifecycleConf{
+				Enabled:         true,
+				Strategy:        "rolling",
+				DailyRetention:  7,
+				WeeklyRetention: 4,
+			},
+			mockNow: standardDate,
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-today", 0, standardDate, defs.StatusDone),
+				mockBcp("bcp-7-days", 7, standardDate, defs.StatusDone),
+				mockBcp("bcp-9-days", 9, standardDate, defs.StatusDone),
+				mockBcp("bcp-12-days", 12, standardDate, defs.StatusDone), // Oldest in Week 1 bucket (Purged)
+			},
+			dryRun:         false,
+			expectedKept:   []string{"bcp-today", "bcp-7-days", "bcp-9-days"},
+			expectedPurged: []string{"bcp-12-days"},
+		},
+		{
+			name: "Calendar Strategy - Exact match vs Nearest Neighbor",
+			cfg: config.LifecycleConf{
+				Enabled:          true,
+				Strategy:         "calendar",
+				DailyRetention:   0,
+				MonthlyRetention: 1,
+				MonthlyDay:       15, // Target the 15th
+			},
+			mockNow: standardDate, // March 26
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-mar-13", 13, standardDate, defs.StatusDone), // 13 days ago (Mar 13, diff 2)
+				mockBcp("bcp-mar-15", 11, standardDate, defs.StatusDone), // 11 days ago (Mar 15, Exact Match!)
+			},
+			dryRun:         false,
+			expectedKept:   []string{"bcp-mar-15"},
+			expectedPurged: []string{"bcp-mar-13"},
+		},
+
+		// --- LEAP YEAR SCENARIOS ---
+		{
+			name: "Leap Year - Daily Retention over Feb 29",
+			cfg: config.LifecycleConf{
+				Enabled:        true,
+				Strategy:       "rolling",
+				DailyRetention: 3,
+			},
+			mockNow: leapYearDate, // Feb 29, 2024
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-feb-29", 0, leapYearDate, defs.StatusDone),
+				mockBcp("bcp-feb-28", 1, leapYearDate, defs.StatusDone),
+				mockBcp("bcp-feb-27", 2, leapYearDate, defs.StatusDone),
+				mockBcp("bcp-feb-25", 4, leapYearDate, defs.StatusDone), // 4 days ago, Purged
+			},
+			dryRun:         false,
+			expectedKept:   []string{"bcp-feb-29", "bcp-feb-28", "bcp-feb-27"},
+			expectedPurged: []string{"bcp-feb-25"},
+		},
+
+		// --- END OF YEAR SCENARIOS ---
+		{
+			name: "End of Year - Monthly Nearest Neighbor across year boundary",
+			cfg: config.LifecycleConf{
+				Enabled:          true,
+				Strategy:         "calendar",
+				DailyRetention:   0,
+				MonthlyRetention: 1,
+				MonthlyDay:       1, // Target the 1st of the month
+			},
+			mockNow: endOfYearDate, // Dec 31, 2025
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-dec-2", 29, endOfYearDate, defs.StatusDone),  // Dec 2 (Diff 1)
+				mockBcp("bcp-nov-29", 32, endOfYearDate, defs.StatusDone), // Nov 29 (Diff 2)
+			},
+			dryRun:         false,
+			expectedKept:   []string{"bcp-dec-2"},
+			expectedPurged: []string{"bcp-nov-29"},
+		},
+
+		// --- STATE HANDLING SCENARIOS ---
+		{
+			name: "In-Progress Backups are ALWAYS protected",
+			cfg: config.LifecycleConf{
+				Enabled:        true,
+				DailyRetention: 1,
+			},
+			mockNow: standardDate,
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-running", 50, standardDate, defs.StatusRunning),
+				mockBcp("bcp-done-old", 50, standardDate, defs.StatusDone),
+			},
+			dryRun:         false,
+			expectedKept:   nil,
+			expectedPurged: []string{"bcp-done-old"},
+		},
+		{
+			name: "Failed Backups - PurgeFailed is TRUE",
+			cfg: config.LifecycleConf{
+				Enabled:        true,
+				PurgeFailed:    true,
+				DailyRetention: 7, // Protect for 7 days
+			},
+			mockNow: standardDate,
+			backups: []backup.BackupMeta{
+				mockBcp("bcp-error-recent", 3, standardDate, defs.StatusError), // Kept
+				mockBcp("bcp-error-old", 10, standardDate, defs.StatusError),   // Purged
+			},
+			dryRun:         false,
+			expectedKept:   []string{"bcp-error-recent"},
+			expectedPurged: []string{"bcp-error-old"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Evaluate(tt.cfg, tt.backups, tt.dryRun, tt.mockNow)
+
+			// Assert DryRun property is set correctly
+			if report.DryRun != tt.dryRun {
+				t.Errorf("Report.DryRun = %v, want %v", report.DryRun, tt.dryRun)
+			}
+
+			// Sort slices to ensure deterministic DeepEqual comparisons
+			sort.Strings(report.BackupsKept)
+			sort.Strings(tt.expectedKept)
+			sort.Strings(report.BackupsPurged)
+			sort.Strings(tt.expectedPurged)
+
+			if len(report.BackupsKept) == 0 && len(tt.expectedKept) == 0 {
+				// both empty, pass
+			} else if !reflect.DeepEqual(report.BackupsKept, tt.expectedKept) {
+				t.Errorf("BackupsKept = %v, want %v", report.BackupsKept, tt.expectedKept)
+			}
+
+			if len(report.BackupsPurged) == 0 && len(tt.expectedPurged) == 0 {
+				// both empty, pass
+			} else if !reflect.DeepEqual(report.BackupsPurged, tt.expectedPurged) {
+				t.Errorf("BackupsPurged = %v, want %v", report.BackupsPurged, tt.expectedPurged)
+			}
+		})
+	}
+}

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -91,7 +91,7 @@ func (c *Client) GetConfigProfile(ctx context.Context, name string) (*config.Con
 }
 
 func (c *Client) AddConfigProfile(ctx context.Context, name string, cfg *Config) (CommandID, error) {
-	opid, err := ctrl.SendAddConfigProfile(ctx, c.conn, name, cfg.Storage)
+	opid, err := ctrl.SendAddConfigProfile(ctx, c.conn, name, cfg.Storage, &cfg.Lifecycle)
 	return CommandID(opid.String()), err
 }
 

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -91,7 +91,12 @@ func (c *Client) GetConfigProfile(ctx context.Context, name string) (*config.Con
 }
 
 func (c *Client) AddConfigProfile(ctx context.Context, name string, cfg *Config) (CommandID, error) {
-	opid, err := ctrl.SendAddConfigProfile(ctx, c.conn, name, cfg.Storage, &cfg.Lifecycle)
+	var lifecycle *config.LifecycleConf
+	if cfg != nil && cfg.Lifecycle != nil {
+		lifecycle = cfg.Lifecycle
+	}
+
+	opid, err := ctrl.SendAddConfigProfile(ctx, c.conn, name, cfg.Storage, lifecycle)
 	return CommandID(opid.String()), err
 }
 


### PR DESCRIPTION
## Summary
This PR introduces **Backup Lifecycle Management** for Percona Backup for MongoDB (PBM). This feature automates the retention and rotation of snapshots using a Grandfather-Father-Son (GFS) policy, addressing critical needs for cost-efficient storage management while ensuring long-term compliance and data durability.

## Key Features
* **Dual Rotation Strategies:**
    * `Rolling` (Default): A time-decay algorithm that creates age-based buckets, ensuring resilience against skipped backup windows.
    * `Calendar`: A strict anchoring strategy for compliance-heavy environments (e.g., "Keep every Friday backup").
* **Safety Circuit Breaker (`minKeep`):** Prevents the "Empty Storage Paradox." If a rotation would leave the cluster with fewer than `X` backups (default 1), the operation aborts to protect the last remaining recovery points.
* **Intelligent Failed Backup Handling:** Optional purging of `StatusError` backups after they age out of the daily window, while protecting in-progress backups.
* **Interactive Safeguards:** Built-in `--dry-run` capability and a mandatory confirmation prompt (default `true`) to prevent accidental data loss during manual runs.
* **Chronological Purging:** Deletions are executed from **oldest to newest**, ensuring the most recent data is preserved longest in the event of a network or process interruption.

## Technical Implementation Details
* **PITR Safety:** The lifecycle manager utilizes the core `backup.DeleteBackup` function, inheriting PBM's internal `isRequiredForOplogSlicing` checks. Deletion will be refused if a snapshot is required for an active Point-in-Time Recovery chain.
* **Concurrency Safe:** The manager strictly filters for `done` snapshots, ensuring that `starting`, `running`, or `stuck` backups are never targeted for deletion.
* **Standardized URI Handling:** Fully compatible with existing `PBM_MONGODB_URI` environment variables and standard PBM connection string formats.

## Testing Performed
* Validated GFS bucket logic across 2 months of synthetic backup history.
* Verified `minKeep` abort logic in both interactive and automated (`prompt: false`) modes.
* Confirmed `Ctrl+C` signal handling during the deletion loop to ensure graceful termination.
* Dry-run verification of "Calendar" vs "Rolling" selection logic.

---

## User Documentation Snapshot

### Configuration Parameters
| Option | Type | Default | Description |
| :--- | :--- | :--- | :--- |
| `lifecycle.enabled` | Boolean | `false` | Toggles automated lifecycle management. |
| `lifecycle.strategy` | String | `"rolling"` | Options: `"rolling"` or `"calendar"`. |
| `lifecycle.minKeep` | Integer | `1` | Ensures you are never left with 0 backups. |
| `lifecycle.prompt` | Boolean | `true` | Requires interactive confirmation `[y/N]` before deletion. |
| `lifecycle.purgeFailed`| Boolean | `false` | Purges failed backups after the daily window expires. |

### Recommended Baseline (7 / 4 / 12)
```yaml
lifecycle:
  enabled: true
  strategy: "rolling"
  minKeep: 1
  prompt: true
  purgeFailed: true
  dailyRetention: 7
  weeklyRetention: 4
  monthlyRetention: 12
```

## Automation (Cron)
For background automation, set lifecycle.prompt: false. The minKeep safety net will automatically abort the purge if no new backups are detected, protecting your historical data.

```
0 3 * * * /usr/bin/pbm lifecycle >> /var/log/pbm-lifecycle.log 2>&1
```

Full documentation available and will be provided to engineering separately.