### PR TITLE
PBM-1730 Abort restore on balancer stop and handle timeouts

### DIFF
--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -104,38 +104,6 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		return
 	}
 
-	// stop balancer during the restore
-	if a.brief.Sharded && nodeInfo.IsClusterLeader() {
-		bs, err := topo.GetBalancerStatus(ctx, a.leadConn)
-		if err != nil {
-			l.Error("get balancer status: %v", err)
-			return
-		}
-
-		if bs.IsOn() {
-			t := cfg.Restore.Timeouts.BalancerStop()
-			if t > 0 {
-				l.Debug("stopping balancer with timeout %s", t)
-				err = topo.StopBalancer(ctx, a.leadConn, t.Milliseconds())
-			} else {
-				l.Debug("stopping balancer")
-				err = topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
-			}
-			if err != nil {
-				l.Error("set balancer off: %v", err)
-			}
-
-			l.Debug("waiting for balancer off")
-			bs := topo.WaitForBalancerDisabled(ctx, a.leadConn, time.Second*30, l)
-			if bs.IsDisabled() {
-				l.Debug("balancer is disabled")
-			} else {
-				l.Warning("balancer is not disabled: balancer mode: %s, in balancer round: %t",
-					bs.Mode, bs.InBalancerRound)
-			}
-		}
-	}
-
 	var bcpType defs.BackupType
 	var bcp *backup.BackupMeta
 

--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -98,6 +98,12 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		return
 	}
 
+	cfg, err := config.GetConfig(ctx, a.leadConn)
+	if err != nil {
+		l.Error("get PBM configuration: %v", err)
+		return
+	}
+
 	// stop balancer during the restore
 	if a.brief.Sharded && nodeInfo.IsClusterLeader() {
 		bs, err := topo.GetBalancerStatus(ctx, a.leadConn)
@@ -107,7 +113,14 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 
 		if bs.IsOn() {
-			err := topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
+			t := cfg.Restore.Timeouts.BalancerStop()
+			if t > 0 {
+				l.Debug("stopping balancer with timeout %s", t)
+				err = topo.StopBalancer(ctx, a.leadConn, t.Milliseconds())
+			} else {
+				l.Debug("stopping balancer")
+				err = topo.SetBalancerStatus(ctx, a.leadConn, topo.BalancerModeOff)
+			}
 			if err != nil {
 				l.Error("set balancer off: %v", err)
 			}
@@ -154,12 +167,6 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 		bcpType = bcp.Type
 		r.BackupName = bcp.Name
-	}
-
-	cfg, err := config.GetConfig(ctx, a.leadConn)
-	if err != nil {
-		l.Error("get PBM configuration: %v", err)
-		return
 	}
 
 	l.Info("recovery started")

--- a/cmd/pbm-agent/restore.go
+++ b/cmd/pbm-agent/restore.go
@@ -98,12 +98,6 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		return
 	}
 
-	cfg, err := config.GetConfig(ctx, a.leadConn)
-	if err != nil {
-		l.Error("get PBM configuration: %v", err)
-		return
-	}
-
 	var bcpType defs.BackupType
 	var bcp *backup.BackupMeta
 
@@ -135,6 +129,12 @@ func (a *Agent) Restore(ctx context.Context, r *ctrl.RestoreCmd, opid ctrl.OPID,
 		}
 		bcpType = bcp.Type
 		r.BackupName = bcp.Name
+	}
+
+	cfg, err := config.GetConfig(ctx, a.leadConn)
+	if err != nil {
+		l.Error("get PBM configuration: %v", err)
+		return
 	}
 
 	l.Info("recovery started")

