### PR TITLE
PBM-1370: Log cleanup --older-than value

### DIFF
--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -242,6 +242,12 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		}
 	}()
 
+	t := time.Unix(int64(d.OlderThan.T), 0).UTC()
+	obj := t.Format("2006-01-02T15:04:05Z")
+
+	l = logger.NewEvent(string(ctrl.CmdCleanup), obj, opid.String(), ep.TS())
+	ctx = log.SetLogEventToContext(ctx, l)
+
 	ct, err := topo.GetClusterTime(ctx, a.leadConn)
 	if err != nil {
 		l.Error("get cluster time: %v", err)
@@ -271,6 +277,8 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		l.Error("make cleanup report: " + err.Error())
 		return
 	}
+
+	l.Info("deleting backups and pitr chunks older than %v %s", t, util.LogProfileArg(d.Profile))
 
 	eg := &errgroup.Group{}
 	eg.SetLimit(runtime.NumCPU())


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1370

Aligned `pbm cleanup --older-than <ts>` with how `pbm delete-backup --older-than <ts>` logs 

Before change:
```
2026-04-22T13:12:47Z I [rs1/rs101:27017] got command cleanup <ts: 1776863567>, opid: 69e8c94f26bf530d7f837c13
2026-04-22T13:12:47Z I [rs1/rs101:27017] got epoch {1776863014 2}
2026-04-22T13:12:47Z I [rs1/rs101:27017] [cleanup] deleting backup "2026-04-22T13:09:18Z"
...
```

After change:
```
2026-04-22T13:26:22Z I [rs1/rs101:27017] got command cleanup <ts: 1776864382>, opid: 69e8cc7e54551a7108006362
2026-04-22T13:26:22Z I [rs1/rs101:27017] got epoch {1776864184 2}
2026-04-22T13:26:22Z I [rs1/rs101:27017] [cleanup/2026-04-22T13:26:00Z] deleting backups and pitr chunks older than 2026-04-22 13:26:00 +0000 UTC
2026-04-22T13:26:22Z I [rs1/rs101:27017] [cleanup/2026-04-22T13:26:00Z] deleting backup "2026-04-22T13:24:22Z"
...
```