### PR TITLE
PBM-1772: logical PITR failure on 8.3 

### DIFF
--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -1211,6 +1211,8 @@ func (o *OplogRestore) handleNonTxnOp(op db.Oplog) error {
 			// allocate fresh physical metadata.
 			op.Query = nil
 
+			// This synthetic drop can be removed once PBM-1670 adds RS
+			// pre-restore cleanup matching sharded restores.
 			op2 := op
 			op2.Object = bson.D{{"drop", collName}}
 			if err := o.handleNonTxnOp(op2); err != nil {

--- a/pbm/oplog/restore.go
+++ b/pbm/oplog/restore.go
@@ -1205,6 +1205,12 @@ func (o *OplogRestore) handleNonTxnOp(op db.Oplog) error {
 				o.indexCatalog.SetCollation(dbName, collName, true)
 			}
 
+			// MongoDB 8.3 create oplog entries may include physical local-catalog
+			// metadata in o2, such as storage idents. PBM is about to force a
+			// drop/recreate, so keep logical data in o and ui, and let MongoDB
+			// allocate fresh physical metadata.
+			op.Query = nil
+
 			op2 := op
 			op2.Object = bson.D{{"drop", collName}}
 			if err := o.handleNonTxnOp(op2); err != nil {

--- a/pbm/oplog/restore_test.go
+++ b/pbm/oplog/restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/mongo-tools/common/idx"
 	"github.com/mongodb/mongo-tools/mongorestore/ns"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/percona/percona-backup-mongodb/pbm/log"
@@ -66,9 +67,51 @@ func (d *mdbTestClient) applyOps(entries []interface{}) error {
 		invParams["cmd"] = oe.Object[0].Key
 		invParams["coll"] = oe.Object[0].Value.(string)
 	}
+	if len(oe.Query) > 0 {
+		invParams["o2"] = "1"
+	}
 	d.applyOpsInv = append(d.applyOpsInv, invParams)
 
 	return nil
+}
+
+func TestHandleNonTxnOpCreateStripsO2FromSyntheticDropAndCreate(t *testing.T) {
+	db := newMDBTestClient()
+	oRestore := newOplogRestoreTest(db)
+
+	uuid := bson.Binary{Subtype: 0x04, Data: []byte{1, 2, 3, 4}}
+	op := dbOplogCreateWithO2(uuid)
+
+	err := oRestore.handleNonTxnOp(op)
+	require.NoError(t, err)
+	require.Len(t, db.applyOpsInv, 2)
+
+	wantCmds := []string{"drop", "create"}
+	for i, want := range wantCmds {
+		require.Equal(t, want, db.applyOpsInv[i]["cmd"])
+		require.Empty(t, db.applyOpsInv[i]["o2"])
+	}
+}
+
+func dbOplogCreateWithO2(uuid bson.Binary) db.Oplog {
+	return db.Oplog{
+		Operation: "c",
+		Namespace: "mydb.$cmd",
+		UI:        &uuid,
+		Object: bson.D{
+			{"create", "c1"},
+			{"idIndex", bson.D{
+				{"v", int32(2)},
+				{"key", bson.D{{"_id", int32(1)}}},
+				{"name", "_id_"},
+			}},
+		},
+		Query: bson.D{
+			{"catalogId", int64(1)},
+			{"ident", "collection-ident"},
+			{"idIndexIdent", "index-ident"},
+		},
+	}
 }
 
 func TestIsOpForCloning(t *testing.T) {


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1772


The root cause was a synthetic delete introduced by PBM-1012 in combination with 8.3 changes -- a create oplog entry now carries physical idents inside `o2` field. If storage doesn't require matching physical indents, a valid solution is to drop `o2` field from the entry and allocate a new one. 

We can later refine the approach when working PBM-1670. 
