### PR TITLE
PBM-1728 Support workload federation for OCI

### DIFF
--- a/packaging/conf/pbm-conf-reference.yml
+++ b/packaging/conf/pbm-conf-reference.yml
@@ -15,7 +15,8 @@
 ##  - GCS,
 ##  - Minio (for S3 compatible storage),
 ##  - shared filesystem,
-##  - Azure
+##  - Azure,
+##  - OCI
 
 
 #---------------------S3 Storage Configuration--------------------------
@@ -193,6 +194,46 @@
 #
 ## The maximum object size that will be stored on the storage
 #      maxObjSizeGB: 194560
+
+#--------------------Oracle Cloud Infrastructure Object Storage Configuration-----------------------
+#  type: oci
+#  oci:
+
+## OCI Object Storage bucket region, namespace, and bucket name.
+#    region:
+#    namespace:
+#    bucket:
+
+## The data directory to store backups in.
+## When undefined, backups are saved at the root of the bucket.
+#    prefix:
+
+## OCI authentication configuration.
+## Supported types: userPrincipal, instancePrincipal, okeWorkloadIdentity.
+## userPrincipal requires the nested userPrincipal block.
+## instancePrincipal and okeWorkloadIdentity do not require further configuration.
+#    credentials:
+#      type: userPrincipal
+#      userPrincipal:
+#        tenancy:
+#        user:
+#        fingerprint:
+#        privateKey:
+#        privateKeyPassphrase:
+
+## Retry configuration options.
+#    retryer:
+#      maxAttempts: 8
+#      maxBackoff: 30s
+
+## The size of data chunks in bytes to upload to the bucket in a single request.
+#    uploadPartSize: 10485760
+
+## The maximum number of parallel upload workers.
+#    uploadConcurrency: 5
+
+## The maximum object size that will be stored on the storage.
+#    maxObjSizeGB: 10138
 
 #====================Point-in-Time Recovery Configuration==================
 

