### PR TITLE
PBM-1715: Multi-files parallel upload and download during physical backup/restore with FS/NFS

### DIFF
--- a/cmd/pbm-agent/backup.go
+++ b/cmd/pbm-agent/backup.go
@@ -128,6 +128,9 @@ func (a *Agent) Backup(ctx context.Context, cmd *ctrl.BackupCmd, opid ctrl.OPID,
 	bcp.SetMongoVersion(a.brief.Version.VersionString)
 	bcp.SetSlicerInterval(cfg.BackupSlicerInterval())
 	bcp.SetTimeouts(cfg.Backup.Timeouts)
+	if cmd.NumParallelFiles != nil {
+		bcp.SetNumParallelFiles(int(*cmd.NumParallelFiles))
+	}
 
 	if isClusterLeader {
 		balancer := topo.BalancerModeOff

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -41,6 +41,7 @@ type backupOpts struct {
 	usersAndRoles    bool
 
 	numParallelColls int32
+	numParallelFiles int32
 }
 
 type backupOut struct {
@@ -98,9 +99,13 @@ func runBackup(
 	b *backupOpts,
 	outf outFormat,
 ) (fmt.Stringer, error) {
-	numParallelColls, err := parseCLINumParallelCollsOption(b.numParallelColls)
+	numParallelColls, err := parseCLINumParallelOption(b.numParallelColls)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse --num-parallel-collections option")
+	}
+	numParallelFiles, err := parseCLINumParallelOption(b.numParallelFiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse --num-parallel-files option")
 	}
 	nss, err := parseCLINSOption(b.ns)
 	if err != nil {
@@ -153,6 +158,7 @@ func runBackup(
 			Compression:      compression,
 			CompressionLevel: level,
 			NumParallelColls: numParallelColls,
+			NumParallelFiles: numParallelFiles,
 			Filelist:         b.externList,
 			Profile:          b.profile.Value(),
 		},
@@ -784,7 +790,7 @@ func (e incompatibleMongodVersionError) Unwrap() error {
 	return errIncompatible
 }
 
-func parseCLINumParallelCollsOption(value int32) (*int32, error) {
+func parseCLINumParallelOption(value int32) (*int32, error) {
 	if value < 0 {
 		return nil, errors.New("value cannot be negative")
 	}

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -292,6 +292,10 @@ func (app *pbmApp) buildBackupCmd() *cobra.Command {
 	backupCmd.Flags().Int32Var(
 		&backupOptions.numParallelColls, "num-parallel-collections", 0, "Number of parallel collections",
 	)
+	backupCmd.Flags().Int32Var(
+		&backupOptions.numParallelFiles, "num-parallel-files", 0,
+		"Number of files to upload in parallel (physical backup, filesystem storage only)",
+	)
 	backupCmd.Flags().StringVar(
 		&backupOptions.ns, "ns", "", `Namespaces to backup (e.g. "db.*", "db.collection"). If not set, backup all ("*.*")`,
 	)

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -833,6 +833,10 @@ func (app *pbmApp) buildRestoreCmd() *cobra.Command {
 		"Number of parallel collections",
 	)
 	restoreCmd.Flags().Int32Var(
+		&restoreOptions.numParallelFiles, "num-parallel-files", 0,
+		"Number of files to copy in parallel (physical restore, filesystem storage only)",
+	)
+	restoreCmd.Flags().Int32Var(
 		&restoreOptions.numInsertionWorkers, "num-insertion-workers-per-collection", 0,
 		"Specifies the number of insertion workers to run concurrently per collection. For large imports, "+
 			"increasing the number of insertion workers may increase the speed of the import.",

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -57,6 +57,7 @@ type restoreOpts struct {
 	allowPartlyDone *bool
 
 	numParallelColls    int32
+	numParallelFiles    int32
 	numInsertionWorkers int32
 	indexCommitQuorum   string
 }
@@ -125,9 +126,13 @@ func runRestore(
 	node string,
 	outf outFormat,
 ) (fmt.Stringer, error) {
-	numParallelColls, err := parseCLINumParallelCollsOption(o.numParallelColls)
+	numParallelColls, err := parseCLINumParallelOption(o.numParallelColls)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse --num-parallel-collections option")
+	}
+	numParallelFiles, err := parseCLINumParallelOption(o.numParallelFiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse --num-parallel-files option")
 	}
 	numInsertionWorkers, err := parseCLINumInsertionWorkersOption(o.numInsertionWorkers)
 	if err != nil {
@@ -189,6 +194,7 @@ func runRestore(
 		conn,
 		o,
 		numParallelColls,
+		numParallelFiles,
 		numInsertionWorkers,
 		indexCommitQuorum,
 		nss,
@@ -459,6 +465,7 @@ func doRestore(
 	conn connect.Client,
 	o *restoreOpts,
 	numParallelColls *int32,
+	numParallelFiles *int32,
 	numInsertionWorkers *int32,
 	indexCommitQuorum config.IndexCommitQuorum,
 	nss []string,
@@ -486,6 +493,7 @@ func doRestore(
 			Name:                name,
 			BackupName:          bcp,
 			NumParallelColls:    numParallelColls,
+			NumParallelFiles:    numParallelFiles,
 			NumInsertionWorkers: numInsertionWorkers,
 			IndexCommitQuorum:   indexCommitQuorum,
 			Namespaces:          nss,

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -33,6 +33,7 @@ type Backup struct {
 	incrBase            bool
 	timeouts            *config.BackupTimeouts
 	numParallelColls    int
+	numParallelFiles    int
 	oplogSlicerInterval time.Duration
 }
 
@@ -86,6 +87,10 @@ func (b *Backup) SetTimeouts(t *config.BackupTimeouts) {
 	b.timeouts = t
 }
 
+func (b *Backup) SetNumParallelFiles(n int) {
+	b.numParallelFiles = n
+}
+
 func (b *Backup) SetSlicerInterval(d time.Duration) {
 	b.oplogSlicerInterval = d
 }
@@ -98,12 +103,15 @@ func (b *Backup) SlicerInterval() time.Duration {
 	return b.oplogSlicerInterval
 }
 
-// numParallelFiles is the number of files to upload concurrently during
+// getNumParallelFiles is the number of files to upload concurrently during
 // physical backup. Defaults to 1 (sequential) when unset in the config.
-func (b *Backup) numParallelFiles() int {
+func (b *Backup) getNumParallelFiles() int {
 	if b.config != nil && b.config.Storage.Type != storage.Filesystem {
 		// there's not paralelizm for cloud storage on this level
 		return 1
+	}
+	if b.numParallelFiles > 0 {
+		return b.numParallelFiles
 	}
 	return b.config.Backup.GetNumParallelFiles()
 }

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -98,6 +98,16 @@ func (b *Backup) SlicerInterval() time.Duration {
 	return b.oplogSlicerInterval
 }
 
+// numParallelFiles is the number of files to upload concurrently during
+// physical backup. Defaults to 1 (sequential) when unset in the config.
+func (b *Backup) numParallelFiles() int {
+	if b.config != nil && b.config.Storage.Type != storage.Filesystem {
+		// there's not paralelizm for cloud storage on this level
+		return 1
+	}
+	return b.config.Backup.GetNumParallelFiles()
+}
+
 func (b *Backup) Init(
 	ctx context.Context,
 	bcp *ctrl.BackupCmd,

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -658,12 +658,61 @@ func trimFilePrefix(fname, trimPrefix string) string {
 	return path.Clean("./" + strings.TrimPrefix(fname, trimPrefix))
 }
 
-// Uploads given files to the storage. files may come as 16Mb (by default)
-// blocks in that case it will concat consecutive blocks in one bigger file.
+// upItem is one entry of an upload.
+// It contains the file name and and info about whether it's necessary to upload it.
+type upItem struct {
+	file   File
+	upload bool
+}
+
+// planUploads walks files in order and produces the upload plan. files may
+// come as 16Mb (by default) blocks; in that case consecutive blocks of the
+// same file are coalesced into one bigger upload.
 // For example: f1[0-16], f1[16-24], f1[64-16] becomes f1[0-24], f1[50-16].
-// If this is an incremental, NOT base backup, it will skip uploading of
-// unchanged files (Len == 0) but add them to the meta as we need know
-// what files shouldn't be restored (those which isn't in the target backup).
+// If this is an incremental, NOT base backup, unchanged files (Len == 0) are
+// not uploaded but still recorded in the meta as we need to know what files
+// shouldn't be restored (those which aren't in the target backup).
+func planUploads(files []File, incr bool) []upItem {
+	if len(files) == 0 {
+		return nil
+	}
+
+	upItems := make([]upItem, 0, len(files))
+	wfile := files[0]
+	for _, file := range files[1:] {
+		// Skip uploading unchanged files if incremental
+		// but add them to the meta to keep track of files to be restored
+		// from prev backups. Plus sometimes the cursor can return an offset
+		// beyond the current file size. Such phantom changes shouldn't
+		// be copied. But save meta to have file size.
+		if incr && (file.Len == 0 || file.Off >= file.Size) {
+			file.Off = -1
+			file.Len = -1
+
+			upItems = append(upItems, upItem{file: file})
+			continue
+		}
+
+		if wfile.Name == file.Name &&
+			wfile.Off+wfile.Len == file.Off {
+			wfile.Len += file.Len
+			wfile.Size = file.Size
+			continue
+		}
+
+		upItems = append(upItems, upItem{file: wfile, upload: true})
+		wfile = file
+	}
+
+	// flush the last pending file unless it's an incremental no-op
+	if !(incr && wfile.Off == 0 && wfile.Len == 0) {
+		upItems = append(upItems, upItem{file: wfile, upload: true})
+	}
+
+	return upItems
+}
+
+// uploadFiles uploads the given files to the storage.
 func uploadFiles(
 	ctx context.Context,
 	files []File,
@@ -679,63 +728,29 @@ func uploadFiles(
 		return nil, nil
 	}
 
-	wfile := files[0]
-	data := []File{}
+	upItems := planUploads(files, incr)
+
+	data := make([]File, 0, len(upItems))
 	cpBuf := make([]byte, bufSize)
 	saveBuf := make([]byte, bufSize)
 	fsSaveBuf := make([]byte, bufSize)
-	for _, file := range files[1:] {
-		select {
-		case <-ctx.Done():
-			return nil, storage.ErrCancelled
-		default:
-		}
-
-		// Skip uploading unchanged files if incremental
-		// but add them to the meta to keep track of files to be restored
-		// from prev backups. Plus sometimes the cursor can return an offset
-		// beyond the current file size. Such phantom changes shouldn't
-		// be copied. But save meta to have file size.
-		if incr && (file.Len == 0 || file.Off >= file.Size) {
-			file.Off = -1
-			file.Len = -1
-			file.Name = trimFilePrefix(file.Name, trimPrefix)
-
-			data = append(data, file)
+	for _, s := range upItems {
+		relName := trimFilePrefix(s.file.Name, trimPrefix)
+		if !s.upload {
+			s.file.Name = relName
+			data = append(data, s.file)
 			continue
 		}
 
-		if wfile.Name == file.Name &&
-			wfile.Off+wfile.Len == file.Off {
-			wfile.Len += file.Len
-			wfile.Size = file.Size
-			continue
-		}
-
-		fw, err := writeFile(ctx, &wfile, path.Join(subdir, trimFilePrefix(wfile.Name, trimPrefix)), stg, comprT, comprL,
+		fw, err := writeFile(ctx, &s.file, path.Join(subdir, relName), stg, comprT, comprL,
 			cpBuf, saveBuf, fsSaveBuf)
 		if err != nil {
-			return data, errors.Wrapf(err, "upload file `%s`", wfile.Name)
+			return data, errors.Wrapf(err, "upload file `%s`", s.file.Name)
 		}
-		fw.Name = trimFilePrefix(wfile.Name, trimPrefix)
+		fw.Name = relName
 
 		data = append(data, *fw)
-
-		wfile = file
 	}
-
-	if incr && wfile.Off == 0 && wfile.Len == 0 {
-		return data, nil
-	}
-
-	f, err := writeFile(ctx, &wfile, path.Join(subdir, trimFilePrefix(wfile.Name, trimPrefix)), stg, comprT, comprL,
-		cpBuf, saveBuf, fsSaveBuf)
-	if err != nil {
-		return data, errors.Wrapf(err, "upload file `%s`", wfile.Name)
-	}
-	f.Name = trimFilePrefix(wfile.Name, trimPrefix)
-
-	data = append(data, *f)
 
 	return data, nil
 }

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -667,8 +667,8 @@ type upItem struct {
 
 // planUploads walks files in order and produces the upload plan. files may
 // come as 16Mb (by default) blocks; in that case consecutive blocks of the
-// same file are coalesced into one bigger upload.
-// For example: f1[0-16], f1[16-24], f1[64-16] becomes f1[0-24], f1[50-16].
+// same file are coalesced into one bigger upload. In [Off-Len] notation:
+// f1[0-16], f1[16-16], f1[64-16] becomes f1[0-32], f1[64-16].
 // If this is an incremental, NOT base backup, unchanged files (Len == 0) are
 // not uploaded but still recorded in the meta as we need to know what files
 // shouldn't be restored (those which aren't in the target backup).

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -520,7 +520,7 @@ func (b *Backup) uploadPhysical(
 	stg storage.Storage,
 	l log.LogEvent,
 ) error {
-	numWorkers := b.numParallelFiles()
+	numWorkers := b.getNumParallelFiles()
 	if numWorkers > 1 {
 		l.Info("uploading data (%d files in parallel)", numWorkers)
 	} else {

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
@@ -519,7 +520,13 @@ func (b *Backup) uploadPhysical(
 	stg storage.Storage,
 	l log.LogEvent,
 ) error {
-	l.Info("uploading data")
+	numWorkers := b.numParallelFiles()
+	if numWorkers > 1 {
+		l.Info("uploading data (%d files in parallel)", numWorkers)
+	} else {
+		l.Info("uploading data")
+	}
+
 	dataFiles, err := uploadFiles(
 		ctx,
 		data,
@@ -530,6 +537,7 @@ func (b *Backup) uploadPhysical(
 		bcp.Compression,
 		bcp.CompressionLevel,
 		b.getBackupBufSize(),
+		numWorkers,
 	)
 	if err != nil {
 		return errors.Wrap(err, "upload data files")
@@ -547,6 +555,7 @@ func (b *Backup) uploadPhysical(
 		bcp.Compression,
 		bcp.CompressionLevel,
 		b.getBackupBufSize(),
+		numWorkers,
 	)
 	if err != nil {
 		return errors.Wrap(err, "upload journal files")
@@ -712,7 +721,8 @@ func planUploads(files []File, incr bool) []upItem {
 	return upItems
 }
 
-// uploadFiles uploads the given files to the storage.
+// uploadFiles uploads the given files to the storage, running up concurrently
+// `numWorkers` function calls of writeFile.
 func uploadFiles(
 	ctx context.Context,
 	files []File,
@@ -723,6 +733,7 @@ func uploadFiles(
 	comprT compress.CompressionType,
 	comprL *int,
 	bufSize int,
+	numWorker int,
 ) ([]File, error) {
 	if len(files) == 0 {
 		return nil, nil
@@ -730,29 +741,67 @@ func uploadFiles(
 
 	upItems := planUploads(files, incr)
 
-	data := make([]File, 0, len(upItems))
-	cpBuf := make([]byte, bufSize)
-	saveBuf := make([]byte, bufSize)
-	fsSaveBuf := make([]byte, bufSize)
-	for _, s := range upItems {
-		relName := trimFilePrefix(s.file.Name, trimPrefix)
+	// each concurrent upload needs its own set of buffer (x3)
+	type uploadBufs struct{ cp, save, fsSave []byte }
+	bufPool := make(chan uploadBufs, numWorker)
+	allBufs := make([]byte, numWorker*3*bufSize)
+	for i := range numWorker {
+		base := i * 3 * bufSize
+		bufPool <- uploadBufs{
+			cp:     allBufs[base : base+bufSize : base+bufSize],
+			save:   allBufs[base+bufSize : base+2*bufSize : base+2*bufSize],
+			fsSave: allBufs[base+2*bufSize : base+3*bufSize : base+3*bufSize],
+		}
+	}
+
+	// each goroutine writes a distinct index, so no locking needed.
+	results := make([]File, len(upItems))
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(numWorker)
+
+	for i, s := range upItems {
+		fname := trimFilePrefix(s.file.Name, trimPrefix)
 		if !s.upload {
-			s.file.Name = relName
-			data = append(data, s.file)
+			s.file.Name = fname
+			results[i] = s.file
 			continue
 		}
 
-		fw, err := writeFile(ctx, &s.file, path.Join(subdir, relName), stg, comprT, comprL,
-			cpBuf, saveBuf, fsSaveBuf)
-		if err != nil {
-			return data, errors.Wrapf(err, "upload file `%s`", s.file.Name)
+		// fail fast if single item fails
+		if egCtx.Err() != nil {
+			break
 		}
-		fw.Name = relName
 
-		data = append(data, *fw)
+		eg.Go(func() error {
+			bufs := <-bufPool
+			defer func() { bufPool <- bufs }()
+
+			fw, err := writeFile(
+				egCtx,
+				&s.file,
+				path.Join(subdir, fname),
+				stg,
+				comprT,
+				comprL,
+				bufs.cp,
+				bufs.save,
+				bufs.fsSave,
+			)
+			if err != nil {
+				return errors.Wrapf(err, "upload file `%s`", s.file.Name)
+			}
+			fw.Name = fname
+
+			results[i] = *fw
+			return nil
+		})
 	}
 
-	return data, nil
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 func writeFile(

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -733,7 +733,7 @@ func uploadFiles(
 	comprT compress.CompressionType,
 	comprL *int,
 	bufSize int,
-	numWorker int,
+	numWorkers int,
 ) ([]File, error) {
 	if len(files) == 0 {
 		return nil, nil
@@ -743,9 +743,9 @@ func uploadFiles(
 
 	// each concurrent upload needs its own set of buffer (x3)
 	type uploadBufs struct{ cp, save, fsSave []byte }
-	bufPool := make(chan uploadBufs, numWorker)
-	allBufs := make([]byte, numWorker*3*bufSize)
-	for i := range numWorker {
+	bufPool := make(chan uploadBufs, numWorkers)
+	allBufs := make([]byte, numWorkers*3*bufSize)
+	for i := range numWorkers {
 		base := i * 3 * bufSize
 		bufPool <- uploadBufs{
 			cp:     allBufs[base : base+bufSize : base+bufSize],
@@ -757,7 +757,7 @@ func uploadFiles(
 	// each goroutine writes a distinct index, so no locking needed.
 	results := make([]File, len(upItems))
 	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(numWorker)
+	eg.SetLimit(numWorkers)
 
 	for i, s := range upItems {
 		fname := trimFilePrefix(s.file.Name, trimPrefix)

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -714,7 +714,7 @@ func planUploads(files []File, incr bool) []upItem {
 	}
 
 	// flush the last pending file unless it's an incremental no-op
-	if !(incr && wfile.Off == 0 && wfile.Len == 0) {
+	if !incr || wfile.Off != 0 || wfile.Len != 0 {
 		upItems = append(upItems, upItem{file: wfile, upload: true})
 	}
 

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -757,7 +757,7 @@ func uploadFiles(
 	// each goroutine writes a distinct index, so no locking needed.
 	results := make([]File, len(upItems))
 	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(numWorkers)
+	eg.SetLimit(min(numWorkers, len(upItems)))
 
 	for i, s := range upItems {
 		fname := trimFilePrefix(s.file.Name, trimPrefix)

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -398,7 +398,7 @@ func (b *Backup) handleExternal(
 ) error {
 	filelist := make(Filelist, 0, len(data)+len(jrnls)+2) // +2 for metadata and filelist
 	for _, f := range append(data, jrnls...) {
-		f.Name = path.Clean("./" + strings.TrimPrefix(f.Name, dbpath))
+		f.Name = trimFilePrefix(f.Name, dbpath)
 		filelist = append(filelist, f)
 	}
 
@@ -650,6 +650,14 @@ func (id *UUID) IsZero() bool {
 	return bytes.Equal(id.UUID[:], uuid.Nil[:])
 }
 
+// trimFilePrefix strips trimPrefix from fname and returns
+// a cleaned relative path (e.g. `foo` rather than `/foo`).
+func trimFilePrefix(fname, trimPrefix string) string {
+	// path.Clean to get rid of `/` at the beginning in case it's
+	// left after TrimPrefix. Just for consistent file names in metadata
+	return path.Clean("./" + strings.TrimPrefix(fname, trimPrefix))
+}
+
 // Uploads given files to the storage. files may come as 16Mb (by default)
 // blocks in that case it will concat consecutive blocks in one bigger file.
 // For example: f1[0-16], f1[16-24], f1[64-16] becomes f1[0-24], f1[50-16].
@@ -669,12 +677,6 @@ func uploadFiles(
 ) ([]File, error) {
 	if len(files) == 0 {
 		return nil, nil
-	}
-
-	trim := func(fname string) string {
-		// path.Clean to get rid of `/` at the beginning in case it's
-		// left after TrimPrefix. Just for consistent file names in metadata
-		return path.Clean("./" + strings.TrimPrefix(fname, trimPrefix))
 	}
 
 	wfile := files[0]
@@ -697,7 +699,7 @@ func uploadFiles(
 		if incr && (file.Len == 0 || file.Off >= file.Size) {
 			file.Off = -1
 			file.Len = -1
-			file.Name = trim(file.Name)
+			file.Name = trimFilePrefix(file.Name, trimPrefix)
 
 			data = append(data, file)
 			continue
@@ -710,12 +712,12 @@ func uploadFiles(
 			continue
 		}
 
-		fw, err := writeFile(ctx, &wfile, path.Join(subdir, trim(wfile.Name)), stg, comprT, comprL,
+		fw, err := writeFile(ctx, &wfile, path.Join(subdir, trimFilePrefix(wfile.Name, trimPrefix)), stg, comprT, comprL,
 			cpBuf, saveBuf, fsSaveBuf)
 		if err != nil {
 			return data, errors.Wrapf(err, "upload file `%s`", wfile.Name)
 		}
-		fw.Name = trim(wfile.Name)
+		fw.Name = trimFilePrefix(wfile.Name, trimPrefix)
 
 		data = append(data, *fw)
 
@@ -726,12 +728,12 @@ func uploadFiles(
 		return data, nil
 	}
 
-	f, err := writeFile(ctx, &wfile, path.Join(subdir, trim(wfile.Name)), stg, comprT, comprL,
+	f, err := writeFile(ctx, &wfile, path.Join(subdir, trimFilePrefix(wfile.Name, trimPrefix)), stg, comprT, comprL,
 		cpBuf, saveBuf, fsSaveBuf)
 	if err != nil {
 		return data, errors.Wrapf(err, "upload file `%s`", wfile.Name)
 	}
-	f.Name = trim(wfile.Name)
+	f.Name = trimFilePrefix(wfile.Name, trimPrefix)
 
 	data = append(data, *f)
 

--- a/pbm/backup/physical_test.go
+++ b/pbm/backup/physical_test.go
@@ -419,104 +419,284 @@ func TestPlanUploads(t *testing.T) {
 	up := func(file File) upItem { return upItem{file: file, upload: true} }
 	skip := func(file File) upItem { return upItem{file: file} }
 
-	cases := []struct {
+	type planUploadsCase struct {
 		name  string
 		files []File
 		incr  bool
 		want  []upItem
-	}{
-		{
-			name:  "empty input",
-			files: nil,
-			want:  nil,
-		},
-		{
-			name:  "single file",
-			files: []File{f("a", 0, 16, 16)},
-			want:  []upItem{up(f("a", 0, 16, 16))},
-		},
-		{
-			name: "coalesce consecutive blocks of same file",
-			files: []File{
-				f("a", 0, 16, 48),
-				f("a", 16, 16, 48),
-				f("a", 32, 16, 48),
-			},
-			want: []upItem{up(f("a", 0, 48, 48))},
-		},
-		{
-			name: "gap between blocks is not coalesced",
-			files: []File{
-				f("a", 0, 16, 80),
-				f("a", 48, 16, 80),
-			},
-			want: []upItem{
-				up(f("a", 0, 16, 80)),
-				up(f("a", 48, 16, 80)),
-			},
-		},
-		{
-			name: "different files are separate uploads",
-			files: []File{
-				f("a", 0, 16, 16),
-				f("b", 0, 16, 16),
-			},
-			want: []upItem{
-				up(f("a", 0, 16, 16)),
-				up(f("b", 0, 16, 16)),
-			},
-		},
-		{
-			name: "incremental: unchanged file (Len==0) recorded as skip",
-			incr: true,
-			files: []File{
-				f("a", 0, 16, 48),
-				f("b", 0, 0, 100),
-				f("c", 0, 16, 16),
-			},
-			want: []upItem{
-				skip(f("b", -1, -1, 100)),
-				up(f("a", 0, 16, 48)),
-				up(f("c", 0, 16, 16)),
-			},
-		},
-		{
-			name: "incremental: phantom out-of-range (Off>=Size) recorded as skip",
-			incr: true,
-			files: []File{
-				f("a", 0, 16, 48),
-				f("b", 100, 16, 50),
-			},
-			want: []upItem{
-				skip(f("b", -1, -1, 50)),
-				up(f("a", 0, 16, 48)),
-			},
-		},
-		{
-			name:  "incremental: lone unchanged head file is dropped",
-			incr:  true,
-			files: []File{f("a", 0, 0, 100)},
-			want:  []upItem{},
-		},
-		{
-			name: "non-incremental does not skip Len==0 files",
-			files: []File{
-				f("a", 0, 16, 32),
-				f("b", 5, 0, 100), // kept as-is, no Off/Len reset
-			},
-			want: []upItem{
-				up(f("a", 0, 16, 32)),
-				up(f("b", 5, 0, 100)),
-			},
-		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := planUploads(c.files, c.incr)
-			if !reflect.DeepEqual(got, c.want) {
-				t.Errorf("planUploads want=%+v, got=%+v", c.want, got)
-			}
-		})
-	}
+	t.Run("physical", func(t *testing.T) {
+		cases := []planUploadsCase{
+			{
+				name:  "nil input",
+				files: nil,
+				want:  nil,
+			},
+			{
+				name:  "empty slice input",
+				files: []File{},
+				want:  nil,
+			},
+			{
+				name:  "single file",
+				files: []File{f("a", 0, 16, 16)},
+				want:  []upItem{up(f("a", 0, 16, 16))},
+			},
+			{
+				name:  "single file",
+				files: []File{f("a", 0, 0, 16)},
+				want:  []upItem{up(f("a", 0, 0, 16))},
+			},
+			{
+				name: "multiple files",
+				files: []File{
+					f("a", 0, 0, 16),
+					f("b", 0, 0, 32),
+					f("c", 0, 0, 64),
+				},
+				want: []upItem{
+					up(f("a", 0, 0, 16)),
+					up(f("b", 0, 0, 32)),
+					up(f("c", 0, 0, 64)),
+				},
+			},
+			{
+				name: "Len==0 file is uploaded, not skipped",
+				files: []File{
+					f("a", 0, 16, 32),
+					f("b", 5, 0, 100),
+				},
+				want: []upItem{
+					up(f("a", 0, 16, 32)),
+					up(f("b", 5, 0, 100)),
+				},
+			},
+			{
+				name: "Off>=Size file is uploaded, not skipped",
+				files: []File{
+					f("a", 0, 16, 16),
+					f("b", 100, 16, 50),
+				},
+				want: []upItem{
+					up(f("a", 0, 16, 16)),
+					up(f("b", 100, 16, 50)),
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				got := planUploads(tt.files, tt.incr)
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("planUploads want=%+v, got=%+v", tt.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("incremental base", func(t *testing.T) {
+		cases := []planUploadsCase{
+			{
+				name:  "single file, non-empty -> one upload",
+				files: []File{f("a", 0, 16, 32)},
+				incr:  true,
+				want:  []upItem{up(f("a", 0, 16, 32))},
+			},
+			{
+				name: "Off<Size is in-range -> uploaded, not skipped",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 48),
+					f("b", 49, 16, 50),
+				},
+				want: []upItem{
+					up(f("a", 0, 16, 48)),
+					up(f("b", 49, 16, 50)),
+				},
+			},
+			{
+				name: "coalesce consecutive blocks",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 48),
+					f("a", 16, 16, 48),
+					f("a", 32, 16, 48),
+				},
+				want: []upItem{up(f("a", 0, 48, 48))},
+			},
+			{
+				name: "coalesce consecutive blocks with 2 parts",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 1024),
+					f("a", 16, 16, 1024),
+					f("a", 64, 16, 1024),
+					f("a", 80, 16, 1024),
+				},
+				want: []upItem{
+					up(f("a", 0, 32, 1024)),
+					up(f("a", 64, 32, 1024)),
+				},
+			},
+			{
+				name: "same file: two blocks coalesce, gapped third separate",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 80),
+					f("a", 16, 16, 80),
+					f("a", 64, 16, 80),
+				},
+				want: []upItem{
+					up(f("a", 0, 32, 80)),
+					up(f("a", 64, 16, 80)),
+				},
+			},
+			{
+				name: "gap between blocks is not coalesced",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 80),
+					f("a", 48, 16, 80),
+				},
+				want: []upItem{
+					up(f("a", 0, 16, 80)),
+					up(f("a", 48, 16, 80)),
+				},
+			},
+			{
+				name: "coalesce updates Size to the latest block's Size",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 100),
+					f("a", 16, 16, 200),
+				},
+				want: []upItem{up(f("a", 0, 32, 200))},
+			},
+			{
+				name: "different files are separate uploads",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 16),
+					f("b", 0, 16, 16),
+				},
+				want: []upItem{
+					up(f("a", 0, 16, 16)),
+					up(f("b", 0, 16, 16)),
+				},
+			},
+			{
+				name: "coalescing block is broken",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 64),
+					f("a", 16, 16, 64),
+					f("b", 0, 16, 16),
+					f("a", 32, 16, 64),
+					f("a", 48, 16, 64),
+				},
+				want: []upItem{
+					up(f("a", 0, 32, 64)),
+					up(f("b", 0, 16, 16)),
+					up(f("a", 32, 32, 64)),
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				got := planUploads(tt.files, tt.incr)
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("planUploads want=%+v, got=%+v", tt.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("incremental", func(t *testing.T) {
+		cases := []planUploadsCase{
+			{
+				name: "unchanged file recorded as skip",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 48),
+					f("b", 0, 0, 100),
+					f("c", 0, 16, 16),
+				},
+				want: []upItem{
+					skip(f("b", -1, -1, 100)),
+					up(f("a", 0, 16, 48)),
+					up(f("c", 0, 16, 16)),
+				},
+			},
+			{
+				name: "out-of-range (Off>Size) recorded as skip",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 48),
+					f("b", 100, 16, 50),
+				},
+				want: []upItem{
+					skip(f("b", -1, -1, 50)),
+					up(f("a", 0, 16, 48)),
+				},
+			},
+			{
+				name: "out-of-range boundary (Off==Size) recorded as skip",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 48),
+					f("b", 50, 16, 50),
+				},
+				want: []upItem{
+					skip(f("b", -1, -1, 50)),
+					up(f("a", 0, 16, 48)),
+				},
+			},
+			{
+				name:  "unchanged head file is dropped",
+				incr:  true,
+				files: []File{f("a", 0, 0, 100)},
+				want:  []upItem{},
+			},
+			{
+				name: "skip between coalescing blocks preserves coalesce",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 32),
+					f("b", 0, 0, 16),
+					f("a", 16, 16, 32),
+				},
+				want: []upItem{
+					skip(f("b", -1, -1, 16)),
+					up(f("a", 0, 32, 32)),
+				},
+			},
+			{
+				name: "multiple skips and upload",
+				incr: true,
+				files: []File{
+					f("a", 0, 16, 16),
+					f("b", 0, 0, 16),
+					f("c", 0, 0, 16),
+					f("d", 100, 16, 50),
+				},
+				want: []upItem{
+					skip(f("b", -1, -1, 16)),
+					skip(f("c", -1, -1, 16)),
+					skip(f("d", -1, -1, 50)),
+					up(f("a", 0, 16, 16)),
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				got := planUploads(tt.files, tt.incr)
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("planUploads want=%+v, got=%+v", tt.want, got)
+				}
+			})
+		}
+	})
 }

--- a/pbm/backup/physical_test.go
+++ b/pbm/backup/physical_test.go
@@ -372,3 +372,41 @@ func BenchmarkCopyFileToFSStorage(b *testing.B) {
 		b.Logf("%+v", r)
 	}
 }
+
+func TestTrimFilePrefix(t *testing.T) {
+	cases := []struct {
+		name       string
+		fname      string
+		trimPrefix string
+		want       string
+	}{
+		{
+			name:       "leading slash left after trim is cleaned",
+			fname:      "/data/db/collection.wt",
+			trimPrefix: "/data/db",
+			want:       "collection.wt",
+		},
+		{
+			name:       "prefix with trailing slash",
+			fname:      "/data/db/journal/WiredTigerLog.0001",
+			trimPrefix: "/data/db/",
+			want:       "journal/WiredTigerLog.0001",
+		},
+		{
+			name:       "no matching prefix keeps relative path",
+			fname:      "collection.wt",
+			trimPrefix: "/data/db",
+			want:       "collection.wt",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := trimFilePrefix(c.fname, c.trimPrefix)
+			if got != c.want {
+				t.Errorf("trimFilePrefix(%q, %q) = %q, want %q",
+					c.fname, c.trimPrefix, got, c.want)
+			}
+		})
+	}
+}

--- a/pbm/backup/physical_test.go
+++ b/pbm/backup/physical_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -406,6 +407,115 @@ func TestTrimFilePrefix(t *testing.T) {
 			if got != c.want {
 				t.Errorf("trimFilePrefix(%q, %q) = %q, want %q",
 					c.fname, c.trimPrefix, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPlanUploads(t *testing.T) {
+	f := func(name string, off, length, size int64) File {
+		return File{Name: name, Off: off, Len: length, Size: size}
+	}
+	up := func(file File) upItem { return upItem{file: file, upload: true} }
+	skip := func(file File) upItem { return upItem{file: file} }
+
+	cases := []struct {
+		name  string
+		files []File
+		incr  bool
+		want  []upItem
+	}{
+		{
+			name:  "empty input",
+			files: nil,
+			want:  nil,
+		},
+		{
+			name:  "single file",
+			files: []File{f("a", 0, 16, 16)},
+			want:  []upItem{up(f("a", 0, 16, 16))},
+		},
+		{
+			name: "coalesce consecutive blocks of same file",
+			files: []File{
+				f("a", 0, 16, 48),
+				f("a", 16, 16, 48),
+				f("a", 32, 16, 48),
+			},
+			want: []upItem{up(f("a", 0, 48, 48))},
+		},
+		{
+			name: "gap between blocks is not coalesced",
+			files: []File{
+				f("a", 0, 16, 80),
+				f("a", 48, 16, 80),
+			},
+			want: []upItem{
+				up(f("a", 0, 16, 80)),
+				up(f("a", 48, 16, 80)),
+			},
+		},
+		{
+			name: "different files are separate uploads",
+			files: []File{
+				f("a", 0, 16, 16),
+				f("b", 0, 16, 16),
+			},
+			want: []upItem{
+				up(f("a", 0, 16, 16)),
+				up(f("b", 0, 16, 16)),
+			},
+		},
+		{
+			name: "incremental: unchanged file (Len==0) recorded as skip",
+			incr: true,
+			files: []File{
+				f("a", 0, 16, 48),
+				f("b", 0, 0, 100),
+				f("c", 0, 16, 16),
+			},
+			want: []upItem{
+				skip(f("b", -1, -1, 100)),
+				up(f("a", 0, 16, 48)),
+				up(f("c", 0, 16, 16)),
+			},
+		},
+		{
+			name: "incremental: phantom out-of-range (Off>=Size) recorded as skip",
+			incr: true,
+			files: []File{
+				f("a", 0, 16, 48),
+				f("b", 100, 16, 50),
+			},
+			want: []upItem{
+				skip(f("b", -1, -1, 50)),
+				up(f("a", 0, 16, 48)),
+			},
+		},
+		{
+			name:  "incremental: lone unchanged head file is dropped",
+			incr:  true,
+			files: []File{f("a", 0, 0, 100)},
+			want:  []upItem{},
+		},
+		{
+			name: "non-incremental does not skip Len==0 files",
+			files: []File{
+				f("a", 0, 16, 32),
+				f("b", 5, 0, 100), // kept as-is, no Off/Len reset
+			},
+			want: []upItem{
+				up(f("a", 0, 16, 32)),
+				up(f("b", 5, 0, 100)),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := planUploads(c.files, c.incr)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("planUploads want=%+v, got=%+v", c.want, got)
 			}
 		})
 	}

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -424,6 +424,7 @@ type RestoreConf struct {
 	BatchSize              int               `bson:"batchSize" json:"batchSize,omitempty" yaml:"batchSize,omitempty"`
 	NumInsertionWorkers    int               `bson:"numInsertionWorkers" json:"numInsertionWorkers,omitempty" yaml:"numInsertionWorkers,omitempty"`
 	NumParallelCollections int               `bson:"numParallelCollections" json:"numParallelCollections,omitempty" yaml:"numParallelCollections,omitempty"`
+	NumParallelFiles       int               `bson:"numParallelFiles" json:"numParallelFiles,omitempty" yaml:"numParallelFiles,omitempty"`
 	IndexCommitQuorum      IndexCommitQuorum `bson:"indexCommitQuorum,omitempty" json:"indexCommitQuorum,omitempty" yaml:"indexCommitQuorum,omitempty"`
 
 	// NumDownloadWorkers sets the num of goroutine would be requesting chunks
@@ -507,6 +508,13 @@ func (cfg *RestoreConf) GetIndexCommitQuorum() IndexCommitQuorum {
 	return DefaultRestoreIndexCommitQuorum
 }
 
+func (cfg *RestoreConf) GetNumParallelFiles() int {
+	if cfg == nil || cfg.NumParallelFiles < 1 {
+		return 1
+	}
+	return cfg.NumParallelFiles
+}
+
 //nolint:lll
 type BackupConf struct {
 	OplogSpanMin     float64                  `bson:"oplogSpanMin" json:"oplogSpanMin" yaml:"oplogSpanMin"`
@@ -541,11 +549,11 @@ func (cfg *BackupConf) Clone() *BackupConf {
 	return &rv
 }
 
-func (b *BackupConf) GetNumParallelFiles() int {
-	if b == nil || b.NumParallelFiles < 1 {
+func (cfg *BackupConf) GetNumParallelFiles() int {
+	if cfg == nil || cfg.NumParallelFiles < 1 {
 		return 1
 	}
-	return b.NumParallelFiles
+	return cfg.NumParallelFiles
 }
 
 //nolint:lll

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -516,6 +516,7 @@ type BackupConf struct {
 	CompressionLevel *int                     `bson:"compressionLevel,omitempty" json:"compressionLevel,omitempty" yaml:"compressionLevel,omitempty"`
 
 	NumParallelCollections int `bson:"numParallelCollections" json:"numParallelCollections,omitempty" yaml:"numParallelCollections,omitempty"`
+	NumParallelFiles       int `bson:"numParallelFiles" json:"numParallelFiles,omitempty" yaml:"numParallelFiles,omitempty"`
 }
 
 func (cfg *BackupConf) Clone() *BackupConf {
@@ -538,6 +539,13 @@ func (cfg *BackupConf) Clone() *BackupConf {
 	}
 
 	return &rv
+}
+
+func (b *BackupConf) GetNumParallelFiles() int {
+	if b == nil || b.NumParallelFiles < 1 {
+		return 1
+	}
+	return b.NumParallelFiles
 }
 
 //nolint:lll

--- a/pbm/config/config_test.go
+++ b/pbm/config/config_test.go
@@ -749,6 +749,50 @@ func TestSetConfigVarTrimsSlashes(t *testing.T) {
 	}
 }
 
+func TestBackupConfGetNumParallelFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *BackupConf
+		want int
+	}{
+		{name: "nil receiver", cfg: nil, want: 1},
+		{name: "unset (zero) defaults to 1", cfg: &BackupConf{}, want: 1},
+		{name: "negative defaults to 1", cfg: &BackupConf{NumParallelFiles: -5}, want: 1},
+		{name: "one", cfg: &BackupConf{NumParallelFiles: 1}, want: 1},
+		{name: "configured value", cfg: &BackupConf{NumParallelFiles: 8}, want: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.GetNumParallelFiles(); got != tt.want {
+				t.Errorf("GetNumParallelFiles() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestoreConfGetNumParallelFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *RestoreConf
+		want int
+	}{
+		{name: "nil receiver", cfg: nil, want: 1},
+		{name: "unset (zero) defaults to 1", cfg: &RestoreConf{}, want: 1},
+		{name: "negative defaults to 1", cfg: &RestoreConf{NumParallelFiles: -5}, want: 1},
+		{name: "one", cfg: &RestoreConf{NumParallelFiles: 1}, want: 1},
+		{name: "configured value", cfg: &RestoreConf{NumParallelFiles: 8}, want: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.GetNumParallelFiles(); got != tt.want {
+				t.Errorf("GetNumParallelFiles() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -163,6 +163,7 @@ type RestoreCmd struct {
 	AllowPartlyDone *bool             `bson:"allowPartlyDone"`
 
 	NumParallelColls    *int32                   `bson:"numParallelColls,omitempty"`
+	NumParallelFiles    *int32                   `bson:"numParallelFiles,omitempty"`
 	NumInsertionWorkers *int32                   `bson:"numInsertionWorkers,omitempty"`
 	IndexCommitQuorum   config.IndexCommitQuorum `bson:"indexCommitQuorum,omitempty"`
 

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -135,6 +135,7 @@ type BackupCmd struct {
 	Compression      compress.CompressionType `bson:"compression"`
 	CompressionLevel *int                     `bson:"level,omitempty"`
 	NumParallelColls *int32                   `bson:"numParallelColls,omitempty"`
+	NumParallelFiles *int32                   `bson:"numParallelFiles,omitempty"`
 	Filelist         bool                     `bson:"filelist,omitempty"`
 	Profile          string                   `bson:"profile,omitempty"`
 	UsersAndRoles    bool                     `bson:"usersAndRoles,omitempty"`

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1723,6 +1723,9 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 			defer func() { bufPool <- cpBuf }()
 
 			for _, op := range job.ops {
+				if err := egCtx.Err(); err != nil {
+					return err
+				}
 				if err := r.copyFile(op.src, job.dst, op.fMeta, op.cmpr, cpBuf); err != nil {
 					return err
 				}

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -27,6 +27,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/writeconcern"
 	"golang.org/x/mod/semver"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
 
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
@@ -1599,6 +1600,65 @@ func (r *PhysRestore) dumpMeta(meta *RestoreMeta, s defs.Status, msg string) err
 	return nil
 }
 
+// copyFileJob is all copy operations targeting one destination file, in the
+// order they must be applied: base backup first and then increments.
+// The main purpose is ability to execute jobs in parallel.
+// ops is empty for a directory-only entry which ensures dst's directory exists.
+type copyFileJob struct {
+	dst string
+	ops []copyOp
+}
+
+// copyOp is a single block/layer to write into a destination file.
+type copyOp struct {
+	src   string
+	fMeta backup.File
+	cmpr  compress.CompressionType
+}
+
+// planCopyFiles walks r.files in restore order (base -> target) and groups
+// every copy operation by its destination file. The grouping is what makes
+// parallel copying safe, across jobs the destinations differ so they don't race.
+func (r *PhysRestore) planCopyFiles(setName string) []copyFileJob {
+	var jobs []copyFileJob
+	idxByDst := make(map[string]int)
+
+	add := func(dst string, op *copyOp) {
+		idx, ok := idxByDst[dst]
+		if !ok {
+			idx = len(jobs)
+			idxByDst[dst] = idx
+			jobs = append(jobs, copyFileJob{dst: dst})
+		}
+		if op != nil {
+			jobs[idx].ops = append(jobs[idx].ops, *op)
+		}
+	}
+
+	for i := len(r.files) - 1; i >= 0; i-- {
+		set := r.files[i]
+		for _, f := range set.Data {
+			src := filepath.Join(set.BcpName, setName, f.Path(set.Cmpr))
+			// cut dbpath from destination if there is any (see PBM-1058)
+			fname := f.Name
+			if set.dbpath != "" {
+				fname = strings.TrimPrefix(fname, set.dbpath)
+			}
+			dst := filepath.Join(r.dbpath, fname)
+
+			// if this is a directory, only ensure it is created.
+			if set.BcpName == bcpDir {
+				add(dst, nil)
+				continue
+			}
+
+			add(dst, &copyOp{src: src, fMeta: f, cmpr: set.Cmpr})
+		}
+	}
+
+	return jobs
+}
+
 func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 	var stat *storage.DownloadStat
 	defer func() {
@@ -1612,40 +1672,58 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 	}()
 
 	setName := util.MakeReverseRSMapFunc(r.rsMap)(r.nodeInfo.SetName)
+	jobs := r.planCopyFiles(setName)
 
-	var cpBuf []byte
-	if r.bufSize == 0 {
-		// original/default bufSize
-		cpBuf = make([]byte, 32*1024)
-	} else {
-		cpBuf = make([]byte, r.bufSize)
+	numWorkers := r.numParallelFiles()
+	if numWorkers > 1 {
+		r.log.Info("downloading data (%d files in parallel)", numWorkers)
 	}
-	for i := len(r.files) - 1; i >= 0; i-- {
-		set := r.files[i]
-		for _, f := range set.Data {
-			src := filepath.Join(set.BcpName, setName, f.Path(set.Cmpr))
-			// cut dbpath from destination if there is any (see PBM-1058)
-			fname := f.Name
-			if set.dbpath != "" {
-				fname = strings.TrimPrefix(fname, set.dbpath)
-			}
-			dst := filepath.Join(r.dbpath, fname)
 
-			err := os.MkdirAll(filepath.Dir(dst), os.ModeDir|0o700)
-			if err != nil {
-				return stat, errors.Wrapf(err, "create path %s", filepath.Dir(dst))
-			}
-			// if this is a directory, only ensure it is created.
-			if set.BcpName == bcpDir {
-				r.log.Info("create dir <%s>", filepath.Dir(f.Name))
-				continue
-			}
+	bufLen := 32 * 1024 // original/default bufSize
+	if r.bufSize != 0 {
+		bufLen = r.bufSize
+	}
+	// each concurrent copy needs its own buffer
+	bufPool := make(chan []byte, numWorkers)
+	allBufs := make([]byte, numWorkers*bufLen)
+	for i := range numWorkers {
+		// preallocate buffer for each worker
+		bufPool <- allBufs[i*bufLen : (i+1)*bufLen : (i+1)*bufLen]
+	}
 
-			err = r.copyFile(src, dst, f, set.Cmpr, cpBuf)
-			if err != nil {
-				return stat, err
-			}
+	eg, egCtx := errgroup.WithContext(context.Background())
+	eg.SetLimit(numWorkers)
+
+	for _, job := range jobs {
+		// stop processing once a copy has failed
+		if egCtx.Err() != nil {
+			break
 		}
+
+		eg.Go(func() error {
+			if err := os.MkdirAll(filepath.Dir(job.dst), os.ModeDir|0o700); err != nil {
+				return errors.Wrapf(err, "create path %s", filepath.Dir(job.dst))
+			}
+			// directory-only entry: nothing to copy.
+			if len(job.ops) == 0 {
+				r.log.Info("create dir <%s>", filepath.Dir(job.dst))
+				return nil
+			}
+
+			cpBuf := <-bufPool
+			defer func() { bufPool <- cpBuf }()
+
+			for _, op := range job.ops {
+				if err := r.copyFile(op.src, job.dst, op.fMeta, op.cmpr, cpBuf); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return stat, err
 	}
 	return stat, nil
 }
@@ -3137,6 +3215,16 @@ func GetMongodConfig(mongodCfg string) (*topo.MongodOpts, error) {
 		return nil, errors.Wrap(err, "unable to unmarshal mongod config file")
 	}
 	return mOpts, nil
+}
+
+// numParallelFiles is the number of files to copy concurrently during
+// physical restore. Defaults to 1 (sequential) when unset in the config.
+func (r *PhysRestore) numParallelFiles() int {
+	if r.bcpStg.Type() != storage.Filesystem {
+		// there's no parallelism for cloud storage on this level
+		return 1
+	}
+	return r.confOpts.GetNumParallelFiles()
 }
 
 // physRestoreFromExtDump creates PhysRestore object from dump on the storage.

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1701,7 +1701,7 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 	}
 
 	eg, egCtx := errgroup.WithContext(context.Background())
-	eg.SetLimit(numWorkers)
+	eg.SetLimit(min(numWorkers, len(jobs)))
 
 	for _, job := range jobs {
 		// stop processing once a copy has failed

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -1668,8 +1668,11 @@ func (r *PhysRestore) planCopyFiles(setName string) []copyFileJob {
 func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 	var stat *storage.DownloadStat
 	defer func() {
-		if r.bcpStg.Type() != storage.S3 || r.bcpStg.Type() != storage.GCS {
-			// currently Downloader is only supported for S3 and GCS
+		if r.bcpStg.Type() != storage.S3 &&
+			r.bcpStg.Type() != storage.GCS &&
+			r.bcpStg.Type() != storage.Minio &&
+			r.bcpStg.Type() != storage.OCI {
+			// download is not supported for the rest of providers
 			return
 		}
 		s := r.bcpStg.DownloadStat()

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -128,6 +128,8 @@ type PhysRestore struct {
 	fallback        bool
 	allowPartlyDone bool
 	bufSize         int
+
+	numParallelFiles int
 }
 
 func NewPhysical(
@@ -1212,6 +1214,10 @@ func (r *PhysRestore) Snapshot(
 		return errors.Wrap(err, "init")
 	}
 
+	if cmd.NumParallelFiles != nil && *cmd.NumParallelFiles > 0 {
+		r.numParallelFiles = int(*cmd.NumParallelFiles)
+	}
+
 	if cmd.BackupName == "" && !cmd.External {
 		return errors.New("restore isn't external and no backup set")
 	}
@@ -1674,7 +1680,7 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 	setName := util.MakeReverseRSMapFunc(r.rsMap)(r.nodeInfo.SetName)
 	jobs := r.planCopyFiles(setName)
 
-	numWorkers := r.numParallelFiles()
+	numWorkers := r.GetNumParallelFiles()
 	if numWorkers > 1 {
 		r.log.Info("downloading data (%d files in parallel)", numWorkers)
 	}
@@ -3217,12 +3223,15 @@ func GetMongodConfig(mongodCfg string) (*topo.MongodOpts, error) {
 	return mOpts, nil
 }
 
-// numParallelFiles is the number of files to copy concurrently during
+// GetNumParallelFiles is the number of files to copy concurrently during
 // physical restore. Defaults to 1 (sequential) when unset in the config.
-func (r *PhysRestore) numParallelFiles() int {
+func (r *PhysRestore) GetNumParallelFiles() int {
 	if r.bcpStg.Type() != storage.Filesystem {
 		// there's no parallelism for cloud storage on this level
 		return 1
+	}
+	if r.numParallelFiles > 0 {
+		return r.numParallelFiles
 	}
 	return r.confOpts.GetNumParallelFiles()
 }

--- a/pbm/restore/physical_test.go
+++ b/pbm/restore/physical_test.go
@@ -730,3 +730,86 @@ func BenchmarkCopyFileFromFSStorage(b *testing.B) {
 		b.Logf("%+v", res)
 	}
 }
+
+func TestPlanCopyFiles(t *testing.T) {
+	const setName = "rs0"
+	none := compress.CompressionTypeNone
+
+	// f is a test constructor for the backup.File fields
+	f := func(name string, off, length, size int64) backup.File {
+		return backup.File{Name: name, Off: off, Len: length, Size: size}
+	}
+
+	tests := []struct {
+		name   string
+		dbpath string
+		files  []files
+		want   []copyFileJob
+	}{
+		{
+			name:   "empty",
+			dbpath: "/data/db",
+			files:  nil,
+			want:   nil,
+		},
+		{
+			name:   "layers and blocks of one file grouped, base-first order",
+			dbpath: "/data/db",
+			// slice order is target-first; planCopyFiles applies base-first.
+			files: []files{
+				{BcpName: "bcp-target", Cmpr: none, Data: []backup.File{
+					f("coll-1.wt", 32, 16, 48),
+				}},
+				{BcpName: "bcp-base", Cmpr: none, Data: []backup.File{
+					f("coll-1.wt", 0, 16, 48),
+					f("coll-1.wt", 16, 16, 48),
+					f("index-2.wt", 0, 0, 100),
+				}},
+			},
+			want: []copyFileJob{
+				{dst: "/data/db/coll-1.wt", ops: []copyOp{
+					{src: "bcp-base/rs0/coll-1.wt.0-16", fMeta: f("coll-1.wt", 0, 16, 48), cmpr: none},
+					{src: "bcp-base/rs0/coll-1.wt.16-16", fMeta: f("coll-1.wt", 16, 16, 48), cmpr: none},
+					{src: "bcp-target/rs0/coll-1.wt.32-16", fMeta: f("coll-1.wt", 32, 16, 48), cmpr: none},
+				}},
+				{dst: "/data/db/index-2.wt", ops: []copyOp{
+					{src: "bcp-base/rs0/index-2.wt", fMeta: f("index-2.wt", 0, 0, 100), cmpr: none},
+				}},
+			},
+		},
+		{
+			name:   "directory-only entry has no ops",
+			dbpath: "/data/db",
+			files: []files{
+				{BcpName: bcpDir, Data: []backup.File{f("somedir/coll.wt", -1, -1, -1)}},
+			},
+			want: []copyFileJob{
+				{dst: "/data/db/somedir/coll.wt"},
+			},
+		},
+		{
+			name:   "PBM-1058 dbpath stripped from destination",
+			dbpath: "/data/db",
+			files: []files{
+				{BcpName: "bcp1", Cmpr: none, dbpath: "/data/db", Data: []backup.File{
+					f("/data/db/coll-9.wt", 0, 16, 16),
+				}},
+			},
+			want: []copyFileJob{
+				{dst: "/data/db/coll-9.wt", ops: []copyOp{
+					{src: "bcp1/rs0/data/db/coll-9.wt.0-16", fMeta: f("/data/db/coll-9.wt", 0, 16, 16), cmpr: none},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PhysRestore{dbpath: tt.dbpath, files: tt.files}
+			got := r.planCopyFiles(setName)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("planCopyFiles: got=%+v want=%+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1715

PR adds support for parallel file upload/download during backup/physical restore for FS/NFS storage types.

The following configuration parameters and options are available:
```
$ pbm config --list
storage:
  type: filesystem
  filesystem:
    path: /opt/backups/pbm
backup:
  numParallelFiles: 4
restore:
  numParallelFiles: 4
```

```
$ pbm backup --help
Make backup

Usage:
  pbm backup [flags]

Flags:
....
      --num-parallel-files int32        Number of files to upload in parallel (physical backup, filesystem storage only)
```
```
$ pbm restore --help
Restore backup

Usage:
  pbm restore [backup_name] [flags]

Flags:
....
      --num-parallel-files int32       Number of files to copy in parallel (physical restore, filesystem storage only)
```