### PR TITLE
PBM-1710 PBM add SBOM into packaging

### DIFF
--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -13,3 +13,4 @@ completions/zsh/_pbm-agent /usr/share/zsh/vendor-completions/
 completions/zsh/_pbm /usr/share/zsh/vendor-completions/
 completions/zsh/_pbm-speed-test /usr/share/zsh/vendor-completions/
 LICENSE /usr/share/doc/percona-backup-mongodb/
+percona-backup-mongodb-*.cdx.json /usr/share/doc/percona-backup-mongodb/

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -75,6 +75,18 @@ override_dh_auto_install:
 	cp -f packaging/conf/pbm-agent.service $(TMP)/pbm-agent.service
 	cp -f packaging/conf/pbm-conf-reference.yml $(TMP)/pbm-conf-reference.yml
 	cp -f LICENSE $(TMP)/LICENSE
+	# CycloneDX 1.6 SBOM for the .deb. Scope = Go binaries in $(TMP); filename
+	# is self-identifying when extracted from /usr/share/doc/. Catalogers
+	# limited to go-module-binary-cataloger (tarball-equivalent scope); file
+	# catalogers disabled to keep package-level granularity.
+	syft scan "dir:$(TMP)" \
+		--override-default-catalogers go-module-binary-cataloger \
+		--select-catalogers "-file" \
+		--source-name "percona-backup-mongodb" \
+		--source-version "$(VERSION)" \
+		-o "cyclonedx-json@1.6=$(TMP)/percona-backup-mongodb-$(VERSION).cdx.json"
+	test "$$(jq '.components | length' $(TMP)/percona-backup-mongodb-$(VERSION).cdx.json)" -ge 10 \
+		|| { echo "ERROR: DEB SBOM has too few components" >&2; exit 1; }
 	ls -la $(TMP)
 
 override_dh_systemd_start:

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -85,6 +85,11 @@ override_dh_auto_install:
 		--source-name "percona-backup-mongodb" \
 		--source-version "$(VERSION)" \
 		-o "cyclonedx-json@1.6=$(TMP)/percona-backup-mongodb-$(VERSION).cdx.json"
+	# Overwrite syft's auto-generated metadata.component (type=file, opaque
+	# bom-ref) with a proper application identity including a deb PURL.
+	jq --arg purl "pkg:deb/percona-backup-mongodb@$(VERSION)" --arg ver "$(VERSION)" '.metadata.component = {"bom-ref": $purl, "type": "application", "name": "percona-backup-mongodb", "version": $ver, "purl": $purl}' \
+		$(TMP)/percona-backup-mongodb-$(VERSION).cdx.json > $(TMP)/sbom.tmp \
+		&& mv $(TMP)/sbom.tmp $(TMP)/percona-backup-mongodb-$(VERSION).cdx.json
 	test "$$(jq '.components | length' $(TMP)/percona-backup-mongodb-$(VERSION).cdx.json)" -ge 10 \
 		|| { echo "ERROR: DEB SBOM has too few components" >&2; exit 1; }
 	ls -la $(TMP)

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -87,7 +87,7 @@ override_dh_auto_install:
 		-o "cyclonedx-json@1.6=$(TMP)/percona-backup-mongodb-$(VERSION).cdx.json"
 	# Overwrite syft's auto-generated metadata.component (type=file, opaque
 	# bom-ref) with a proper application identity including a deb PURL.
-	jq --arg purl "pkg:deb/percona-backup-mongodb@$(VERSION)" --arg ver "$(VERSION)" '.metadata.component = {"bom-ref": $purl, "type": "application", "name": "percona-backup-mongodb", "version": $ver, "purl": $purl}' \
+	jq --arg purl "pkg:deb/percona-backup-mongodb@$(VERSION)" --arg ver "$(VERSION)" '.metadata.component = {"bom-ref": $$purl, "type": "application", "name": "percona-backup-mongodb", "version": $$ver, "purl": $$purl}' \
 		$(TMP)/percona-backup-mongodb-$(VERSION).cdx.json > $(TMP)/sbom.tmp \
 		&& mv $(TMP)/sbom.tmp $(TMP)/percona-backup-mongodb-$(VERSION).cdx.json
 	test "$$(jq '.components | length' $(TMP)/percona-backup-mongodb-$(VERSION).cdx.json)" -ge 10 \

