### PR TITLE
PBM-1345 Prevent PITR slicer from uploading invalid chunks when other RS fails

### DIFF
--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -871,6 +871,18 @@ func (a *Agent) pitrActivityMonitor(ctx context.Context) {
 				continue
 			}
 
+			// If any RS reported an error, let the error monitor handle it.
+			// Acting here would set StatusReconfig, masking the error and
+			// preventing proper error handling by the slicers on stop.
+			rsErrors, err := oplog.GetReplSetsWithStatus(ctx, a.leadConn, oplog.StatusError)
+			if err != nil && !errors.Is(err, errors.ErrNotFound) {
+				l.Error("activity check RS errors: %v", err)
+				continue
+			}
+			if len(rsErrors) > 0 {
+				continue
+			}
+
 			ackedAgents, err := oplog.GetAgentsWithACK(ctx, a.leadConn)
 			if err != nil {
 				l.Error("activity get acked agents", err)

--- a/pbm/slicer/slicer.go
+++ b/pbm/slicer/slicer.go
@@ -339,6 +339,14 @@ func (s *Slicer) Stream(
 		// upload the chunks up to the current time and return
 		case <-stopC:
 			s.l.Info("got done signal, stopping")
+			// If the cluster is in error state, skip the final upload — the chunk
+			// would be useless since another RS has a gap. On query failure, fall
+			// through to the normal upload path (safe default).
+			status, serr := oplog.GetClusterStatus(ctx, s.leadClient)
+			if serr == nil && status == oplog.StatusError {
+				s.l.Info("stopping without final upload due to cluster error")
+				return nil
+			}
 			lastSlice = true
 		// on wakeup or tick whatever comes first do the job
 		case bcp := <-backupSig:

--- a/pbm/slicer/slicer.go
+++ b/pbm/slicer/slicer.go
@@ -326,6 +326,7 @@ func (s *Slicer) Stream(
 	s.l.Debug(LogStartMsg)
 
 	lastSlice := false
+	uploaded := false
 	llock := &lock.LockHeader{
 		Replset: s.rs,
 		Type:    ctrl.CmdPITR,
@@ -339,12 +340,19 @@ func (s *Slicer) Stream(
 		// upload the chunks up to the current time and return
 		case <-stopC:
 			s.l.Info("got done signal, stopping")
-			// If the cluster is in error state, skip the final upload — the chunk
-			// would be useless since another RS has a gap. On query failure, fall
-			// through to the normal upload path (safe default).
+			// If the cluster is in error state, any chunks from this RS are
+			// useless since another RS has a gap. Delete the last chunk if
+			// a tick managed to upload one before the error was detected
+			// and skip the final upload. On query failure, fall through to
+			// the normal upload path (safe default).
 			status, serr := oplog.GetClusterStatus(ctx, s.leadClient)
 			if serr == nil && status == oplog.StatusError {
-				s.l.Info("stopping without final upload due to cluster error")
+				s.l.Info("stopping due to cluster error, skipping final upload")
+				if uploaded {
+					if err := s.deleteLastChunk(ctx); err != nil {
+						s.l.Error("cleanup last chunk: %v", err)
+					}
+				}
 				return nil
 			}
 			lastSlice = true
@@ -454,6 +462,7 @@ func (s *Slicer) Stream(
 			return nil
 		}
 
+		uploaded = true
 		s.lastTS = sliceTo
 
 		if ispan := s.GetSpan(); cspan != ispan {
@@ -505,6 +514,20 @@ func (s *Slicer) upload(
 		}
 	}
 
+	return nil
+}
+
+func (s *Slicer) deleteLastChunk(ctx context.Context) error {
+	lastChunk, err := oplog.PITRLastChunkMeta(ctx, s.leadClient, s.rs)
+	if err != nil {
+		return errors.Wrap(err, "find last chunk")
+	}
+
+	if err := oplog.DeleteChunkData(ctx, s.leadClient, s.storage, *lastChunk); err != nil {
+		return errors.Wrap(err, "delete chunk data")
+	}
+
+	s.l.Info("cleaned up chunk %s due to cluster error", lastChunk.FName)
 	return nil
 }
 


### PR DESCRIPTION
Ticket:
https://perconadev.atlassian.net/browse/PBM-1345

The idea for this fix is 

1. When streaming receives stop signal, check whether PITR is in `StatusError`
2. If in `StatusError` skip the upload of current chunk / remove the last uploaded chunk  
3. Adjust `pitrActivityMonitor` to skip reconfiguration if there are RS errors
    - this was a race with `pitrErrorMonitor` which shoudl be the one making decision on errors

This is generally fine for production oplog spans (default is 10 min) 

In future on error, we might track the last recorded TS and remove chunks based on that. 