--- a/cmd/pbm/oplog.go
+++ b/cmd/pbm/oplog.go
@@ -104,7 +104,7 @@ func replayOplog(
 	startCtx, cancel := context.WithTimeout(ctx, defs.WaitActionStart)
 	defer cancel()
 
-	m, err := waitForRestoreStatus(startCtx, conn, name, restore.GetRestoreMeta)
+	m, err := waitForReplayStatus(startCtx, conn, name, restore.GetRestoreMeta)
 	if err != nil {
 		return nil, err
 	}
@@ -130,4 +130,62 @@ func replayOplog(
 	}
 
 	return oplogReplayResult{Name: name, done: true}, nil
+}
+
+func waitForReplayStatus(
+	ctx context.Context,
+	conn connect.Client,
+	name string,
+	getfn getRestoreMetaFn,
+) (*restore.RestoreMeta, error) {
+	tk := time.NewTicker(time.Second * 1)
+	defer tk.Stop()
+
+	meta := new(restore.RestoreMeta) // TODO
+	for {
+		select {
+		case <-tk.C:
+			fmt.Print(".")
+
+			var err error
+			meta, err = getfn(ctx, conn, name)
+			if errors.Is(err, errors.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return nil, errors.Wrap(err, "get metadata")
+			}
+			if meta == nil {
+				continue
+			}
+			switch meta.Status {
+			case defs.StatusRunning, defs.StatusDumpDone, defs.StatusDone:
+				return meta, nil
+			case defs.StatusError:
+				rs := ""
+				for _, s := range meta.Replsets {
+					rs += fmt.Sprintf("\n- Restore on replicaset \"%s\" in state: %v", s.Name, s.Status)
+					if s.Error != "" {
+						rs += ": " + s.Error
+					}
+				}
+				return nil, errors.New(meta.Error + rs)
+			}
+		case <-ctx.Done():
+			rs := ""
+			if meta != nil {
+				for _, s := range meta.Replsets {
+					rs += fmt.Sprintf("- Restore on replicaset \"%s\" in state: %v\n", s.Name, s.Status)
+					if s.Error != "" {
+						rs += ": " + s.Error
+					}
+				}
+			}
+			if rs == "" {
+				rs = "<no replset has started restore>\n"
+			}
+
+			return nil, errors.New("no confirmation that restore has successfully started. Replsets status:\n" + rs)
+		}
+	}
 }

--- a/cmd/pbm/oplog.go
+++ b/cmd/pbm/oplog.go
@@ -11,7 +11,6 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
-	"github.com/percona/percona-backup-mongodb/pbm/restore"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"github.com/percona/percona-backup-mongodb/sdk"
 )