--- a/packaging/pbm_sbom/pbm_generate_sbom.sh
+++ b/packaging/pbm_sbom/pbm_generate_sbom.sh
@@ -1,162 +1,280 @@
 #!/bin/bash
+#
+# Generate a CycloneDX 1.6 "operations SBOM" for an environment that has
+# Percona Backup for MongoDB installed from a Percona repository.
+#
+# What this script does:
+#   1. Installs PBM from the requested Percona repo channel (laboratory /
+#      testing / experimental / release) inside the current environment
+#      (typically a fresh build container).
+#   2. Runs Syft against the resulting filesystem with a focused set of
+#      catalogers:
+#        * dpkg-db-cataloger          - Debian/Ubuntu installed packages
+#        * rpm-db-cataloger           - RHEL/Oracle/Amazon Linux installed packages
+#        * go-module-binary-cataloger - Go modules embedded in pbm/pbm-agent
+#   3. Writes a CycloneDX 1.6 JSON SBOM and validates it against the schema.
+#
+# This is an OPERATIONS SBOM (CycloneDX lifecycle phase = "operations"):
+# it describes the state of the container/system AFTER PBM has been
+# installed. It is meant to be published as a supplementary artifact next
+# to the packages in the Percona downloads area.
+#
+# This script is NOT used to produce:
+#   * The SBOM inside .deb / .rpm packages
+#     (/usr/share/doc/percona-backup-mongodb/sbom.cdx.json) - that is
+#     generated inline from debian/rules and the RPM spec %install
+#     section using syft directly against the binary in the staging dir.
+#   * The canonical SBOM in the repository root - produced by a dedicated
+#     GitHub Actions workflow.
+#   * The Docker image SBOM - produced by scanning the built image with
+#     syft and attaching it via oras as an OCI 1.1 referrer artifact in
+#     the percona-docker build pipeline.
+#
+
 set -euo pipefail
 
-shell_quote_string() {
-    echo "$1" | sed -e 's,\([^a-zA-Z0-9/_.=-]\),\\\1,g'
-}
+# cyclonedx-cli is a .NET application that by default requires libicu for
+# globalization support. We don't need any locale-sensitive behaviour for
+# JSON parsing / schema validation, so run it in invariant mode to avoid
+# pulling libicu into the build container.
+# See: https://aka.ms/dotnet-missing-libicu
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
-usage () {
+CYCLONEDX_CLI_VERSION="v0.27.2"
+SYFT_INSTALL_URL="https://raw.githubusercontent.com/anchore/syft/main/install.sh"
+
+# --- Defaults / required parameters --------------------------------------
+WORKDIR="$(pwd -P)"
+PBM_VERSION=""
+REPO_TYPE=""
+GIT_REPO=""
+GIT_BRANCH=""
+OUTPUT=""
+SKIP_INSTALL="0"
+
+usage() {
     cat <<EOF
-Usage: $0 [OPTIONS]
-    The following options may be given :
-        --pbm_version        PostgreSQL major_version.minor_version
-        --repo_type         Repository type
-        --help) usage ;;
-Example $0 --pbm_version=7.0.18-11 --repo_type=testing
+Usage: $0 --pbm_version=VERSION [OPTIONS]
+
+Generate a CycloneDX 1.6 SBOM for the Percona Backup for MongoDB package
+installed in the current environment.
+
+Required:
+  --pbm_version=VERSION     Product version (e.g. 2.14.0). No default.
+
+Legacy CLI compatibility (used by Jenkins job hetzner-pbm_generate_sbom):
+  --builddir=DIR            Working directory (default: current dir)
+  --repo_type=TYPE          Percona repository to enable:
+                            laboratory | testing | experimental | release
+  --git_repo=URL            Informational only (kept for compatibility)
+  --git_branch=NAME         Informational only (kept for compatibility)
+
+Optional:
+  --output=PATH             Override output SBOM file path.
+                            Default: <builddir>/pbm_sbom/sbom-percona-backup-mongodb-<version>-<platform>-<arch>.cdx.json
+  --skip-install            Do not install PBM; assume it is already
+                            installed in the current environment.
+  --help                    Show this help and exit.
+
+Example:
+  $0 --pbm_version=2.14.0 --repo_type=testing
 EOF
-        exit 1
+    exit 1
 }
 
