### PR TITLE
PBM-1712 Stop regular heartbeat before cleanup wait

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -254,6 +254,10 @@ func (r *PhysRestore) close(noerr bool, progress nodeStatus) (err error) {
 		}
 	}
 
+	if r.stopHB != nil {
+		close(r.stopHB)
+	}
+
 	r.log.Debug("wait for cluster status")
 	cStatus, err := r.waitClusterStatus()
 	if err != nil {
@@ -273,9 +277,6 @@ func (r *PhysRestore) close(noerr bool, progress nodeStatus) (err error) {
 
 		if r.stopCleanupHB != nil {
 			close(r.stopCleanupHB)
-		}
-		if r.stopHB != nil {
-			close(r.stopHB)
 		}
 	}()
 


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1712

Code already underwent some refactoring since the ticket was created. The root cause is simply that a node was keeping itself waiting by its own heartbeat. 