### PR TITLE
PBM-1638: Automatic Inclusion of KMIP/Vault Key Identifier - Handling  Older PSMDB Versions

### DIFF
--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -312,7 +312,7 @@ func (b *Backup) doPhysical(
 	if err != nil {
 		return errors.Wrap(err, "get mongod options")
 	}
-	err = topo.ExpandSecOptsWithEncAtRest(ctx, b.nodeConn, mopts.Security)
+	err = topo.ExpandSecOptsWithEncAtRest(ctx, b.nodeConn, mopts.Security, l)
 	if err != nil {
 		return errors.Wrap(err, "get encryption at rest options")
 	}

--- a/pbm/topo/node.go
+++ b/pbm/topo/node.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
+	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/version"
 )
 
@@ -271,6 +272,7 @@ func ExpandSecOptsWithEncAtRest(
 	ctx context.Context,
 	m *mongo.Client,
 	secOpts *MongodOptsSec,
+	l log.LogEvent,
 ) error {
 	if secOpts == nil || secOpts.EnableEncryption == nil || !*secOpts.EnableEncryption {
 		// encryption is not enabled
@@ -282,6 +284,12 @@ func ExpandSecOptsWithEncAtRest(
 		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
 		if err != nil {
 			return errors.Wrap(err, "get encryption at rest for kmip")
+		}
+		if encAtRestRaw.IsZero() {
+			l.Info("To store KMIP's keyIdentifier info within backup metadata, " +
+				"the latest PSMDB patch version is required.")
+			// backup should continue
+			return nil
 		}
 
 		var encAtRest struct {
@@ -302,6 +310,12 @@ func ExpandSecOptsWithEncAtRest(
 		encAtRestRaw, err := getEncryptionAtRest(ctx, m)
 		if err != nil {
 			return errors.Wrap(err, "get encryption at rest for vault")
+		}
+		if encAtRestRaw.IsZero() {
+			l.Info("To store Vault's secretVersion info within backup metadata, " +
+				"the latest PSMDB patch version is required.")
+			// backup should continue
+			return nil
 		}
 
 		var encAtRest struct {


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1638
Follows: #1296 

PR adds handling when PSMDB doesn't support `serverStatus().encryptionAtRest`. In that case:
- log message is added
- backup doesn't break with error, and it continues execution.