-append_arg_to_args () {
-    args="$args "$(shell_quote_string "$1")
-}
-
-parse_arguments() {
-    pick_args=
-    if test "$1" = PICK-ARGS-FROM-ARGV
-    then
-        pick_args=1
-        shift
-    fi
-
-    for arg do
-        val=$(echo "$arg" | sed -e 's;^--[^=]*=;;')
-        case "$arg" in
-            --builddir=*) WORKDIR="$val" ;;
-            --pbm_version=*) PBM_VERSION="$val" ;;
-            --repo_type=*) REPO_TYPE="$val" ;;
-            --git_repo=*) GIT_REPO="$val" ;;
-            --git_branch=*) GIT_BRANCH="$val" ;;
-            --help) usage ;;
-            *)
-                if test -n "$pick_args"
-                then
-                    append_arg_to_args "$arg"
-                fi
+# --- Argument parsing ----------------------------------------------------
+for arg in "$@"; do
+    val="${arg#*=}"
+    case "$arg" in
+        --builddir=*)     WORKDIR="$val" ;;
+        --pbm_version=*)  PBM_VERSION="$val" ;;
+        --repo_type=*)    REPO_TYPE="$val" ;;
+        --git_repo=*)     GIT_REPO="$val" ;;
+        --git_branch=*)   GIT_BRANCH="$val" ;;
+        --output=*)       OUTPUT="$val" ;;
+        --skip-install)   SKIP_INSTALL="1" ;;
+        --help|-h)        usage ;;
+        *)
+            echo "ERROR: unknown argument: $arg" >&2
+            usage
             ;;
-        esac
-    done
-}
+    esac
+done
 
-CWD=$(pwd)
-PBM_VERSION=2.10.0
-REPO_TYPE=testing
-ARCH=$(uname -m)
+if [[ -z "$PBM_VERSION" ]]; then
+    echo "ERROR: --pbm_version is required (no default fallback)." >&2
+    usage
+fi
 
-parse_arguments PICK-ARGS-FROM-ARGV "$@"
+if [[ "$SKIP_INSTALL" = "0" && -z "$REPO_TYPE" ]]; then
+    echo "ERROR: --repo_type is required unless --skip-install is given." >&2
+    usage
+fi
 
-# Set non-interactive tzdata environment variables to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
-# Platform detection
-if [ -f /etc/os-release ]; then
-  . /etc/os-release
-  PLATFORM_ID=$(echo "$ID" | tr '[:upper:]' '[:lower:]')
-  VERSION_ID=$(echo "$VERSION_ID" | tr -d '"')
-else
-  echo "Unable to detect OS."
-  exit 1
+# --- Platform detection --------------------------------------------------
+if [[ ! -f /etc/os-release ]]; then
+    echo "ERROR: cannot detect OS (no /etc/os-release)." >&2
+    exit 1
 fi
+# shellcheck disable=SC1091
+. /etc/os-release
+PLATFORM_ID="$(echo "${ID:-}"            | tr '[:upper:]' '[:lower:]')"
+VERSION_ID="$(echo  "${VERSION_ID:-}"    | tr -d '"')"
+CODENAME="$(echo    "${VERSION_CODENAME:-}" | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
 