@@ -101,10 +100,7 @@ func replayOplog(
 
 	fmt.Printf("Starting oplog replay '%s - %s'", o.start, o.end)
 
-	startCtx, cancel := context.WithTimeout(ctx, defs.WaitActionStart)
-	defer cancel()
-
-	m, err := waitForReplayStatus(startCtx, conn, name, restore.GetRestoreMeta)
+	m, err := waitForRestoreStatus(ctx, conn, stg, l, name, defs.LogicalBackup, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -130,62 +126,4 @@ func replayOplog(
 	}
 
 	return oplogReplayResult{Name: name, done: true}, nil
-}
-
-func waitForReplayStatus(
-	ctx context.Context,
-	conn connect.Client,
-	name string,
-	getfn getRestoreMetaFn,
-) (*restore.RestoreMeta, error) {
-	tk := time.NewTicker(time.Second * 1)
-	defer tk.Stop()
-
-	meta := new(restore.RestoreMeta) // TODO
-	for {
-		select {
-		case <-tk.C:
-			fmt.Print(".")
-
-			var err error
-			meta, err = getfn(ctx, conn, name)
-			if errors.Is(err, errors.ErrNotFound) {
-				continue
-			}
-			if err != nil {
-				return nil, errors.Wrap(err, "get metadata")
-			}
-			if meta == nil {
-				continue
-			}
-			switch meta.Status {
-			case defs.StatusRunning, defs.StatusDumpDone, defs.StatusDone:
-				return meta, nil
-			case defs.StatusError:
-				rs := ""
-				for _, s := range meta.Replsets {
-					rs += fmt.Sprintf("\n- Restore on replicaset \"%s\" in state: %v", s.Name, s.Status)
-					if s.Error != "" {
-						rs += ": " + s.Error
-					}
-				}
-				return nil, errors.New(meta.Error + rs)
-			}
-		case <-ctx.Done():
-			rs := ""
-			if meta != nil {
-				for _, s := range meta.Replsets {
-					rs += fmt.Sprintf("- Restore on replicaset \"%s\" in state: %v\n", s.Name, s.Status)
-					if s.Error != "" {
-						rs += ": " + s.Error
-					}
-				}
-			}
-			if rs == "" {
-				rs = "<no replset has started restore>\n"
-			}
-
-			return nil, errors.New("no confirmation that restore has successfully started. Replsets status:\n" + rs)
-		}
-	}
 }

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -181,7 +181,7 @@ func runRestore(
 	}
 
 	m, err := doRestore(ctx, conn, stg, l, o, numParallelColls, numInsertionWorkers,
-		nss, o.nsFrom, o.nsTo, rsMap, outf)
+		nss, o.nsFrom, o.nsTo, rsMap, outf, tdiff)
 	if err != nil {
 		if errors.Is(err, errUserCanceled) {
 			return outMsg{err.Error()}, nil
@@ -443,6 +443,7 @@ func doRestore(
 	nsTo string,
 	rsMapping map[string]string,
 	outf outFormat,
+	tskew int64,
 ) (*restore.RestoreMeta, error) {
 	bcp, bcpType, err := checkBackup(ctx, conn, o, nss, nsFrom, nsTo)
 	if err != nil {
@@ -559,7 +560,7 @@ func doRestore(
 		existsTimeout = time.Second * 120
 	}
 
-	return waitForRestoreStatus(ctx, conn, name, fn, existsTimeout)
+	return waitForRestoreStatus(ctx, conn, name, fn, existsTimeout, tskew)
 }
 
 func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {
@@ -639,6 +640,7 @@ func waitForRestoreStatus(
 	name string,
 	getfn getRestoreMetaFn,
 	existsTimeout time.Duration,
+	tskew int64,
 ) (*restore.RestoreMeta, error) {
 	if _, err := waitForRestoreExists(ctx, conn, name, getfn, existsTimeout); err != nil {
 		return nil, err
@@ -668,6 +670,10 @@ func waitForRestoreStatus(
 					}
 				}
 				return nil, errors.New(meta.Error + rs)
+			}
+
+			if err := checkRestoreStale(ctx, conn, meta, tskew); err != nil {
+				return nil, err
 			}
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -238,6 +238,29 @@ func runRestore(
 // But for physical ones, the cluster by this time is down. So we compare with
 // the wall time taking into account a time skew (wallTime - clusterTime) taken
 // when the cluster time was still available.
+func checkRestoreStale(ctx context.Context, conn connect.Client, meta *restore.RestoreMeta, tskew int64) error {
+	var ctime uint32
+	var frameSec uint32
+
+	if meta.Type == defs.LogicalBackup {
+		clusterTime, err := topo.GetClusterTime(ctx, conn)
+		if err != nil {
+			return errors.Wrap(err, "read cluster time")
+		}
+		frameSec = defs.StaleFrameSec
+		ctime = clusterTime.T
+	} else {
+		frameSec = 60 * 3
+		ctime = uint32(time.Now().Unix() + tskew)
+	}
+
+	if meta.Hb.T+frameSec < ctime {
+		return errors.Errorf("operation staled, last heartbeat: %v", meta.Hb.T)
+	}
+
+	return nil
+}
+
 func waitRestore(
 	ctx context.Context,
 	conn connect.Client,
@@ -252,12 +275,6 @@ func waitRestore(
 		getMeta = func(_ context.Context, _ connect.Client, name string) (*restore.RestoreMeta, error) {
 			return restore.GetPhysRestoreMeta(name, stg, l)
 		}
-	}
-
-	var ctime uint32
-	frameSec := defs.StaleFrameSec
-	if m.Type != defs.LogicalBackup {
-		frameSec = 60 * 3
 	}
 
 	tk := time.NewTicker(time.Second * 1)
@@ -296,18 +313,8 @@ func waitRestore(
 			return restoreFailedError{fmt.Sprintf("operation failed with: %s", rmeta.Error)}
 		}
 
-		if m.Type == defs.LogicalBackup {
-			clusterTime, err := topo.GetClusterTime(ctx, conn)
-			if err != nil {
-				return errors.Wrap(err, "read cluster time")
-			}
-			ctime = clusterTime.T
-		} else {
-			ctime = uint32(time.Now().Unix() + tskew)
-		}
-
-		if rmeta.Hb.T+frameSec < ctime {
-			return errors.Errorf("operation staled, last heartbeat: %v", rmeta.Hb.T)
+		if err := checkRestoreStale(ctx, conn, rmeta, tskew); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -541,26 +541,7 @@ func doRestore(
 
 	fmt.Printf("Starting restore %s%s%s", name, pitrs, bcpName)
 
-	var (
-		fn            getRestoreMetaFn
-		existsTimeout time.Duration
-	)
-	if bcpType == defs.LogicalBackup {
-		fn = restore.GetRestoreMeta
-		existsTimeout = defs.WaitActionStart
-	} else {
-		fn = func(ctx context.Context, conn connect.Client, name string) (*restore.RestoreMeta, error) {
-			meta, err := restore.GetRestoreMeta(ctx, conn, name)
-			if err == nil {
-				return meta, nil
-			}
-			return restore.GetPhysRestoreMeta(name, stg, l)
-		}
-		// physical restore may take more time to start
-		existsTimeout = time.Second * 120
-	}
-
-	return waitForRestoreStatus(ctx, conn, name, fn, existsTimeout, tskew)
+	return waitForRestoreStatus(ctx, conn, stg, l, name, bcpType, tskew)
 }
 
 func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {
@@ -642,12 +623,28 @@ func waitForRestoreExists(
 func waitForRestoreStatus(
 	ctx context.Context,
 	conn connect.Client,
+	stg storage.Storage,
+	l log.LogEvent,
 	name string,
-	getfn getRestoreMetaFn,
-	existsTimeout time.Duration,
+	bcpType defs.BackupType,
 	tskew int64,
 ) (*restore.RestoreMeta, error) {
-	if _, err := waitForRestoreExists(ctx, conn, name, getfn, existsTimeout); err != nil {
+	getMeta := restore.GetRestoreMeta
+	existsTimeout := defs.WaitActionStart
+
+	if bcpType != defs.LogicalBackup {
+		getMeta = func(ctx context.Context, conn connect.Client, name string) (*restore.RestoreMeta, error) {
+			meta, err := restore.GetRestoreMeta(ctx, conn, name)
+			if err == nil {
+				return meta, nil
+			}
+			return restore.GetPhysRestoreMeta(name, stg, l)
+		}
+		// physical restore may take more time to start
+		existsTimeout = time.Second * 120
+	}
+
+	if _, err := waitForRestoreExists(ctx, conn, name, getMeta, existsTimeout); err != nil {
 		return nil, err
 	}
 
@@ -659,7 +656,7 @@ func waitForRestoreStatus(
 		case <-tk.C:
 			fmt.Print(".")
 
-			meta, err := getfn(ctx, conn, name)
+			meta, err := getMeta(ctx, conn, name)
 			if err != nil {
 				return nil, errors.Wrap(err, "get metadata")
 			}

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -180,14 +180,23 @@ func runRestore(
 		return nil, errors.Wrap(err, "get storage")
 	}
 
-	m, err := doRestore(ctx, conn, stg, l, o, numParallelColls, numInsertionWorkers,
-		nss, o.nsFrom, o.nsTo, rsMap, outf, tdiff)
+	m, err := doRestore(ctx, conn, o, numParallelColls, numInsertionWorkers, nss, o.nsFrom, o.nsTo, rsMap)
 	if err != nil {
 		if errors.Is(err, errUserCanceled) {
 			return outMsg{err.Error()}, nil
 		}
 		return nil, err
 	}
+
+	if outf == outText {
+		restoreDesc := restoreDesc(o, m.Name, m.Backup)
+		fmt.Printf("Starting restore %s", restoreDesc)
+		m, err = waitForRestoreStatus(ctx, conn, stg, l, m.Name, m.Type, tdiff)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if o.extern && outf == outText {
 		err = waitRestore(ctx, conn, stg, l, m, defs.StatusCopyReady, tdiff)
 		if err != nil {
@@ -433,8 +442,6 @@ func nsIsTaken(
 func doRestore(
 	ctx context.Context,
 	conn connect.Client,
-	stg storage.Storage,
-	l log.LogEvent,
 	o *restoreOpts,
 	numParallelColls *int32,
 	numInsertionWorkers *int32,
@@ -442,8 +449,6 @@ func doRestore(
 	nsFrom string,
 	nsTo string,
 	rsMapping map[string]string,
-	outf outFormat,
-	tskew int64,
 ) (*restore.RestoreMeta, error) {
 	bcp, bcpType, err := checkBackup(ctx, conn, o, nss, nsFrom, nsTo)
 	if err != nil {
@@ -506,6 +511,28 @@ func doRestore(
 		}
 	}
 
+	if !o.yes {
+		restoreDesc := restoreDesc(o, name, bcp)
+		fmt.Printf("Restore: %s\n", restoreDesc)
+		err := askConfirmation("Are you sure you want to start the restore?")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = sendCmd(ctx, conn, cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "send command")
+	}
+
+	return &restore.RestoreMeta{
+		Name:   name,
+		Backup: bcp,
+		Type:   bcpType,
+	}, nil
+}
+
+func restoreDesc(o *restoreOpts, name, bcp string) string {
 	bcpName := ""
 	if bcp != "" {
 		bcpName = fmt.Sprintf(" from '%s'", bcp)
@@ -518,30 +545,7 @@ func doRestore(
 		pitrs = fmt.Sprintf(" to point-in-time %s", o.pitr)
 	}
 
-	if !o.yes {
-		fmt.Printf("Restore: %s%s%s\n", name, pitrs, bcpName)
-		err := askConfirmation("Are you sure you want to start the restore?")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = sendCmd(ctx, conn, cmd)
-	if err != nil {
-		return nil, errors.Wrap(err, "send command")
-	}
-
-	if outf != outText {
-		return &restore.RestoreMeta{
-			Name:   name,
-			Backup: bcp,
-			Type:   bcpType,
-		}, nil
-	}
-
-	fmt.Printf("Starting restore %s%s%s", name, pitrs, bcpName)
-
-	return waitForRestoreStatus(ctx, conn, stg, l, name, bcpType, tskew)
+	return fmt.Sprintf("%s%s%s", name, pitrs, bcpName)
 }
 
 func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -627,6 +627,11 @@ func waitForRestoreExists(
 			if meta == nil {
 				continue
 			}
+			// Physical restore meta from storage may be non-nil
+			// even before the first heartbeat is written.
+			if meta.Hb.T == 0 {
+				continue
+			}
 			return meta, nil
 		case <-to:
 			return nil, errors.New("no progress from leader, restore metadata not found")

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -541,16 +541,12 @@ func doRestore(
 	fmt.Printf("Starting restore %s%s%s", name, pitrs, bcpName)
 
 	var (
-		fn     getRestoreMetaFn
-		cancel context.CancelFunc
+		fn            getRestoreMetaFn
+		existsTimeout time.Duration
 	)
-
-	// physical restore may take more time to start
-	const waitPhysRestoreStart = time.Second * 120
-	var startCtx context.Context
 	if bcpType == defs.LogicalBackup {
 		fn = restore.GetRestoreMeta
-		startCtx, cancel = context.WithTimeout(ctx, defs.WaitActionStart)
+		existsTimeout = defs.WaitActionStart
 	} else {
 		fn = func(ctx context.Context, conn connect.Client, name string) (*restore.RestoreMeta, error) {
 			meta, err := restore.GetRestoreMeta(ctx, conn, name)
@@ -559,11 +555,11 @@ func doRestore(
 			}
 			return restore.GetPhysRestoreMeta(name, stg, l)
 		}
-		startCtx, cancel = context.WithTimeout(ctx, waitPhysRestoreStart)
+		// physical restore may take more time to start
+		existsTimeout = time.Second * 120
 	}
-	defer cancel()
 
-	return waitForRestoreStatus(startCtx, conn, name, fn)
+	return waitForRestoreStatus(ctx, conn, name, fn, existsTimeout)
 }
 
 func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {
@@ -642,26 +638,23 @@ func waitForRestoreStatus(
 	conn connect.Client,
 	name string,
 	getfn getRestoreMetaFn,
+	existsTimeout time.Duration,
 ) (*restore.RestoreMeta, error) {
+	if _, err := waitForRestoreExists(ctx, conn, name, getfn, existsTimeout); err != nil {
+		return nil, err
+	}
+
 	tk := time.NewTicker(time.Second * 1)
 	defer tk.Stop()
 
-	meta := new(restore.RestoreMeta) // TODO
 	for {
 		select {
 		case <-tk.C:
 			fmt.Print(".")
 
-			var err error
-			meta, err = getfn(ctx, conn, name)
-			if errors.Is(err, errors.ErrNotFound) {
-				continue
-			}
+			meta, err := getfn(ctx, conn, name)
 			if err != nil {
 				return nil, errors.Wrap(err, "get metadata")
-			}
-			if meta == nil {
-				continue
 			}
 			switch meta.Status {
 			case defs.StatusRunning, defs.StatusDumpDone, defs.StatusDone:
@@ -677,20 +670,7 @@ func waitForRestoreStatus(
 				return nil, errors.New(meta.Error + rs)
 			}
 		case <-ctx.Done():
-			rs := ""
-			if meta != nil {
-				for _, s := range meta.Replsets {
-					rs += fmt.Sprintf("- Restore on replicaset \"%s\" in state: %v\n", s.Name, s.Status)
-					if s.Error != "" {
-						rs += ": " + s.Error
-					}
-				}
-			}
-			if rs == "" {
-				rs = "<no replset has started restore>\n"
-			}
-
-			return nil, errors.New("no confirmation that restore has successfully started. Replsets status:\n" + rs)
+			return nil, ctx.Err()
 		}
 	}
 }

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -604,6 +604,39 @@ func parseTS(t string) (primitive.Timestamp, error) {
 
 type getRestoreMetaFn func(ctx context.Context, conn connect.Client, name string) (*restore.RestoreMeta, error)
 
+func waitForRestoreExists(
+	ctx context.Context,
+	conn connect.Client,
+	name string,
+	getfn getRestoreMetaFn,
+	timeout time.Duration,
+) (*restore.RestoreMeta, error) {
+	tk := time.NewTicker(time.Second * 1)
+	defer tk.Stop()
+	to := time.After(timeout)
+
+	for {
+		select {
+		case <-tk.C:
+			fmt.Print(".")
+
+			meta, err := getfn(ctx, conn, name)
+			if errors.Is(err, errors.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return nil, errors.Wrap(err, "get metadata")
+			}
+			if meta == nil {
+				continue
+			}
+			return meta, nil
+		case <-to:
+			return nil, errors.New("no progress from leader, restore metadata not found")
+		}
+	}
+}
+
 func waitForRestoreStatus(
 	ctx context.Context,
 	conn connect.Client,

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -418,6 +418,8 @@ type RestoreConf struct {
 
 	FallbackEnabled *bool `bson:"fallbackEnabled,omitempty" json:"fallbackEnabled,omitempty" yaml:"fallbackEnabled,omitempty"`
 	AllowPartlyDone *bool `bson:"allowPartlyDone,omitempty" json:"allowPartlyDone,omitempty" yaml:"allowPartlyDone,omitempty"`
+
+	Timeouts *RestoreTimeouts `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
 }
 
 func (cfg *RestoreConf) Clone() *RestoreConf {
@@ -432,8 +434,30 @@ func (cfg *RestoreConf) Clone() *RestoreConf {
 			rv.MongodLocationMap[k] = v
 		}
 	}
+	if cfg.Timeouts != nil {
+		rv.Timeouts = &RestoreTimeouts{
+			BalancerStopSec: cfg.Timeouts.BalancerStopSec,
+		}
+	}
 
 	return &rv
+}
+
+//nolint:lll
+type RestoreTimeouts struct {
+	// BalancerStopSec is timeout (in seconds) to wait for the balancer to stop.
+	// 0 means wait indefinitely (default).
+	BalancerStopSec uint32 `bson:"balancerStop,omitempty" json:"balancerStop,omitempty" yaml:"balancerStop,omitempty"`
+}
+
+// BalancerStop returns timeout duration for waiting for the balancer to stop.
+// Returns 0 if not set, meaning PBM will wait indefinitely.
+func (t *RestoreTimeouts) BalancerStop() time.Duration {
+	if t == nil {
+		return 0
+	}
+
+	return time.Duration(t.BalancerStopSec) * time.Second
 }
 
 // GetFallbackEnabled gets config's or default value for fallbackEnabled

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -146,11 +146,10 @@ func (r *Restore) exit(ctx context.Context, err error) {
 
 // stopBalancer stops the balancer and waits for it to be fully disabled.
 // Uses the configured restore.timeouts.balancerStop if set.
-func (r *Restore) stopBalancer(ctx context.Context) {
+func (r *Restore) stopBalancer(ctx context.Context) error {
 	bs, err := topo.GetBalancerStatus(ctx, r.leadConn)
 	if err != nil {
-		r.log.Error("get balancer status: %v", err)
-		return
+		return errors.Wrap(err, "get balancer status")
 	}
 
 	if bs.IsOn() {
@@ -163,7 +162,7 @@ func (r *Restore) stopBalancer(ctx context.Context) {
 			err = topo.SetBalancerStatus(ctx, r.leadConn, topo.BalancerModeOff)
 		}
 		if err != nil {
-			r.log.Error("set balancer off: %v", err)
+			return errors.Wrap(err, "set balancer off")
 		}
 
 		r.log.Debug("waiting for balancer off")
@@ -175,6 +174,8 @@ func (r *Restore) stopBalancer(ctx context.Context) {
 				bs.Mode, bs.InBalancerRound)
 		}
 	}
+
+	return nil
 }
 
 // resolveNamespace resolves final namespace(s) based on the backup namespace,
@@ -253,7 +254,9 @@ func (r *Restore) Snapshot(
 	}
 
 	if r.brief.Sharded && r.nodeInfo.IsClusterLeader() {
-		r.stopBalancer(ctx)
+		if err := r.stopBalancer(ctx); err != nil {
+			return err
+		}
 	}
 
 	r.bcpStg, err = util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
@@ -395,7 +398,9 @@ func (r *Restore) PITR(
 	}
 
 	if r.brief.Sharded && r.nodeInfo.IsClusterLeader() {
-		r.stopBalancer(ctx)
+		if err := r.stopBalancer(ctx); err != nil {
+			return err
+		}
 	}
 
 	if bcp.LastWriteTS.Compare(cmd.OplogTS) >= 0 {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -144,6 +144,39 @@ func (r *Restore) exit(ctx context.Context, err error) {
 	r.Close()
 }
 
+// stopBalancer stops the balancer and waits for it to be fully disabled.
+// Uses the configured restore.timeouts.balancerStop if set.
+func (r *Restore) stopBalancer(ctx context.Context) {
+	bs, err := topo.GetBalancerStatus(ctx, r.leadConn)
+	if err != nil {
+		r.log.Error("get balancer status: %v", err)
+		return
+	}
+
+	if bs.IsOn() {
+		t := r.cfg.Restore.Timeouts.BalancerStop()
+		if t > 0 {
+			r.log.Debug("stopping balancer with timeout %s", t)
+			err = topo.StopBalancer(ctx, r.leadConn, t.Milliseconds())
+		} else {
+			r.log.Debug("stopping balancer")
+			err = topo.SetBalancerStatus(ctx, r.leadConn, topo.BalancerModeOff)
+		}
+		if err != nil {
+			r.log.Error("set balancer off: %v", err)
+		}
+
+		r.log.Debug("waiting for balancer off")
+		bs := topo.WaitForBalancerDisabled(ctx, r.leadConn, time.Second*30, r.log)
+		if bs.IsDisabled() {
+			r.log.Debug("balancer is disabled")
+		} else {
+			r.log.Warning("balancer is not disabled: balancer mode: %s, in balancer round: %t",
+				bs.Mode, bs.InBalancerRound)
+		}
+	}
+}
+
 // resolveNamespace resolves final namespace(s) based on the backup namespace,
 // restore namespace, cloning options and option whether we should restore users&roles
 func resolveNamespace(
@@ -217,6 +250,10 @@ func (r *Restore) Snapshot(
 	err = r.init(ctx, cmd.Name, opid, l)
 	if err != nil {
 		return err
+	}
+
+	if r.brief.Sharded && r.nodeInfo.IsClusterLeader() {
+		r.stopBalancer(ctx)
 	}
 
 	r.bcpStg, err = util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
@@ -355,6 +392,10 @@ func (r *Restore) PITR(
 	err = r.init(ctx, cmd.Name, opid, l)
 	if err != nil {
 		return err
+	}
+
+	if r.brief.Sharded && r.nodeInfo.IsClusterLeader() {
+		r.stopBalancer(ctx)
 	}
 
 	if bcp.LastWriteTS.Compare(cmd.OplogTS) >= 0 {


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1730

- Reintroduces `restore.timeouts.stopBalancer`
- Balancer is stopped only for logical restore 
- Balancer is stopped after restore meta exists (right after `r.init()` call)
- Failure to stop the balancer leads to a backup failure and stop
- `pbm restore` waiting behavior unified with `pbm backup`
   -  without `--wait` wait for metada existence with timout, then unconditionally wait for `StatusRunning` while monitoring HB 
   - with `--wait` wait for terminal status while monitoring HB (behavior unchanged) 
   
Wait difference for `json` ouput:
- CLI doesn't wait for `StatusRunning` when ouput is not text
- `pbm restore <name> --out=json` is basically "fire and forget", unlike backup, which waits for `StatusRunning` regardless of output format
- This is a current dev behavior which I kept

Last two commits are pure refactoring, which IMHO makes the code more understandable but could be dropped entirely 