--- a/pbm/config/config_test.go
+++ b/pbm/config/config_test.go
@@ -297,10 +297,13 @@ func TestIsSameStorage(t *testing.T) {
 			Bucket:    "b1",
 			Prefix:    "p1",
 			Credentials: ocistorage.Credentials{
-				Tenancy:     "t1",
-				User:        "u1",
-				Fingerprint: "f1",
-				PrivateKey:  "pk1",
+				Type: ocistorage.AuthTypeUserPrincipal,
+				UserPrincipal: &ocistorage.UserPrincipalCredentials{
+					Tenancy:     "t1",
+					User:        "u1",
+					Fingerprint: "f1",
+					PrivateKey:  "pk1",
+				},
 			},
 		}
 		eq := &ocistorage.Config{

--- a/pbm/storage/oci/config.go
+++ b/pbm/storage/oci/config.go
@@ -59,8 +59,20 @@ type Retryer struct {
 	MaxBackoff time.Duration `bson:"maxBackoff" json:"maxBackoff" yaml:"maxBackoff"`
 }
 
+type AuthType string
+
+const (
+	AuthTypeUserPrincipal AuthType = "userPrincipal"
+)
+
 //nolint:lll
 type Credentials struct {
+	Type          AuthType                  `bson:"type,omitempty" json:"type,omitempty" yaml:"type,omitempty"`
+	UserPrincipal *UserPrincipalCredentials `bson:"userPrincipal,omitempty" json:"userPrincipal,omitempty" yaml:"userPrincipal,omitempty"`
+}
+
+//nolint:lll
+type UserPrincipalCredentials struct {
 	Tenancy              storage.MaskedString `bson:"tenancy" json:"tenancy,omitempty" yaml:"tenancy,omitempty"`
 	User                 storage.MaskedString `bson:"user" json:"user,omitempty" yaml:"user,omitempty"`
 	Fingerprint          storage.MaskedString `bson:"fingerprint" json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
@@ -74,6 +86,10 @@ func (cfg *Config) Clone() *Config {
 	}
 
 	rv := *cfg
+	if cfg.Credentials.UserPrincipal != nil {
+		v := *cfg.Credentials.UserPrincipal
+		rv.Credentials.UserPrincipal = &v
+	}
 	if cfg.MaxObjSizeGB != nil {
 		v := *cfg.MaxObjSizeGB
 		rv.MaxObjSizeGB = &v
@@ -116,7 +132,9 @@ func (cfg *Config) Cast() error {
 	if cfg == nil {
 		return errors.New("missing oci configuration with oci storage type")
 	}
-
+	if cfg.Credentials.Type == "" {
+		cfg.Credentials.Type = AuthTypeUserPrincipal
+	}
 	if cfg.UploadPartSize > maxUploadPartSize {
 		return errors.Errorf("uploadPartSize cannot exceed %d", maxUploadPartSize)
 	}

--- a/pbm/storage/oci/config.go
+++ b/pbm/storage/oci/config.go
@@ -62,7 +62,8 @@ type Retryer struct {
 type AuthType string
 
 const (
-	AuthTypeUserPrincipal AuthType = "userPrincipal"
+	AuthTypeUserPrincipal     AuthType = "userPrincipal"
+	AuthTypeInstancePrincipal AuthType = "instancePrincipal"
 )
 
 //nolint:lll

--- a/pbm/storage/oci/config.go
+++ b/pbm/storage/oci/config.go
@@ -62,8 +62,9 @@ type Retryer struct {
 type AuthType string
 
 const (
-	AuthTypeUserPrincipal     AuthType = "userPrincipal"
-	AuthTypeInstancePrincipal AuthType = "instancePrincipal"
+	AuthTypeUserPrincipal       AuthType = "userPrincipal"
+	AuthTypeInstancePrincipal   AuthType = "instancePrincipal"
+	AuthTypeOkeWorkloadIdentity AuthType = "okeWorkloadIdentity"
 )
 
 //nolint:lll

--- a/pbm/storage/oci/config_test.go
+++ b/pbm/storage/oci/config_test.go
@@ -18,6 +18,7 @@ func TestCastSetsDefaults(t *testing.T) {
 
 	require.NoError(t, cfg.Cast())
 
+	assert.Equal(t, AuthTypeUserPrincipal, cfg.Credentials.Type)
 	assert.Equal(t, defaultUploadPartSize, cfg.UploadPartSize)
 	assert.Equal(t, defaultUploadConcurrency, cfg.UploadConcurrency)
 	assert.Equal(t, float64(defaultMaxObjSizeGB), cfg.GetMaxObjSizeGB())
@@ -203,6 +204,16 @@ func TestGetMaxObjSizeGB(t *testing.T) {
 	assert.Less(t, defaultMaxObjSizeGB, maxObjSizeGB)
 }
 
+func TestCloneCopiesUserPrincipal(t *testing.T) {
+	cfg := testConfig(testPrivateKey(t))
+
+	clone := cfg.Clone()
+	require.NotNil(t, clone)
+	require.NotNil(t, clone.Credentials.UserPrincipal)
+	require.NotSame(t, cfg.Credentials.UserPrincipal, clone.Credentials.UserPrincipal)
+	assert.Equal(t, cfg, clone)
+}
+
 func TestIsSameStorage(t *testing.T) {
 	cfg := &Config{
 		Region:    "eu-frankfurt-1",
@@ -210,10 +221,13 @@ func TestIsSameStorage(t *testing.T) {
 		Bucket:    "b1",
 		Prefix:    "p1",
 		Credentials: Credentials{
-			Tenancy:     "t1",
-			User:        "u1",
-			Fingerprint: "f1",
-			PrivateKey:  "pk1",
+			Type: AuthTypeUserPrincipal,
+			UserPrincipal: &UserPrincipalCredentials{
+				Tenancy:     "t1",
+				User:        "u1",
+				Fingerprint: "f1",
+				PrivateKey:  "pk1",
+			},
 		},
 		UploadPartSize:    1,
 		UploadConcurrency: 2,
@@ -269,24 +283,34 @@ func TestConfigureClientMissingFields(t *testing.T) {
 			wantErr: "bucket is required",
 		},
 		{
+			name:    "unsupported credentials type",
+			mutate:  func(cfg *Config) { cfg.Credentials.Type = "unknown" },
+			wantErr: "unsupported OCI credentials type",
+		},
+		{
+			name:    "user principal config",
+			mutate:  func(cfg *Config) { cfg.Credentials.UserPrincipal = nil },
+			wantErr: "credentials.userPrincipal is required",
+		},
+		{
 			name:    "tenancy",
-			mutate:  func(cfg *Config) { cfg.Credentials.Tenancy = "" },
-			wantErr: "credentials.tenancy is required",
+			mutate:  func(cfg *Config) { cfg.Credentials.UserPrincipal.Tenancy = "" },
+			wantErr: "credentials.userPrincipal.tenancy is required",
 		},
 		{
 			name:    "user",
-			mutate:  func(cfg *Config) { cfg.Credentials.User = "" },
-			wantErr: "credentials.user is required",
+			mutate:  func(cfg *Config) { cfg.Credentials.UserPrincipal.User = "" },
+			wantErr: "credentials.userPrincipal.user is required",
 		},
 		{
 			name:    "fingerprint",
-			mutate:  func(cfg *Config) { cfg.Credentials.Fingerprint = "" },
-			wantErr: "credentials.fingerprint is required",
+			mutate:  func(cfg *Config) { cfg.Credentials.UserPrincipal.Fingerprint = "" },
+			wantErr: "credentials.userPrincipal.fingerprint is required",
 		},
 		{
 			name:    "private key",
-			mutate:  func(cfg *Config) { cfg.Credentials.PrivateKey = "" },
-			wantErr: "credentials.privateKey is required",
+			mutate:  func(cfg *Config) { cfg.Credentials.UserPrincipal.PrivateKey = "" },
+			wantErr: "credentials.userPrincipal.privateKey is required",
 		},
 	}
 
@@ -321,16 +345,30 @@ func TestConfigureClient(t *testing.T) {
 	require.NotNil(t, gotRetryPolicy.NextDuration)
 }
 
+func TestConfigureClientDefaultsToUserPrincipal(t *testing.T) {
+	cfg := testConfig(testPrivateKey(t))
+	cfg.Credentials.Type = ""
+
+	client, err := configureClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, client.RetryPolicy())
+}
+
 func testConfig(privateKey string) *Config {
 	return &Config{
 		Region:    "eu-frankfurt-1",
 		Namespace: "testns",
 		Bucket:    "testbucket",
 		Credentials: Credentials{
-			Tenancy:     "ocid1.tenancy.oc1..test",
-			User:        "ocid1.user.oc1..test",
-			Fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
-			PrivateKey:  storage.MaskedString(privateKey),
+			Type: AuthTypeUserPrincipal,
+			UserPrincipal: &UserPrincipalCredentials{
+				Tenancy:     "ocid1.tenancy.oc1..test",
+				User:        "ocid1.user.oc1..test",
+				Fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
+				PrivateKey:  storage.MaskedString(privateKey),
+			},
 		},
 	}
 }

--- a/pbm/storage/oci/oci.go
+++ b/pbm/storage/oci/oci.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
 
@@ -115,6 +116,8 @@ func configurationProvider(cfg *Config) (common.ConfigurationProvider, error) {
 	switch authType {
 	case AuthTypeUserPrincipal:
 		return userPrincipalProvider(cfg)
+	case AuthTypeInstancePrincipal:
+		return auth.InstancePrincipalConfigurationProviderForRegion(common.StringToRegion(cfg.Region))
 	default:
 		return nil, errors.Errorf("unsupported OCI credentials type %q", authType)
 	}

--- a/pbm/storage/oci/oci.go
+++ b/pbm/storage/oci/oci.go
@@ -101,6 +101,13 @@ func configureClient(cfg *Config) (*objectstorage.ObjectStorageClient, error) {
 	client.SetCustomClientConfiguration(common.CustomClientConfiguration{
 		RetryPolicy: retryPolicy,
 	})
+	if cfg.Credentials.Type == AuthTypeOkeWorkloadIdentity {
+		// OKE provider gets its region from OCI_RESOURCE_PRINCIPAL_REGION and has no ForRegion variant.
+		// PBM's cfg.Region is the Object Storage bucket region, so override the service endpoint.
+		// This must happen after SetCustomClientConfiguration because the OCI SDK refreshes
+		// the endpoint from provider.Region() when custom config is applied.
+		client.SetRegion(cfg.Region)
+	}
 	// Match OCI transfer manager behavior: use a no-timeout client for large uploads.
 	client.HTTPClient = &http.Client{}
 
@@ -118,6 +125,8 @@ func configurationProvider(cfg *Config) (common.ConfigurationProvider, error) {
 		return userPrincipalProvider(cfg)
 	case AuthTypeInstancePrincipal:
 		return auth.InstancePrincipalConfigurationProviderForRegion(common.StringToRegion(cfg.Region))
+	case AuthTypeOkeWorkloadIdentity:
+		return auth.OkeWorkloadIdentityConfigurationProvider()
 	default:
 		return nil, errors.Errorf("unsupported OCI credentials type %q", authType)
 	}

--- a/pbm/storage/oci/oci.go
+++ b/pbm/storage/oci/oci.go
@@ -86,31 +86,11 @@ func configureClient(cfg *Config) (*objectstorage.ObjectStorageClient, error) {
 	if cfg.Bucket == "" {
 		return nil, errors.New("bucket is required")
 	}
-	if cfg.Credentials.Tenancy == "" {
-		return nil, errors.New("credentials.tenancy is required")
-	}
-	if cfg.Credentials.User == "" {
-		return nil, errors.New("credentials.user is required")
-	}
-	if cfg.Credentials.Fingerprint == "" {
-		return nil, errors.New("credentials.fingerprint is required")
-	}
-	if cfg.Credentials.PrivateKey == "" {
-		return nil, errors.New("credentials.privateKey is required")
-	}
 
-	var passphrase *string
-	if cfg.Credentials.PrivateKeyPassphrase != "" {
-		passphrase = common.String(string(cfg.Credentials.PrivateKeyPassphrase))
+	provider, err := configurationProvider(cfg)
+	if err != nil {
+		return nil, err
 	}
-	provider := common.NewRawConfigurationProvider(
-		string(cfg.Credentials.Tenancy),
-		string(cfg.Credentials.User),
-		cfg.Region,
-		string(cfg.Credentials.Fingerprint),
-		string(cfg.Credentials.PrivateKey),
-		passphrase,
-	)
 
 	client, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(provider)
 	if err != nil {
@@ -124,6 +104,53 @@ func configureClient(cfg *Config) (*objectstorage.ObjectStorageClient, error) {
 	client.HTTPClient = &http.Client{}
 
 	return &client, nil
+}
+
+func configurationProvider(cfg *Config) (common.ConfigurationProvider, error) {
+	authType := cfg.Credentials.Type
+	if authType == "" {
+		authType = AuthTypeUserPrincipal
+	}
+
+	switch authType {
+	case AuthTypeUserPrincipal:
+		return userPrincipalProvider(cfg)
+	default:
+		return nil, errors.Errorf("unsupported OCI credentials type %q", authType)
+	}
+}
+
+func userPrincipalProvider(cfg *Config) (common.ConfigurationProvider, error) {
+	creds := cfg.Credentials.UserPrincipal
+	if creds == nil {
+		return nil, errors.New("credentials.userPrincipal is required")
+	}
+	if creds.Tenancy == "" {
+		return nil, errors.New("credentials.userPrincipal.tenancy is required")
+	}
+	if creds.User == "" {
+		return nil, errors.New("credentials.userPrincipal.user is required")
+	}
+	if creds.Fingerprint == "" {
+		return nil, errors.New("credentials.userPrincipal.fingerprint is required")
+	}
+	if creds.PrivateKey == "" {
+		return nil, errors.New("credentials.userPrincipal.privateKey is required")
+	}
+
+	var passphrase *string
+	if creds.PrivateKeyPassphrase != "" {
+		passphrase = common.String(string(creds.PrivateKeyPassphrase))
+	}
+
+	return common.NewRawConfigurationProvider(
+		string(creds.Tenancy),
+		string(creds.User),
+		cfg.Region,
+		string(creds.Fingerprint),
+		string(creds.PrivateKey),
+		passphrase,
+	), nil
 }
 
 func newRetryPolicy(cfg *Retryer) *common.RetryPolicy {


### PR DESCRIPTION
ticket: https://perconadev.atlassian.net/browse/PBM-1728
related to: https://github.com/percona/percona-backup-mongodb/pull/1318

- Adds support for instance principal auth
- Adds support for OKE workload identity
- Credentials shape changed to accommodate the different types of authentication


Example configuration 

```yaml
storage:
  type: oci
  oci:
    region: eu-frankfurt-1
    namespace: idvufsl0apl6
    bucket: pbm-test-jakub
    prefix: pbm
    retryer:
      maxAttempts: 15
      maxBackoff: 180s
    credentials:
      type: userPrincipal # instancePrincipal | okeWorkloadIdentity
      userPrincipal:
        tenancy: ocid1.tenancy.oc1..xxx
        user: ocid1.user.oc1..yyy
        fingerprint: e0:a8:24:e5:f6:b8:6e:...
        privateKey: |
          -----BEGIN PRIVATE KEY-----

          ...
          -----END PRIVATE KEY-----
```