-# Function to install dependencies
-install_dependencies() {
-  case "$PLATFORM_ID" in
-    ol|centos|rhel|rocky|almalinux)
-      # RHEL/CentOS/OracleLinux (RHEL 8/9)
-      RHEL=$(rpm --eval %rhel)
-      PLATFORM=${PLATFORM_ID}${RHEL}
-      dnf install -y jq
-      dnf config-manager --set-enabled ol${RHEL}_codeready_builder || true
-      dnf install -y 'dnf-command(config-manager)'
-      ;;
+case "$PLATFORM_ID" in
+    ol|rhel|centos|rocky|almalinux|oraclelinux)
+        RHEL_MAJOR="$(rpm --eval %rhel)"
+        PLATFORM="${PLATFORM_ID}${RHEL_MAJOR}"
+        ;;
     amzn)
-      RHEL=$(rpm --eval %amzn)
-      PLATFORM=${PLATFORM_ID}${RHEL}
-      dnf install -y jq tar
-      dnf install -y 'dnf-command(config-manager)'
-      ;;
+        AMZN_MAJOR="$(rpm --eval %amzn)"
+        PLATFORM="${PLATFORM_ID}${AMZN_MAJOR}"
+        ;;
     ubuntu|debian)
-      # Install dependencies for Ubuntu/Debian
-      PLATFORM=$(echo "$VERSION_CODENAME" | tr '[:upper:]' '[:lower:]')
-      apt update
-      apt install -y curl gnupg jq lsb-release
-      apt --fix-broken install -y  # Fix broken dependencies
-      ;;
+        if [[ -z "$CODENAME" ]]; then
+            echo "ERROR: VERSION_CODENAME missing in /etc/os-release on ${PLATFORM_ID}." >&2
+            exit 1
+        fi
+        PLATFORM="$CODENAME"
+        ;;
     *)
-      echo "Unsupported platform: $PLATFORM_ID"
-      exit 1
-      ;;
-  esac
+        echo "ERROR: unsupported platform: $PLATFORM_ID" >&2
+        exit 1
+        ;;
+esac
+
+# --- Toolchain installation ---------------------------------------------
+install_dependencies() {
+    case "$PLATFORM_ID" in
+        ol|rhel|centos|rocky|almalinux|oraclelinux)
+            dnf install -y jq tar curl
+            dnf install -y 'dnf-command(config-manager)' || true
+            dnf config-manager --set-enabled "ol${RHEL_MAJOR}_codeready_builder" || true
+            ;;
+        amzn)
+            dnf install -y jq tar curl
+            dnf install -y 'dnf-command(config-manager)' || true
+            ;;
+        ubuntu|debian)
+            apt-get update
+            apt-get install -y --no-install-recommends curl gnupg jq lsb-release ca-certificates
+            apt-get --fix-broken install -y || true
+            ;;
+    esac
 }
 
-# Install required dependencies
-install_dependencies
-
-# Install Percona repo and PostgreSQL
 install_percona_backup_mongodb() {
-  case "$PLATFORM_ID" in
-    ol|rhel|centos|oraclelinux|amzn)
-      # Install Percona repo on RHEL/CentOS/OracleLinux
-      curl -sO https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-      dnf install -y percona-release-latest.noarch.rpm
-      percona-release enable pbm ${REPO_TYPE}
-      dnf install -y \
-	percona-backup-mongodb
-      ;;
-    ubuntu|debian)
-      # Install Percona repo on Ubuntu/Debian
-      curl -sO https://repo.percona.com/apt/percona-release_latest.generic_all.deb
-      dpkg -i percona-release_latest.generic_all.deb
-      apt --fix-broken install -y  # Fix broken dependencies
-      apt update
-
-      # Explicitly enable the pbm repository
-      percona-release enable telemetry
-      percona-release enable pbm ${REPO_TYPE}
-      apt-get update
-      apt-get install -y \
-	percona-backup-mongodb
-      ;;
-    *)
-      echo "Unsupported platform: $PLATFORM_ID"
-      exit 1
-      ;;
-  esac
+    case "$PLATFORM_ID" in
+        ol|rhel|centos|rocky|almalinux|oraclelinux|amzn)
+            curl -fsSL -O https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+            dnf install -y ./percona-release-latest.noarch.rpm
+            percona-release enable pbm "$REPO_TYPE"
+            dnf install -y percona-backup-mongodb
+            ;;
+        ubuntu|debian)
+            curl -fsSL -O https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+            dpkg -i percona-release_latest.generic_all.deb || apt-get --fix-broken install -y
+            apt-get update
+            percona-release enable telemetry || true
+            percona-release enable pbm "$REPO_TYPE"
+            apt-get update
+            apt-get install -y percona-backup-mongodb
+            ;;
+    esac
 }
 
