### PR TITLE
Added option for Parallel upload with grpc client

### DIFF
--- a/pbm/storage/gcs/config.go
+++ b/pbm/storage/gcs/config.go
@@ -19,7 +19,26 @@ type Config struct {
 	ChunkSize    int      `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
 	MaxObjSizeGB *float64 `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 
+	ParallelUpload *ParallelUpload `bson:"parallelUpload,omitempty" json:"parallelUpload,omitempty" yaml:"parallelUpload,omitempty"`
+
 	Retryer *Retryer `bson:"retryer,omitempty" json:"retryer,omitempty" yaml:"retryer,omitempty"`
+}
+
+// ParallelUpload configures the experimental Google Cloud Storage parallel upload feature.
+//
+// Parallel uploads are supported only by the Google SDK gRPC client. HMAC credentials
+// continue to use the MinIO client and are not affected by this setting.
+type ParallelUpload struct {
+	// Enabled switches the Google SDK client to gRPC and enables Writer parallel uploads.
+	Enabled bool `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	// PartSize is the size of each temporary part in bytes.
+	// If unset, PBM uses the computed ChunkSize for the uploaded object.
+	PartSize int `bson:"partSize,omitempty" json:"partSize,omitempty" yaml:"partSize,omitempty"`
+
+	// MaxConcurrency is the number of goroutines used to upload parts in parallel.
+	// If unset, the Google SDK chooses a value based on the number of CPUs.
+	MaxConcurrency int `bson:"maxConcurrency,omitempty" json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty"`
 }
 
 //nolint:lll
@@ -72,6 +91,10 @@ func (cfg *Config) Clone() *Config {
 		v := *cfg.MaxObjSizeGB
 		rv.MaxObjSizeGB = &v
 	}
