### PR TITLE
PBM-1638: Automatic Inclusion of KMIP/Vault Key Identifier in Physical Backup Metadata

### DIFF
--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -312,6 +312,10 @@ func (b *Backup) doPhysical(
 	if err != nil {
 		return errors.Wrap(err, "get mongod options")
 	}
+	err = topo.ExpandSecOptsWithEncAtRest(ctx, b.nodeConn, mopts.Security)
+	if err != nil {
+		return errors.Wrap(err, "get encryption at rest options")
+	}
 
 	rsMeta.MongodOpts = mopts
 	rsMeta.Status = defs.StatusRunning

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -272,7 +272,7 @@ func ExpandSecOptsWithEncAtRest(
 	m *mongo.Client,
 	secOpts *MongodOptsSec,
 ) error {
-	if secOpts.EnableEncryption == nil || !*secOpts.EnableEncryption {
+	if secOpts == nil || secOpts.EnableEncryption == nil || !*secOpts.EnableEncryption {
 		// encryption is not enabled
 		return nil
 	}
@@ -281,7 +281,7 @@ func ExpandSecOptsWithEncAtRest(
 	case secOpts.KMIP != nil:
 		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
 		if err != nil {
-			errors.Wrap(err, "get encryption at rest for kmip")
+			return errors.Wrap(err, "get encryption at rest for kmip")
 		}
 
 		var encAtRest struct {
@@ -293,7 +293,7 @@ func ExpandSecOptsWithEncAtRest(
 		}
 		err = encAtRestRaw.Unmarshal(&encAtRest)
 		if err != nil {
-			errors.Wrap(err, "unmarshal encryption at rest for kmip")
+			return errors.Wrap(err, "unmarshal encryption at rest for kmip")
 		}
 
 		secOpts.KMIP.KeyIdentifier = &encAtRest.EncryptionKeyId.KMIP.KeyID
@@ -301,7 +301,7 @@ func ExpandSecOptsWithEncAtRest(
 	case secOpts.Vault != nil:
 		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
 		if err != nil {
-			errors.Wrap(err, "get encryption at rest for vault")
+			return errors.Wrap(err, "get encryption at rest for vault")
 		}
 
 		var encAtRest struct {
@@ -313,7 +313,7 @@ func ExpandSecOptsWithEncAtRest(
 		}
 		err = encAtRestRaw.Unmarshal(&encAtRest)
 		if err != nil {
-			errors.Wrap(err, "unmarshal encryption at rest for vault")
+			return errors.Wrap(err, "unmarshal encryption at rest for vault")
 		}
 
 		secretVersion, err := strconv.ParseUint(encAtRest.EncryptionKeyId.Vault.Version, 10, 32)
@@ -328,7 +328,7 @@ func ExpandSecOptsWithEncAtRest(
 }
 
 // getEncryptionAtRest fetches polymorphic encryptionAtRest field from serverStatus.
-// For possible shapes of document framgent see: PSMDB-1633.
+// For possible shapes of document fragment see: PSMDB-1633.
 func getEncryptionAtRest(ctx context.Context, m *mongo.Client) (*bson.RawValue, error) {
 	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"serverStatus", 1}})
 	if err := res.Err(); err != nil {

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -2,6 +2,7 @@ package topo
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -260,6 +261,90 @@ func GetMongodOpts(ctx context.Context, m *mongo.Client, defaults *MongodOpts) (
 		return nil, errors.Wrap(err, "run mongo command")
 	}
 	return &opts.Parsed, nil
+}
+
+// ExpandSecOptsWithEncAtRest fetches missing encryption at rest settings from serverStatus,
+// and assign them to security options.
+// For KMIP, KeyIdentifier is assigned.
+// For Vault, SecretVersion is assigned.
+func ExpandSecOptsWithEncAtRest(
+	ctx context.Context,
+	m *mongo.Client,
+	secOpts *MongodOptsSec,
+) error {
+	if secOpts.EnableEncryption == nil || !*secOpts.EnableEncryption {
+		// encryption is not enabled
+		return nil
+	}
+
+	switch {
+	case secOpts.KMIP != nil:
+		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
+		if err != nil {
+			errors.Wrap(err, "get encryption at rest for kmip")
+		}
+
+		var encAtRest struct {
+			EncryptionKeyId struct {
+				KMIP struct {
+					KeyID string `bson:"keyId,omitempty"`
+				} `bson:"kmip,omitempty"`
+			} `bson:"encryptionKeyId,omitempty"`
+		}
+		err = encAtRestRaw.Unmarshal(&encAtRest)
+		if err != nil {
+			errors.Wrap(err, "unmarshal encryption at rest for kmip")
+		}
+
+		secOpts.KMIP.KeyIdentifier = &encAtRest.EncryptionKeyId.KMIP.KeyID
+
+	case secOpts.Vault != nil:
+		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
+		if err != nil {
+			errors.Wrap(err, "get encryption at rest for vault")
+		}
+
+		var encAtRest struct {
+			EncryptionKeyId struct {
+				Vault struct {
+					Version string `bson:"version,omitempty"`
+				} `bson:"vault,omitempty"`
+			} `bson:"encryptionKeyId,omitempty"`
+		}
+		err = encAtRestRaw.Unmarshal(&encAtRest)
+		if err != nil {
+			errors.Wrap(err, "unmarshal encryption at rest for vault")
+		}
+
+		secretVersion, err := strconv.ParseUint(encAtRest.EncryptionKeyId.Vault.Version, 10, 32)
+		if err == nil {
+			// assign secretVersion only if it's number
+			ver := uint32(secretVersion)
+			secOpts.Vault.SecretVersion = &ver
+		}
+	}
+
+	return nil
+}
+
+// getEncryptionAtRest fetches polymorphic encryptionAtRest field from serverStatus.
+// For possible shapes of document framgent see: PSMDB-1633.
+func getEncryptionAtRest(ctx context.Context, m *mongo.Client) (*bson.RawValue, error) {
+	res := m.Database(defs.DB).RunCommand(ctx, bson.D{{"serverStatus", 1}})
+	if err := res.Err(); err != nil {
+		return nil, errors.Wrap(err, "cmd serverStatus")
+	}
+
+	raw, err := res.Raw()
+	if err != nil {
+		return nil, errors.Wrap(err, "bson serverStatus")
+	}
+
+	encAtRest, err := raw.LookupErr("encryptionAtRest")
+	if err != nil {
+		return nil, errors.Wrap(err, "lookup encryptionAtRest")
+	}
+	return &encAtRest, nil
 }
 
 //nolint:lll

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -340,10 +340,7 @@ func getEncryptionAtRest(ctx context.Context, m *mongo.Client) (*bson.RawValue, 
 		return nil, errors.Wrap(err, "bson serverStatus")
 	}
 
-	encAtRest, err := raw.LookupErr("encryptionAtRest")
-	if err != nil {
-		return nil, errors.Wrap(err, "lookup encryptionAtRest")
-	}
+	encAtRest := raw.Lookup("encryptionAtRest")
 	return &encAtRest, nil
 }
 


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1638

PR expands `describe-backup` command with KMIP/Vault key identifiers.

For KMIP:
```
$ pbm describe-backup 2026-03-30T14:01:23Z
name: "2026-03-30T14:01:23Z"
...
status: done
replsets:
- name: rs2
  status: done
  ...
  security:
    enableEncryption: true
    kmip:
      serverName: cosmian
      port: 5696
      clientCertificateFile: /etc/pykmip/mongod.pem
      serverCAFile: /etc/pykmip/ca.crt
      keyIdentifier: cbe0a6b4-7d7a-47c3-aa40-39abfc9a6f96
- name: rs1
  ...
  security:
    enableEncryption: true
    kmip:
      serverName: cosmian
      port: 5696
      clientCertificateFile: /etc/pykmip/mongod.pem
      serverCAFile: /etc/pykmip/ca.crt
      keyIdentifier: c83c9b79-4064-4463-9f10-5c1bf03f554a
- name: rscfg
  ...
  configsvr: true
  security:
    enableEncryption: true
    kmip:
      serverName: cosmian
      port: 5696
      clientCertificateFile: /etc/pykmip/mongod.pem
      serverCAFile: /etc/pykmip/ca.crt
      keyIdentifier: 42ca7d68-47b2-4c45-8c14-148a92cfd947
```

For Vault:
```
$ pbm describe-backup 2026-03-30T14:06:54Z
name: "2026-03-30T14:06:54Z"
...
replsets:
- name: rs2
  ...
  security:
    enableEncryption: true
    vault:
      serverName: vault
      port: 8200
      tokenFile: /etc/vault/token
      secret: secret/data/mongo
      secretVersion: 5
      disableTLSForTesting: true
- name: rs1
  ...
  security:
    enableEncryption: true
    vault:
      serverName: vault
      port: 8200
      tokenFile: /etc/vault/token
      secret: secret/data/mongo
      secretVersion: 2
      disableTLSForTesting: true
- name: rscfg
  ...
  security:
    enableEncryption: true
    vault:
      serverName: vault
      port: 8200
      tokenFile: /etc/vault/token
      secret: secret/data/mongo
      secretVersion: 8
      disableTLSForTesting: true
```