-# Install Percona repository and PostgreSQL
-install_percona_backup_mongodb
+install_syft() {
+    if ! command -v syft >/dev/null 2>&1; then
+        curl -fsSL "$SYFT_INSTALL_URL" | sh -s -- -b /usr/local/bin
+    fi
+    syft version
+}
 
-# Install Syft (if not already installed)
-if ! command -v syft &>/dev/null; then
-  curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+install_cyclonedx_cli() {
+    if command -v cyclonedx >/dev/null 2>&1; then
+        cyclonedx --version
+        return
+    fi
+    local asset
+    case "$ARCH" in
+        x86_64|amd64)   asset="cyclonedx-linux-x64"   ;;
+        aarch64|arm64)  asset="cyclonedx-linux-arm64" ;;
+        *)
+            echo "ERROR: unsupported arch for cyclonedx-cli: $ARCH" >&2
+            exit 1
+            ;;
+    esac
+    curl -fsSL -o /usr/local/bin/cyclonedx \
+        "https://github.com/CycloneDX/cyclonedx-cli/releases/download/${CYCLONEDX_CLI_VERSION}/${asset}"
+    chmod +x /usr/local/bin/cyclonedx
+    cyclonedx --version
+}
+
+install_dependencies
+if [[ "$SKIP_INSTALL" = "0" ]]; then
+    install_percona_backup_mongodb
+fi
+install_syft
+install_cyclonedx_cli
+
+# --- SBOM generation -----------------------------------------------------
+SBOM_DIR="${WORKDIR}/pbm_sbom"
+mkdir -p "$SBOM_DIR"
+
+if [[ -z "$OUTPUT" ]]; then
+    OUTPUT="${SBOM_DIR}/sbom-percona-backup-mongodb-${PBM_VERSION}-${PLATFORM}-${ARCH}.cdx.json"
 fi
 
-mkdir -p $CWD/pbm_sbom
+# Catalogers we want and ONLY them:
+#  * dpkg-db-cataloger      - Debian/Ubuntu installed packages
+#  * rpm-db-cataloger       - RHEL/Oracle/Amazon Linux installed packages
+#  * go-module-binary-cataloger - Go modules embedded in pbm / pbm-agent
+#
+# We also explicitly disable the "file" cataloger group via --select-catalogers.
+# Syft, by default, auto-adds executable/file-metadata/file-digest catalogers
+# as a sidecar to package catalogers - which results in ~10x SBOM bloat with
+# per-file hashes and metadata. Those are not consumed by Trivy, Grype, or any
+# typical security workflow, so we stay at package granularity here.
+# (See Syft WARN: "adding 'file' tag to the default cataloger selection,
+#  to override add '-file' to the cataloger selection request".)
+CATALOGERS="dpkg-db-cataloger,rpm-db-cataloger,go-module-binary-cataloger"
 
-# Generate full SBOM using db fallback
-echo "Generating full SBOM via db..."
-syft dir:/ --output cyclonedx-json > sbom-full-db.json
+echo "Generating CycloneDX 1.6 SBOM ..."
+echo "  product:     percona-backup-mongodb ${PBM_VERSION}"
+echo "  platform:    ${PLATFORM} (${ARCH})"
+echo "  catalogers:  ${CATALOGERS} (with -file)"
+echo "  output:      ${OUTPUT}"
 