+	if cfg.ParallelUpload != nil {
+		v := *cfg.ParallelUpload
+		rv.ParallelUpload = &v
+	}
 	if cfg.Retryer != nil {
 		v := *cfg.Retryer
 		rv.Retryer = &v
@@ -95,6 +118,9 @@ func (cfg *Config) Equal(other *Config) bool {
 		return false
 	}
 	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
+		return false
+	}
+	if !reflect.DeepEqual(cfg.ParallelUpload, other.ParallelUpload) {
 		return false
 	}
 	if !reflect.DeepEqual(cfg.Credentials, other.Credentials) {
@@ -132,6 +158,15 @@ func (cfg *Config) Cast() error {
 		cfg.ChunkSize = defaultChunkSize
 	}
 
+	if cfg.ParallelUpload != nil {
+		if cfg.ParallelUpload.PartSize < 0 {
+			return errors.New("parallelUpload.partSize cannot be negative")
+		}
+		if cfg.ParallelUpload.MaxConcurrency < 0 {
+			return errors.New("parallelUpload.maxConcurrency cannot be negative")
+		}
+	}
+
 	if cfg.Retryer == nil {
 		cfg.Retryer = &Retryer{
 			MaxAttempts:        defaultMaxAttempts,
@@ -166,4 +201,8 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 		return *cfg.MaxObjSizeGB
 	}
 	return defaultMaxObjSizeGB
+}
+
+func (cfg *Config) parallelUploadEnabled() bool {
+	return cfg.ParallelUpload != nil && cfg.ParallelUpload.Enabled
 }

--- a/pbm/storage/gcs/config_test.go
+++ b/pbm/storage/gcs/config_test.go
@@ -35,6 +35,32 @@ func TestCast(t *testing.T) {
 	if !c.Equal(want) {
 		t.Fatalf("wrong config after Cast, diff=%s", cmp.Diff(*c, *want))
 	}
+
+	t.Run("parallel upload validation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			cfg  *Config
+			err  string
+		}{
+			{
+				name: "negative part size",
+				cfg:  &Config{ParallelUpload: &ParallelUpload{PartSize: -1}},
+				err:  "parallelUpload.partSize cannot be negative",
+			},
+			{
+				name: "negative max concurrency",
+				cfg:  &Config{ParallelUpload: &ParallelUpload{MaxConcurrency: -1}},
+				err:  "parallelUpload.maxConcurrency cannot be negative",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				err := tt.cfg.Cast()
+				if err == nil || !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("expected %q, got %v", tt.err, err)
+				}
+			})
+		}
+	})
 }
 
 func TestConfig(t *testing.T) {
@@ -44,6 +70,11 @@ func TestConfig(t *testing.T) {
 		Credentials: Credentials{
 			ClientEmail: "email@example.com",
 			PrivateKey:  "-----BEGIN PRIVATE KEY-----\nKey\n-----END PRIVATE KEY-----\n",
+		},
+		ParallelUpload: &ParallelUpload{
+			Enabled:        true,
+			PartSize:       16 * 1024 * 1024,
+			MaxConcurrency: 4,
 		},
 	}
 
@@ -57,10 +88,17 @@ func TestConfig(t *testing.T) {
 			t.Error("expected clone to be equal")
 		}
 
+		opts.ParallelUpload.MaxConcurrency = 8
+		if opts.Equal(clone) {
+			t.Error("expected clone to be unchanged when updating original")
+		}
+		opts.ParallelUpload.MaxConcurrency = 4
+
 		opts.Bucket = "updatedName"
 		if opts.Equal(clone) {
 			t.Error("expected clone to be unchanged when updating original")
 		}
+		opts.Bucket = clone.Bucket
 	})
 
 	t.Run("Equal fails", func(t *testing.T) {
@@ -78,6 +116,12 @@ func TestConfig(t *testing.T) {
 		clone.Credentials.ClientEmail = "updated@example.com"
 		if opts.Equal(clone) {
 			t.Error("expected not to be equal when updating credentials")
+		}
+
+		clone = opts.Clone()
+		clone.ParallelUpload.Enabled = false
+		if opts.Equal(clone) {
+			t.Error("expected not to be equal when updating parallel upload")
 		}
 	})
 

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -53,7 +53,11 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 		if merr != nil {
 			return nil, errors.Wrap(merr, "marshal GCS credentials")
 		}
-		cli, err = storagegcs.NewClient(ctx, option.WithCredentialsJSON(creds))
+		if cfg.parallelUploadEnabled() {
+			cli, err = storagegcs.NewGRPCClient(ctx, option.WithCredentialsJSON(creds))
+		} else {
+			cli, err = storagegcs.NewClient(ctx, option.WithCredentialsJSON(creds))
+		}
 	} else {
 		// No explicit credentials — validate ADC resolves to allowed type (Workload Identity)
 		// We only check the credentials type, the scoped used hear doesn't really matter
@@ -65,7 +69,11 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 		if adcErr != nil {
 			return nil, fmt.Errorf("validate default credential type: %w", adcErr)
 		}
-		cli, err = storagegcs.NewClient(ctx)
+		if cfg.parallelUploadEnabled() {
+			cli, err = storagegcs.NewGRPCClient(ctx)
+		} else {
+			cli, err = storagegcs.NewClient(ctx)
+		}
 	}
 
 	if err != nil {
@@ -162,6 +170,13 @@ func (g googleClient) save(name string, data io.Reader, options ...storage.Optio
 	w := g.bucketHandle.Object(path.Join(g.cfg.Prefix, name)).NewWriter(ctx)
 	w.ChunkSize = int(partSize)
 	w.ChunkRetryDeadline = g.cfg.Retryer.ChunkRetryDeadline
+	if g.cfg.parallelUploadEnabled() {
+		w.EnableParallelUpload = true
+		w.ParallelUploadConfig = storagegcs.ParallelUploadConfig{
+			PartSize:       g.cfg.ParallelUpload.PartSize,
+			MaxConcurrency: g.cfg.ParallelUpload.MaxConcurrency,
+		}
+	}
 	if g.log != nil && opts.UseLogger {
 		w.ProgressFunc = func(written int64) {
 			if opts.Size > 0 {


### PR DESCRIPTION
**Ticket**:
[https://perconadev.atlassian.net/browse/PBM-1776](https://perconadev.atlassian.net/browse/PBM-1776)

**Description:**
Added optional configuration for ParallelUpload
Since it is experimental in the SDK according to Google, it is gated with "enable: true"

If the parallel upload is enabled, the client is also switched to the grpc version as per requirements.

Documentation is not updated, if pull request looks good, will submit for documentation as well

**Example configuration snippet:**
```
 Config shape:

  storage:
    gcs:
      parallelUpload:
        enabled: true
        partSize: 16777216 # Optional, default: 16MiB
        maxConcurrency: 4 # Optional, default: (min(4 + NumCPU/2, 16))
```