### PR TITLE
PBM-1598 Revert balancer stop timeout for restore

### DIFF
--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -98,12 +98,6 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		return
 	}
 
-	cfg, err := config.GetConfig(ctx, a.leadConn)
-	if err != nil {
-		l.Error("get PBM configuration: %v", err)
-		return
-	}
-
 	// stop balancer during the restore
 	if a.brief.Sharded && nodeInfo.IsClusterLeader() {
 		bs, err := topo.GetBalancerStatus(ctx, a.leadConn)
@@ -113,14 +107,7 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 
 		if bs.IsOn() {
-			t := cfg.Restore.Timeouts.BalancerStop()
-			if t > 0 {
-				l.Debug("stopping balancer with timeout %s", t)
-				err = topo.StopBalancer(ctx, a.leadConn, t.Milliseconds())
-			} else {
-				l.Debug("stopping balancer")
-				err = topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
-			}
+			err := topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
 			if err != nil {
 				l.Error("set balancer off: %v", err)
 			}
@@ -167,6 +154,12 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 		bcpType = bcp.Type
 		r.BackupName = bcp.Name
+	}
+
+	cfg, err := config.GetConfig(ctx, a.leadConn)
+	if err != nil {
+		l.Error("get PBM configuration: %v", err)
+		return
 	}
 
 	l.Info("recovery started")

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -418,8 +418,6 @@ type RestoreConf struct {
 
 	FallbackEnabled *bool `bson:"fallbackEnabled,omitempty" json:"fallbackEnabled,omitempty" yaml:"fallbackEnabled,omitempty"`
 	AllowPartlyDone *bool `bson:"allowPartlyDone,omitempty" json:"allowPartlyDone,omitempty" yaml:"allowPartlyDone,omitempty"`
-
-	Timeouts *RestoreTimeouts `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
 }
 
 func (cfg *RestoreConf) Clone() *RestoreConf {
@@ -434,30 +432,8 @@ func (cfg *RestoreConf) Clone() *RestoreConf {
 			rv.MongodLocationMap[k] = v
 		}
 	}
-	if cfg.Timeouts != nil {
-		rv.Timeouts = &RestoreTimeouts{
-			BalancerStopSec: cfg.Timeouts.BalancerStopSec,
-		}
-	}
 
 	return &rv
-}
-
-//nolint:lll
-type RestoreTimeouts struct {
-	// BalancerStopSec is timeout (in seconds) to wait for the balancer to stop.
-	// 0 means wait indefinitely (default).
-	BalancerStopSec uint32 `bson:"balancerStop,omitempty" json:"balancerStop,omitempty" yaml:"balancerStop,omitempty"`
-}
-
-// BalancerStop returns timeout duration for waiting for the balancer to stop.
-// Returns 0 if not set, meaning PBM will wait indefinitely.
-func (t *RestoreTimeouts) BalancerStop() time.Duration {
-	if t == nil {
-		return 0
-	}
-
-	return time.Duration(t.BalancerStopSec) * time.Second
 }
 
 // GetFallbackEnabled gets config's or default value for fallbackEnabled


### PR DESCRIPTION
followup to: https://github.com/percona/percona-backup-mongodb/pull/1282

The configurable balancer stop timeout was not part of the original PBM-1598 scope for restores. 