-# Filter PBM components and preserve SBOM structure
-jq '{
-  "$schema": ."$schema",
-  "bomFormat": .bomFormat,
-  "specVersion": .specVersion,
-  "serialNumber": .serialNumber,
-  "version": .version,
-  "metadata": .metadata,
-  "components": [.components[] | select(.name | test("mongodb|percona"; "i"))]
-}' sbom-full-db.json > $CWD/pbm_sbom/sbom-percona-backup-mongodb-${PBM_VERSION}-${PLATFORM}-${ARCH}.json
+syft scan "dir:/" \
+    --override-default-catalogers "$CATALOGERS" \
+    --select-catalogers "-file" \
+    --source-name "percona-backup-mongodb" \
+    --source-version "$PBM_VERSION" \
+    --output "cyclonedx-json@1.6=${OUTPUT}"
 
-echo "✅ SBOM for Percona Backup for MongoDB ${PBM_VERSION} written to: $CWD/pbm_sbom/sbom-percona-backup-mongodb-${PBM_VERSION}-${PLATFORM}-${ARCH}.json"
+# --- Validation ----------------------------------------------------------
+echo "Validating SBOM against CycloneDX 1.6 schema ..."
+cyclonedx validate \
+    --input-file "$OUTPUT" \
+    --input-version v1_6 \
+    --input-format json \
+    --fail-on-errors
+
+# --- Summary -------------------------------------------------------------
+TOTAL_COMPONENTS="$(jq '.components | length' "$OUTPUT")"
+echo ""
+echo "SBOM written: ${OUTPUT}"
+echo "  spec:        $(jq -r '.specVersion' "$OUTPUT")"
+echo "  serial:      $(jq -r '.serialNumber' "$OUTPUT")"
+echo "  components:  ${TOTAL_COMPONENTS}"
+echo ""
+
+if [[ "$TOTAL_COMPONENTS" -lt 10 ]]; then
+    echo "WARNING: SBOM contains only ${TOTAL_COMPONENTS} components - this is" >&2
+    echo "         suspicious. Expected at least OS packages + several Go modules." >&2
+    echo "         Verify cataloger configuration and PBM installation." >&2
+fi

--- a/packaging/rpm/mongodb-backup.spec
+++ b/packaging/rpm/mongodb-backup.spec
@@ -100,13 +100,24 @@ install -D -m 0640 github.com/percona/percona-backup-mongodb/packaging/conf/pbm-
 # to go-module-binary-cataloger (tarball-equivalent scope); file catalogers
 # disabled to keep package-level granularity.
 install -m 0755 -d $RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb
+SBOM_PATH=$RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json
 syft scan "dir:$RPM_BUILD_ROOT/%{_bindir}" \
     --override-default-catalogers go-module-binary-cataloger \
     --select-catalogers "-file" \
     --source-name "percona-backup-mongodb" \
     --source-version "%{version}" \
-    -o "cyclonedx-json@1.6=$RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json"
-test "$(jq '.components | length' $RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json)" -ge 10 \
+    -o "cyclonedx-json@1.6=$SBOM_PATH"
+# Overwrite syft's auto-generated metadata.component (type=file, opaque
+# bom-ref) with a proper application identity including an rpm PURL.
+SBOM_PURL="pkg:rpm/percona-backup-mongodb@%{version}"
+jq --arg purl "$SBOM_PURL" --arg ver "%{version}" '.metadata.component = {
+    "bom-ref": $purl,
+    "type": "application",
+    "name": "percona-backup-mongodb",
+    "version": $ver,
+    "purl": $purl
+}' "$SBOM_PATH" > "$SBOM_PATH.tmp" && mv "$SBOM_PATH.tmp" "$SBOM_PATH"
+test "$(jq '.components | length' $SBOM_PATH)" -ge 10 \
     || { echo "ERROR: RPM SBOM has too few components" >&2; exit 1; }
 
 

--- a/packaging/rpm/mongodb-backup.spec
+++ b/packaging/rpm/mongodb-backup.spec
@@ -95,6 +95,20 @@ install -D -m 0640 github.com/percona/percona-backup-mongodb/packaging/conf/pbm-
   install -m 0750 github.com/percona/percona-backup-mongodb/packaging/rpm/pbm-agent.init $RPM_BUILD_ROOT/etc/rc.d/init.d/pbm-agent
 %endif
 
+# CycloneDX 1.6 SBOM for the .rpm. Scope = Go binaries in %{_bindir}; filename
+# is self-identifying when extracted from /usr/share/doc/. Catalogers limited
+# to go-module-binary-cataloger (tarball-equivalent scope); file catalogers
+# disabled to keep package-level granularity.
+install -m 0755 -d $RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb
+syft scan "dir:$RPM_BUILD_ROOT/%{_bindir}" \
+    --override-default-catalogers go-module-binary-cataloger \
+    --select-catalogers "-file" \
+    --source-name "percona-backup-mongodb" \
+    --source-version "%{version}" \
+    -o "cyclonedx-json@1.6=$RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json"
+test "$(jq '.components | length' $RPM_BUILD_ROOT/%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json)" -ge 10 \
+    || { echo "ERROR: RPM SBOM has too few components" >&2; exit 1; }
+
 
 %pre -n percona-backup-mongodb
 /usr/bin/getent group mongod || /usr/sbin/groupadd -r mongod
@@ -157,6 +171,8 @@ esac
 %{_bindir}/pbm
 %{_bindir}/pbm-speed-test
 %{_bindir}/pbm-agent-entrypoint
+%dir %{_docdir}/percona-backup-mongodb
+%{_docdir}/percona-backup-mongodb/percona-backup-mongodb-%{version}.cdx.json
 %{_datadir}/bash-completion/completions/pbm-agent
 %{_datadir}/bash-completion/completions/pbm
 %{_datadir}/bash-completion/completions/pbm-speed-test

--- a/packaging/scripts/mongodb-backup_builder.sh
+++ b/packaging/scripts/mongodb-backup_builder.sh
@@ -161,6 +161,26 @@ install_golang() {
     ln -s /usr/local/go${GO_VERSION} /usr/local/go
 }
 
+install_sbom_tools() {
+    # Install Syft (SBOM generator) and Grype (vulnerability scanner) on the
+    # build host.
+    #
+    # Use the official Anchore installer scripts because they auto-detect the
+    # host architecture (x86_64 -> amd64, aarch64 -> arm64) and OS.
+    # No pinned version yet.
+    for tool in syft grype; do
+        url="https://raw.githubusercontent.com/anchore/${tool}/main/install.sh"
+        for i in {1..3}; do
+            curl -fsSL "$url" | sh -s -- -b /usr/local/bin && break
+            sleep 10
+        done
+        command -v "$tool" >/dev/null \
+            || { echo "ERROR: ${tool} not installed after 3 attempts" >&2; exit 1; }
+    done
+    syft version
+    grype version
+}
+
 install_deps() {
     if [ $INSTALL = 0 ]; then
         echo "Dependencies will not be installed"
@@ -177,9 +197,9 @@ install_deps() {
         if [ "x$RHEL" = "x10" ]; then
             yum -y install oracle-epel-release-el10
         fi
-        INSTALL_LIST="epel-release git wget"
+        INSTALL_LIST="epel-release git wget jq"
         if [ "x$RHEL" = "x2023" -o "x$RHEL" = "x10" ]; then
-            INSTALL_LIST="git wget"
+            INSTALL_LIST="git wget jq"
         fi
         yum -y install ${INSTALL_LIST}
         yum -y install rpm-build make rpmlint rpmdevtools golang krb5-devel
@@ -192,13 +212,14 @@ install_deps() {
         DEBIAN_FRONTEND=noninteractive apt-get -y install lsb_release
         export DEBIAN=$(lsb_release -sc)
         export ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
-        INSTALL_LIST="wget devscripts debhelper debconf pkg-config curl make golang git libkrb5-dev"
+        INSTALL_LIST="wget devscripts debhelper debconf pkg-config curl make golang git libkrb5-dev jq"
         until DEBIAN_FRONTEND=noninteractive apt-get -y install ${INSTALL_LIST}; do
             sleep 1
             echo "waiting"
         done
         install_golang
     fi
+    install_sbom_tools
     return
 }
 
@@ -455,6 +476,30 @@ build_tarball() {
     cp ./bin/pbm-agent ${WORKDIR}/${PSMDIR}/
     cp ./bin/pbm-speed-test ${WORKDIR}/${PSMDIR}/
     cp ./bin/pbm-agent-entrypoint ${WORKDIR}/${PSMDIR}/
+
+    # Place SBOM at the root of the tarball staging dir so it will be packed
+    # in the archive root.
+    # Scope = ./bin only (the 4 Go binaries that go into the tarball).
+    # Catalogers limited to go-module-binary-cataloger because a tarball is
+    # OS-agnostic; the "file" cataloger group is disabled to keep package
+    # granularity (no per-file hashes/metadata).
+    # The jq count below guards against silent syft failures.
+    SBOM_FILE="${WORKDIR}/${PSMDIR}/${PRODUCT}-${VERSION}.cdx.json"
+    echo "Generating CycloneDX 1.6 SBOM for binary tarball..."
+    syft scan "dir:./bin" \
+        --override-default-catalogers go-module-binary-cataloger \
+        --select-catalogers "-file" \
+        --source-name "percona-backup-mongodb" \
+        --source-version "${VERSION}" \
+        -o "cyclonedx-json@1.6=${SBOM_FILE}" \
+        || { echo "ERROR: syft scan failed for binary tarball" >&2; exit 1; }
+    COMPONENT_COUNT=$(jq '.components | length' "${SBOM_FILE}")
+    if [ "$COMPONENT_COUNT" -lt 10 ]; then
+        echo "ERROR: tarball SBOM has only ${COMPONENT_COUNT} components" >&2
+        exit 1
+    fi
+    echo "Tarball SBOM: ${SBOM_FILE} (${COMPONENT_COUNT} components)"
+
     cd ${WORKDIR}/
 
     tar --owner=0 --group=0 -czf ${WORKDIR}/${PSMDIR}-${ARCH}.tar.gz ${PSMDIR}

--- a/packaging/scripts/mongodb-backup_builder.sh
+++ b/packaging/scripts/mongodb-backup_builder.sh
@@ -493,6 +493,17 @@ build_tarball() {
         --source-version "${VERSION}" \
         -o "cyclonedx-json@1.6=${SBOM_FILE}" \
         || { echo "ERROR: syft scan failed for binary tarball" >&2; exit 1; }
+    # Overwrite syft's auto-generated metadata.component (type=file, opaque
+    # bom-ref) with a proper application identity including a PURL. Tarball is
+    # OS-agnostic, so PURL type is "generic".
+    SBOM_PURL="pkg:generic/percona-backup-mongodb@${VERSION}"
+    jq --arg purl "${SBOM_PURL}" --arg ver "${VERSION}" '.metadata.component = {
+        "bom-ref": $purl,
+        "type": "application",
+        "name": "percona-backup-mongodb",
+        "version": $ver,
+        "purl": $purl
+    }' "${SBOM_FILE}" > "${SBOM_FILE}.tmp" && mv "${SBOM_FILE}.tmp" "${SBOM_FILE}"
     COMPONENT_COUNT=$(jq '.components | length' "${SBOM_FILE}")
     if [ "$COMPONENT_COUNT" -lt 10 ]; then
         echo "ERROR: tarball SBOM has only ${COMPONENT_COUNT} components" >&2


### PR DESCRIPTION
- Install Syft and Grype.
- Generate a CycloneDX 1.6 SBOM for the binary tarball
  Scope is limited to the 4 built PBM Go binaries in ./bin folder.
  using the go-module-binary cataloger; file catalogers are disabled to
  keep package-level granularity. SBOM is placed at the tarball as
  <product>-<version>.cdx.json file.
- Inline syft in debian/rules and rpm spec to produce a CycloneDX 1.6 SBOM
for the package's Go binaries. SBOM is placed at
/usr/share/doc/percona-backup-mongodb/<product>-<version>.cdx.json.
- Patch syft output via jq so metadata.component is a proper application
identity (type=application, human-readable bom-ref, purl) instead of
syft's default type=file with an opaque hash bom-ref. PURL type matches
the artifact: pkg:generic for tarball, pkg:deb for DEB, pkg:rpm for RPM.