### PR TITLE
PBM-1791: Add client-side encryption for backups

### DIFF
--- a/cmd/pbm-speed-test/speedt.go
+++ b/cmd/pbm-speed-test/speedt.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 )
@@ -142,7 +143,8 @@ func doTest(
 
 	r := &Results{}
 	ts := time.Now()
-	size, err := storage.Upload(context.Background(), src, stg, compression, level, fileName)
+	size, err := storage.Upload(context.Background(), src, stg, compression, level,
+		encrypt.EncryptionTypeNone, "", fileName)
 	r.Size = Byte(size)
 	if err != nil {
 		return nil, errors.Wrap(err, "upload")

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
@@ -33,6 +34,7 @@ type backupOpts struct {
 	base             bool
 	compression      string
 	compressionLevel []int
+	encryption       string
 	profile          ProfileFlag
 	ns               string
 	wait             bool
@@ -147,6 +149,11 @@ func runBackup(
 		level = &b.compressionLevel[0]
 	}
 
+	encryption := cfg.EncryptionType()
+	if b.encryption != "" {
+		encryption = encrypt.EncryptionType(b.encryption)
+	}
+
 	err = sendCmd(ctx, conn, ctrl.Cmd{
 		Cmd: ctrl.CmdBackup,
 		Backup: &ctrl.BackupCmd{
@@ -157,6 +164,7 @@ func runBackup(
 			UsersAndRoles:    b.usersAndRoles,
 			Compression:      compression,
 			CompressionLevel: level,
+			Encryption:       encryption,
 			NumParallelColls: numParallelColls,
 			NumParallelFiles: numParallelFiles,
 			Filelist:         b.externList,

--- a/cmd/pbm/main.go
+++ b/cmd/pbm/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
@@ -241,6 +242,12 @@ func (app *pbmApp) buildBackupCmd() *cobra.Command {
 		string(compress.CompressionTypeZstandard),
 	}
 
+	validEncryptions := []string{
+		string(encrypt.EncryptionTypeNone),
+		string(encrypt.EncryptionTypeAES256GCM),
+		string(encrypt.EncryptionTypeXChaCha20Poly1305),
+	}
+
 	validBackupTypes := []string{
 		string(defs.PhysicalBackup),
 		string(defs.LogicalBackup),
@@ -260,6 +267,10 @@ func (app *pbmApp) buildBackupCmd() *cobra.Command {
 				return nil, err
 			}
 
+			if err := app.validateEnum("encryption", backupOptions.encryption, validEncryptions); err != nil {
+				return nil, err
+			}
+
 			if err := app.validateEnum("type", backupOptions.typ, validBackupTypes); err != nil {
 				return nil, err
 			}
@@ -272,6 +283,10 @@ func (app *pbmApp) buildBackupCmd() *cobra.Command {
 	backupCmd.Flags().StringVar(
 		&backupOptions.compression, "compression", "",
 		"Compression type <none>/<gzip>/<snappy>/<lz4>/<s2>/<pgzip>/<zstd>",
+	)
+	backupCmd.Flags().StringVar(
+		&backupOptions.encryption, "encryption", "",
+		"Encryption type <none>/<aes-256-gcm>/<xchacha20-poly1305>",
 	)
 	backupCmd.Flags().StringVarP(
 		&backupOptions.typ, "type", "t", string(defs.LogicalBackup),

--- a/e2e-tests/cmd/ensure-oplog/main.go
+++ b/e2e-tests/cmd/ensure-oplog/main.go
@@ -283,6 +283,11 @@ func ensureReplsetOplog(ctx context.Context, uri string, from, till bson.Timesta
 		compression = compress.CompressionType(cfg.PITR.Compression)
 		compressionLevel = cfg.PITR.CompressionLevel
 	}
+	encryption := cfg.EncryptionType()
+	passphrase, err := cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
 
 	for _, t := range missedChunks {
 		logger.Printf("[%s] ensure missed chunk: %s - %s",
@@ -292,7 +297,8 @@ func ensureReplsetOplog(ctx context.Context, uri string, from, till bson.Timesta
 		o := oplog.NewOplogBackup(m)
 		o.SetTailingSpan(t.from, t.till)
 
-		n, err := storage.Upload(ctx, o, stg, compression, compressionLevel, filename)
+		n, err := storage.Upload(ctx, o, stg, compression, compressionLevel,
+			encryption, passphrase, filename)
 		if err != nil {
 			return errors.Wrapf(err, "failed to upload %s - %s chunk",
 				formatTimestamp(t.from), formatTimestamp(t.till))

--- a/e2e-tests/cmd/pbm-test/run.go
+++ b/e2e-tests/cmd/pbm-test/run.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/e2e-tests/pkg/tests/sharded"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 )
 
 func run(t *sharded.Cluster, typ testTyp) {
@@ -71,6 +72,17 @@ func run(t *sharded.Cluster, typ testTyp) {
 		flushStore(t)
 	}
 
+	t.SetBallastData(1e5)
+
+	runTest("Encrypted Logical Backup & Restore AES-256-GCM",
+		func() { t.EncryptedBackupAndRestore("/etc/pbm/minio-encrypt-aes.yaml", encrypt.EncryptionTypeAES256GCM) })
+	runTest("Encrypted Logical Backup & Restore XChaCha20-Poly1305",
+		func() { t.EncryptedBackupAndRestore("/etc/pbm/minio-encrypt-xchacha.yaml", encrypt.EncryptionTypeXChaCha20Poly1305) })
+	runTest("Encrypted Restore With Wrong Passphrase Fails",
+		func() { t.EncryptedRestoreWrongPassphraseFails("/etc/pbm/minio-encrypt-aes.yaml", "/etc/pbm/minio-encrypt-aes-wrong.yaml") })
+
+	flushStore(t)
+	t.ApplyConfig(context.TODO(), storage)
 	t.SetBallastData(1e5)
 
 	runTest("Check the Cannot Run Delete During Backup",

--- a/e2e-tests/docker/conf/minio-encrypt-aes-wrong.yaml
+++ b/e2e-tests/docker/conf/minio-encrypt-aes-wrong.yaml
@@ -1,0 +1,13 @@
+storage:
+  type: s3
+  s3:
+    endpointUrl: http://minio:9000
+    region: us-east-1
+    bucket: bcp
+    prefix: pbme2etest
+    credentials:
+      access-key-id: "minio1234"
+      secret-access-key: "minio1234"
+backup:
+  encryption: aes-256-gcm
+  encryptionPassphrase: "wrong passphrase that cannot decrypt"

--- a/e2e-tests/docker/conf/minio-encrypt-aes.yaml
+++ b/e2e-tests/docker/conf/minio-encrypt-aes.yaml
@@ -1,0 +1,13 @@
+storage:
+  type: s3
+  s3:
+    endpointUrl: http://minio:9000
+    region: us-east-1
+    bucket: bcp
+    prefix: pbme2etest
+    credentials:
+      access-key-id: "minio1234"
+      secret-access-key: "minio1234"
+backup:
+  encryption: aes-256-gcm
+  encryptionPassphrase: "correct horse battery staple"

--- a/e2e-tests/docker/conf/minio-encrypt-xchacha.yaml
+++ b/e2e-tests/docker/conf/minio-encrypt-xchacha.yaml
@@ -1,0 +1,13 @@
+storage:
+  type: s3
+  s3:
+    endpointUrl: http://minio:9000
+    region: us-east-1
+    bucket: bcp
+    prefix: pbme2etest
+    credentials:
+      access-key-id: "minio1234"
+      secret-access-key: "minio1234"
+backup:
+  encryption: xchacha20-poly1305
+  encryptionPassphrase: "correct horse battery staple"

--- a/e2e-tests/pkg/tests/sharded/test_encryption.go
+++ b/e2e-tests/pkg/tests/sharded/test_encryption.go
@@ -1,0 +1,143 @@
+package sharded
+
+import (
+	"bytes"
+	"context"
+	"io"
+	stdlog "log"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
+)
+
+// pbmEncryptedMagic is the 4-byte marker every PBM-encrypted stream begins
+// with. Data objects on storage must carry it when encryption is enabled.
+var pbmEncryptedMagic = []byte("PBME")
+
+// maxObjectScanBytes caps how large an object we pull off storage to inspect.
+// The big ballast dump is skipped. The small per-collection dumps are enough to
+// prove the storage data is encrypted.
+const maxObjectScanBytes = 8 << 20  // 8 Mib
+
+func (c *Cluster) EncryptedBackupAndRestore(confFile string, expected encrypt.EncryptionType) {
+	c.ApplyConfig(context.TODO(), confFile)
+
+	c.SetBallastData(1e5)
+	checkData := c.DataChecker()
+
+	bcpName := c.LogicalBackup()
+	c.BackupWaitDone(context.TODO(), bcpName)
+
+	c.assertBackupEncryption(context.TODO(), bcpName, expected)
+	c.assertStorageEncrypted(context.TODO(), bcpName)
+
+	c.DeleteBallast()
+
+	stdlog.Println("resync backup list")
+	if err := c.mongopbm.StoreResync(context.TODO()); err != nil {
+		stdlog.Fatalln("Error: resync backup lists:", err)
+	}
+
+	c.LogicalRestore(context.TODO(), bcpName)
+	checkData()
+}
+
+func (c *Cluster) EncryptedRestoreWrongPassphraseFails(correctConf, wrongConf string) {
+	c.ApplyConfig(context.TODO(), correctConf)
+
+	c.SetBallastData(1e5)
+	checkData := c.DataChecker()
+
+	bcpName := c.LogicalBackup()
+	c.BackupWaitDone(context.TODO(), bcpName)
+
+	c.DeleteBallast()
+
+	c.ApplyConfig(context.TODO(), wrongConf)
+
+	stdlog.Println("restoring with the wrong passphrase (expecting failure)")
+	if _, err := c.pbm.Restore(bcpName, []string{}); err != nil {
+		stdlog.Fatalln("starting restore with wrong passphrase:", err)
+	}
+
+	if err := c.pbm.CheckRestore(bcpName, defs.WaitBackupStart*6); err == nil {
+		stdlog.Fatalln("Error: restore with wrong passphrase succeeded, expected decryption failure")
+	} else {
+		stdlog.Printf("restore failed as expected with wrong passphrase: %v", err)
+	}
+
+	c.clearRestoreHistory(context.TODO())
+
+	stdlog.Println("healing cluster with the correct passphrase")
+	c.ApplyConfig(context.TODO(), correctConf)
+	c.LogicalRestore(context.TODO(), bcpName)
+	checkData()
+}
+
+func (c *Cluster) clearRestoreHistory(ctx context.Context) {
+	_, err := c.mongopbm.Conn().MongoClient().
+		Database(defs.DB).
+		Collection(defs.RestoresCollection).
+		DeleteMany(ctx, bson.M{})
+	if err != nil {
+		stdlog.Fatalln("clear restore history:", err)
+	}
+}
+
+func (c *Cluster) assertBackupEncryption(ctx context.Context, bcpName string, expected encrypt.EncryptionType) {
+	meta, err := c.mongopbm.GetBackupMeta(ctx, bcpName)
+	if err != nil {
+		stdlog.Fatalln("get backup meta:", err)
+	}
+	if meta.Encryption != expected {
+		stdlog.Fatalf("backup %s encryption mismatch: got %q, want %q", bcpName, meta.Encryption, expected)
+	}
+	stdlog.Printf("backup %s reports encryption %q", bcpName, meta.Encryption)
+}
+
+func (c *Cluster) assertStorageEncrypted(ctx context.Context, bcpName string) {
+	stg, err := c.mongopbm.Storage(ctx)
+	if err != nil {
+		stdlog.Fatalln("get storage:", err)
+	}
+
+	files, err := stg.List(bcpName, "")
+	if err != nil {
+		stdlog.Fatalln("list backup files:", err)
+	}
+	if len(files) == 0 {
+		stdlog.Fatalf("no files found on storage for backup %s", bcpName)
+	}
+
+	encrypted, checked, skipped := 0, 0, 0
+	for _, f := range files {
+		if f.Size <= 0 || f.Size > maxObjectScanBytes {
+			skipped++
+			continue
+		}
+		name := bcpName + "/" + f.Name
+		r, err := stg.SourceReader(name)
+		if err != nil {
+			stdlog.Fatalf("read %s: %v", name, err)
+		}
+		// Partial reads can stall
+		data, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			stdlog.Fatalf("read %s: %v", name, err)
+		}
+		checked++
+		if bytes.HasPrefix(data, pbmEncryptedMagic) {
+			encrypted++
+		}
+	}
+
+	if encrypted == 0 {
+		stdlog.Fatalf("no encrypted data objects found for backup %s (checked %d, skipped %d large or empty of %d)",
+			bcpName, checked, skipped, len(files))
+	}
+	stdlog.Printf("%d/%d checked objects of backup %s carry the PBM encryption header (%d large or empty skipped)",
+		encrypted, checked, bcpName, skipped)
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/minio v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/mongodb v0.42.0
 	go.mongodb.org/mongo-driver/v2 v2.6.0
+	golang.org/x/crypto v0.49.0
 	golang.org/x/mod v0.33.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
@@ -157,7 +158,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -134,6 +134,7 @@ func (b *Backup) Init(
 		Namespaces:       bcp.Namespaces,
 		SelUsersAndRoles: bcp.UsersAndRoles,
 		Compression:      bcp.Compression,
+		Encryption:       bcp.Encryption,
 		Store: Storage{
 			Name:        b.config.Name,
 			IsProfile:   b.config.IsProfile,

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -112,8 +112,12 @@ func (b *Backup) doLogical(
 				estimatedSize = 1 << 30
 			}
 
-			return storage.UploadWithOpts(ctx, w, stg, bcp.Compression, bcp.CompressionLevel, filename,
-				int64(estimatedSize), nil, nil)
+			passphrase, err := b.config.EncryptionPassphrase()
+			if err != nil {
+				return 0, errors.Wrap(err, "resolve encryption passphrase")
+			}
+			return storage.UploadWithOpts(ctx, w, stg, bcp.Compression, bcp.CompressionLevel,
+				bcp.Encryption, passphrase, filename, int64(estimatedSize), nil, nil)
 		})
 	// ensure slicer is stopped in any case (done, error or canceled)
 	defer stopOplogSlicer() //nolint:errcheck
@@ -178,6 +182,11 @@ func (b *Backup) doLogical(
 		}
 	}
 
+	passphrase, err := b.config.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
 	snapshotSize, err := snapshot.UploadDump(ctx,
 		func(newFile archive.NewWriter) error {
 			bcp, err := archive.NewBackup(ctx, archive.BackupOptions{
@@ -202,7 +211,9 @@ func (b *Backup) doLogical(
 			return stg.Save(filepath, r, storage.Size(sizeHints[ns]))
 		},
 		bcp.Compression,
-		bcp.CompressionLevel)
+		bcp.CompressionLevel,
+		bcp.Encryption,
+		passphrase)
 	if err != nil {
 		return errors.Wrap(err, "dump")
 	}

--- a/pbm/backup/physical.go
+++ b/pbm/backup/physical.go
@@ -20,6 +20,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
@@ -433,7 +434,8 @@ func (b *Backup) handleExternal(
 	if bcp.Filelist {
 		// keep filelist on backup storage for listing files to copy
 		bcpStoragePath := path.Join(bcp.Name, rsMeta.Name, FilelistName)
-		_, err = storage.Upload(ctx, filelist, stg, compress.CompressionTypeNone, nil, bcpStoragePath)
+		_, err = storage.Upload(ctx, filelist, stg, compress.CompressionTypeNone, nil,
+			encrypt.EncryptionTypeNone, "", bcpStoragePath)
 		if err != nil {
 			return errors.Wrapf(err, "save filelist to storage: %q", bcpStoragePath)
 		}
@@ -527,6 +529,11 @@ func (b *Backup) uploadPhysical(
 		l.Info("uploading data")
 	}
 
+	passphrase, err := b.config.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
 	dataFiles, err := uploadFiles(
 		ctx,
 		data,
@@ -538,6 +545,8 @@ func (b *Backup) uploadPhysical(
 		bcp.CompressionLevel,
 		b.getBackupBufSize(),
 		numWorkers,
+		bcp.Encryption,
+		passphrase,
 	)
 	if err != nil {
 		return errors.Wrap(err, "upload data files")
@@ -556,6 +565,8 @@ func (b *Backup) uploadPhysical(
 		bcp.CompressionLevel,
 		b.getBackupBufSize(),
 		numWorkers,
+		bcp.Encryption,
+		passphrase,
 	)
 	if err != nil {
 		return errors.Wrap(err, "upload journal files")
@@ -578,7 +589,8 @@ func (b *Backup) uploadPhysical(
 	}
 
 	filelistPath := path.Join(bcp.Name, rsMeta.Name, FilelistName)
-	flSize, err := storage.Upload(ctx, filelist, stg, compress.CompressionTypeNone, nil, filelistPath)
+	flSize, err := storage.Upload(ctx, filelist, stg, compress.CompressionTypeNone, nil,
+		encrypt.EncryptionTypeNone, "", filelistPath)
 	if err != nil {
 		return errors.Wrapf(err, "upload filelist %q", filelistPath)
 	}
@@ -734,6 +746,8 @@ func uploadFiles(
 	comprL *int,
 	bufSize int,
 	numWorkers int,
+	encrT encrypt.EncryptionType,
+	passphrase string,
 ) ([]File, error) {
 	if len(files) == 0 {
 		return nil, nil
@@ -786,6 +800,8 @@ func uploadFiles(
 				bufs.cp,
 				bufs.save,
 				bufs.fsSave,
+				encrT,
+				passphrase,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "upload file `%s`", s.file.Name)
@@ -814,6 +830,8 @@ func writeFile(
 	cpBuf []byte,
 	saveBuf []byte,
 	fsSaveBuf []byte,
+	encryption encrypt.EncryptionType,
+	passphrase string,
 ) (*File, error) {
 	fstat, err := os.Stat(file.Name)
 	if err != nil {
@@ -836,8 +854,8 @@ func writeFile(
 	if len(cpBuf) > 0 {
 		src = NewFileReader(*file, cpBuf)
 	}
-	_, err = storage.UploadWithOpts(ctx, src, stg, compression, compressLevel, dst,
-		sz, saveBuf, fsSaveBuf)
+	_, err = storage.UploadWithOpts(ctx, src, stg, compression, compressLevel,
+		encryption, passphrase, dst, sz, saveBuf, fsSaveBuf)
 	if err != nil {
 		return nil, errors.Wrap(err, "upload file")
 	}

--- a/pbm/backup/types.go
+++ b/pbm/backup/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/config"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
@@ -42,6 +43,7 @@ type BackupMeta struct {
 	SelUsersAndRoles bool                     `bson:"sel_users_and_roles,omitempty" json:"sel_users_and_roles,omitempty"`
 	Replsets         []BackupReplset          `bson:"replsets" json:"replsets"`
 	Compression      compress.CompressionType `bson:"compression" json:"compression"`
+	Encryption       encrypt.EncryptionType   `bson:"encryption,omitempty" json:"encryption,omitempty"`
 	Store            Storage                  `bson:"store" json:"store"`
 	Size             int64                    `bson:"size" json:"size"`
 	SizeUncompressed int64                    `bson:"size_uncompressed" json:"size_uncompressed"`

--- a/pbm/config/config.go
+++ b/pbm/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -20,6 +21,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/azure"
@@ -81,6 +83,31 @@ type Config struct {
 	Restore *RestoreConf `bson:"restore,omitempty" json:"restore,omitempty" yaml:"restore,omitempty"`
 
 	Epoch bson.Timestamp `bson:"epoch" json:"-" yaml:"-"`
+}
+
+// EnvEncryptionPassphrase is the environment variable used to read the
+// encryption passphrase
+const EnvEncryptionPassphrase = "PBM_ENCRYPTION_PASSPHRASE"
+
+// redactedPassphrase to mask sensitive information in the logs
+const redactedPassphrase = "**REDACTED**"
+
+// EncryptionType returns the encryption algorithm
+func (c *Config) EncryptionType() encrypt.EncryptionType {
+	if c == nil || c.Backup == nil || c.Backup.Encryption == "" {
+		return defs.DefaultEncryption
+	}
+	return c.Backup.Encryption
+}
+
+// EncryptionPassphrase returns the passphrase used to derive the encryption
+// key, resolved from the environment, passphrase file or config, or an empty
+// string when encryption is not configured
+func (c *Config) EncryptionPassphrase() (string, error) {
+	if c == nil || c.Backup == nil {
+		return "", nil
+	}
+	return c.Backup.resolvePassphrase()
 }
 
 func Parse(r io.Reader) (*Config, error) {
@@ -517,14 +544,55 @@ func (cfg *RestoreConf) GetNumParallelFiles() int {
 
 //nolint:lll
 type BackupConf struct {
-	OplogSpanMin     float64                  `bson:"oplogSpanMin" json:"oplogSpanMin" yaml:"oplogSpanMin"`
-	Priority         Priority                 `bson:"priority,omitempty" json:"priority,omitempty" yaml:"priority,omitempty"`
-	Timeouts         *BackupTimeouts          `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
-	Compression      compress.CompressionType `bson:"compression,omitempty" json:"compression,omitempty" yaml:"compression,omitempty"`
-	CompressionLevel *int                     `bson:"compressionLevel,omitempty" json:"compressionLevel,omitempty" yaml:"compressionLevel,omitempty"`
+	OplogSpanMin             float64                  `bson:"oplogSpanMin" json:"oplogSpanMin" yaml:"oplogSpanMin"`
+	Priority                 Priority                 `bson:"priority,omitempty" json:"priority,omitempty" yaml:"priority,omitempty"`
+	Timeouts                 *BackupTimeouts          `bson:"timeouts,omitempty" json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
+	Compression              compress.CompressionType `bson:"compression,omitempty" json:"compression,omitempty" yaml:"compression,omitempty"`
+	CompressionLevel         *int                     `bson:"compressionLevel,omitempty" json:"compressionLevel,omitempty" yaml:"compressionLevel,omitempty"`
+	Encryption               encrypt.EncryptionType   `bson:"encryption,omitempty" json:"encryption,omitempty" yaml:"encryption,omitempty"`
+	EncryptionPassphrase     string                   `bson:"encryptionPassphrase,omitempty" json:"encryptionPassphrase,omitempty" yaml:"encryptionPassphrase,omitempty"`
+	EncryptionPassphraseFile string                   `bson:"encryptionPassphraseFile,omitempty" json:"encryptionPassphraseFile,omitempty" yaml:"encryptionPassphraseFile,omitempty"`
 
 	NumParallelCollections int `bson:"numParallelCollections" json:"numParallelCollections,omitempty" yaml:"numParallelCollections,omitempty"`
 	NumParallelFiles       int `bson:"numParallelFiles" json:"numParallelFiles,omitempty" yaml:"numParallelFiles,omitempty"`
+}
+
+// redact to redact sensitive information of the backup config
+func (cfg BackupConf) redact() BackupConf {
+	r := BackupConf(cfg)
+	if r.EncryptionPassphrase != "" {
+		r.EncryptionPassphrase = redactedPassphrase
+	}
+	return r
+}
+
+// MarshalYAML masks the encryption passphrase
+// bson persistence is unaffected
+func (cfg BackupConf) MarshalYAML() (interface{}, error) {
+	return cfg.redact(), nil
+}
+
+// MarshalJSON masks the encryption passphrase
+// bson persistence is unaffected
+func (cfg BackupConf) MarshalJSON() ([]byte, error) {
+	return json.Marshal(cfg.redact())
+}
+
+// resolvePassphrase returns the passphrase from, in priority order, the
+// PBM_ENCRYPTION_PASSPHRASE environment variable, the EncryptionPassphraseFile,
+// or the inline EncryptionPassphrase field
+func (cfg *BackupConf) resolvePassphrase() (string, error) {
+	if v := os.Getenv(EnvEncryptionPassphrase); v != "" {
+		return v, nil
+	}
+	if cfg.EncryptionPassphraseFile != "" {
+		b, err := os.ReadFile(cfg.EncryptionPassphraseFile)
+		if err != nil {
+			return "", errors.Wrap(err, "read passphrase file")
+		}
+		return strings.TrimRight(string(b), "\r\n"), nil
+	}
+	return cfg.EncryptionPassphrase, nil
 }
 
 func (cfg *BackupConf) Clone() *BackupConf {
@@ -617,6 +685,10 @@ func GetConfig(ctx context.Context, m connect.Client) (*Config, error) {
 		cfg.PITR.CompressionLevel = cfg.Backup.CompressionLevel
 	}
 
+	if cfg.Backup.Encryption == "" {
+		cfg.Backup.Encryption = defs.DefaultEncryption
+	}
+
 	return cfg, nil
 }
 
@@ -643,6 +715,18 @@ func SetConfig(ctx context.Context, m connect.Client, cfg *Config) error {
 	if cfg.Restore != nil {
 		if err := ValidateIndexCommitQuorum(cfg.Restore.IndexCommitQuorum); err != nil {
 			return err
+		}
+	}
+
+	if cfg.Backup != nil {
+		if t := string(cfg.Backup.Encryption); t != "" && !encrypt.IsValidEncryptionType(t) {
+			return errors.Errorf("unsupported encryption type: %q", t)
+		}
+		if cfg.Backup.Encryption != "" && cfg.Backup.Encryption != encrypt.EncryptionTypeNone &&
+			cfg.Backup.EncryptionPassphrase == "" && cfg.Backup.EncryptionPassphraseFile == "" &&
+			os.Getenv(EnvEncryptionPassphrase) == "" {
+			return errors.Errorf("encryption type %q requires a passphrase: set backup.encryptionPassphrase, "+
+				"backup.encryptionPassphraseFile, or the %s env var", cfg.Backup.Encryption, EnvEncryptionPassphrase)
 		}
 	}
 
@@ -803,6 +887,10 @@ func confSetPITR(ctx context.Context, m connect.Client, value bool) error {
 func GetConfigVar(ctx context.Context, m connect.Client, key string) (interface{}, error) {
 	if !validateConfigKey(key) {
 		return nil, errors.Errorf("invalid config key: %s", key)
+	}
+
+	if key == "backup.encryptionPassphrase" {
+		return redactedPassphrase, nil
 	}
 
 	bts, err := m.ConfigCollection().

--- a/pbm/ctrl/cmd.go
+++ b/pbm/ctrl/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/config"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
 
@@ -134,6 +135,7 @@ type BackupCmd struct {
 	Namespaces       []string                 `bson:"nss,omitempty"`
 	Compression      compress.CompressionType `bson:"compression"`
 	CompressionLevel *int                     `bson:"level,omitempty"`
+	Encryption       encrypt.EncryptionType   `bson:"encryption,omitempty"`
 	NumParallelColls *int32                   `bson:"numParallelColls,omitempty"`
 	NumParallelFiles *int32                   `bson:"numParallelFiles,omitempty"`
 	Filelist         bool                     `bson:"filelist,omitempty"`

--- a/pbm/defs/defs.go
+++ b/pbm/defs/defs.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 )
 
@@ -201,3 +202,5 @@ const (
 )
 
 const DefaultCompression = compress.CompressionTypeS2
+
+const DefaultEncryption = encrypt.EncryptionTypeNone

--- a/pbm/encrypt/encrypt.go
+++ b/pbm/encrypt/encrypt.go
@@ -1,0 +1,427 @@
+package encrypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"math"
+
+	"golang.org/x/crypto/argon2"
+	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/percona/percona-backup-mongodb/pbm/errors"
+)
+
+type EncryptionType string
+
+const (
+	EncryptionTypeNone              EncryptionType = "none"
+	EncryptionTypeAES256GCM         EncryptionType = "aes-256-gcm"
+	EncryptionTypeXChaCha20Poly1305 EncryptionType = "xchacha20-poly1305"
+)
+
+const (
+	keyLen     = 32 // AES-256 and XChaCha20 both take a 32 byte key
+	saltLen    = 16 // key derivation function salt
+	counterLen = 4  // per-chunk counter appended to the nonce prefix
+	chunkSize  = 64 * 1024
+
+	// Argon2id cost parameters
+	// Memory is the dominant defense against offline cracking of a low-entropy
+	// passphrase. The target is ~64 MiB and a few hundred ms to derive.
+	// Parallelism is fixed so derivation is reproducible.
+	argonTime    = 3
+	argonMemory  = 64 * 1024 // KiB
+	argonThreads = 4
+
+	// The frame header is a big-endian uint32 (frameHeaderLen bytes). The high
+	// bit flags the final chunk, the remaining 31 bits hold the ciphertext
+	// length.
+	frameHeaderLen = 4
+	finalBit       = uint32(1) << 31
+	maxFrameLen    = finalBit - 1
+
+	formatVersion byte = 1
+)
+
+// magic identifies a PBM encrypted stream and guards against feeding the
+// decryptor unrelated data.
+var magic = [4]byte{'P', 'B', 'M', 'E'}
+
+// algorithm identifiers stored in the stream header. The algorithm is read
+// from the authenticated header on decrypt, so the cipher is bound to the
+// ciphertext.
+const (
+	algoAES256GCM         byte = 1
+	algoXChaCha20Poly1305 byte = 2
+)
+
+func algoID(encryption EncryptionType) (byte, bool) {
+	switch encryption {
+	case EncryptionTypeAES256GCM:
+		return algoAES256GCM, true
+	case EncryptionTypeXChaCha20Poly1305:
+		return algoXChaCha20Poly1305, true
+	default:
+		return 0, false
+	}
+}
+
+func algoType(id byte) (EncryptionType, bool) {
+	switch id {
+	case algoAES256GCM:
+		return EncryptionTypeAES256GCM, true
+	case algoXChaCha20Poly1305:
+		return EncryptionTypeXChaCha20Poly1305, true
+	default:
+		return "", false
+	}
+}
+
+// Byte offsets of the constant-length fields in the stream header.
+const (
+	versionOffset   = len(magic)
+	algorithmOffset = versionOffset + 1
+	saltOffset      = algorithmOffset + 1
+)
+
+// fixedHeaderLen is the size of the constant-length part of the stream header:
+// magic + version + algorithm + salt. It is followed by a nonce prefix whose
+// length depends on the cipher's nonce size.
+const fixedHeaderLen = saltOffset + saltLen
+
+func IsValidEncryptionType(s string) bool {
+	switch EncryptionType(s) {
+	case
+		EncryptionTypeNone,
+		EncryptionTypeAES256GCM,
+		EncryptionTypeXChaCha20Poly1305:
+		return true
+	}
+
+	return false
+}
+
+// deriveKey turns a passphrase into a 32 byte key using Argon2id and the
+// per-stream salt
+func deriveKey(passphrase string, salt []byte) ([]byte, error) {
+	if passphrase == "" {
+		return nil, errors.New("empty passphrase")
+	}
+	return argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemory, argonThreads, keyLen), nil
+}
+
+// newAEAD builds the AEAD cipher for the given encryption type and key
+func newAEAD(encryption EncryptionType, key []byte) (cipher.AEAD, error) {
+	switch encryption {
+	case EncryptionTypeAES256GCM:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "new aes cipher")
+		}
+		gcm, err := cipher.NewGCM(block)
+		return gcm, errors.Wrap(err, "new aes gcm")
+	case EncryptionTypeXChaCha20Poly1305:
+		aead, err := chacha20poly1305.NewX(key)
+		return aead, errors.Wrap(err, "new xchacha20poly1305")
+	default:
+		return nil, errors.Errorf("unsupported encryption type %q", encryption)
+	}
+}
+
+// Encrypt makes a encrypting writer from the given one
+func Encrypt(w io.Writer, encryption EncryptionType, passphrase string) (io.WriteCloser, error) {
+	switch encryption {
+	case EncryptionTypeAES256GCM, EncryptionTypeXChaCha20Poly1305:
+		algo, ok := algoID(encryption)
+		if !ok {
+			return nil, errors.Errorf("unsupported encryption type %q", encryption)
+		}
+
+		salt := make([]byte, saltLen)
+		if _, err := rand.Read(salt); err != nil {
+			return nil, errors.Wrap(err, "generate salt")
+		}
+
+		key, err := deriveKey(passphrase, salt)
+		if err != nil {
+			return nil, err
+		}
+		aead, err := newAEAD(encryption, key)
+		if err != nil {
+			return nil, err
+		}
+
+		noncePrefix := make([]byte, aead.NonceSize()-counterLen)
+		if _, err := rand.Read(noncePrefix); err != nil {
+			return nil, errors.Wrap(err, "generate nonce prefix")
+		}
+
+		header := make([]byte, 0, fixedHeaderLen+len(noncePrefix))
+		header = append(header, magic[:]...)
+		header = append(header, formatVersion)
+		header = append(header, algo)
+		header = append(header, salt...)
+		header = append(header, noncePrefix...)
+
+		return &aeadWriter{
+			w:           w,
+			aead:        aead,
+			noncePrefix: noncePrefix,
+			header:      header,
+			buf:         make([]byte, 0, chunkSize),
+		}, nil
+	case EncryptionTypeNone:
+		fallthrough
+	default:
+		return nopWriteCloser{w}, nil
+	}
+}
+
+// Decrypt wraps the given reader by a decrypting io.ReadCloser
+func Decrypt(r io.Reader, encryption EncryptionType, passphrase string) (io.ReadCloser, error) {
+	switch encryption {
+	case EncryptionTypeAES256GCM, EncryptionTypeXChaCha20Poly1305:
+		header := make([]byte, fixedHeaderLen)
+		if _, err := io.ReadFull(r, header); err != nil {
+			return nil, errors.Wrap(err, "read header")
+		}
+		if [4]byte(header[:versionOffset]) != magic {
+			return nil, errors.New("not a PBM encrypted stream")
+		}
+		if header[versionOffset] != formatVersion {
+			return nil, errors.Errorf("unsupported encryption format version %d", header[versionOffset])
+		}
+
+		streamEncryption, ok := algoType(header[algorithmOffset])
+		if !ok {
+			return nil, errors.Errorf("unknown encryption algorithm id %d", header[algorithmOffset])
+		}
+		// Avoid algorithm downgrade by checking the authenticated header
+		if streamEncryption != encryption {
+			return nil, errors.Errorf("encryption algorithm mismatch: stream is %q, expected %q",
+				streamEncryption, encryption)
+		}
+		salt := header[saltOffset : saltOffset+saltLen]
+
+		key, err := deriveKey(passphrase, salt)
+		if err != nil {
+			return nil, err
+		}
+		aead, err := newAEAD(streamEncryption, key)
+		if err != nil {
+			return nil, err
+		}
+
+		noncePrefix := make([]byte, aead.NonceSize()-counterLen)
+		if _, err := io.ReadFull(r, noncePrefix); err != nil {
+			return nil, errors.Wrap(err, "read nonce prefix")
+		}
+		header = append(header, noncePrefix...)
+
+		return &aeadReader{r: r, aead: aead, noncePrefix: noncePrefix, header: header}, nil
+	case EncryptionTypeNone:
+		fallthrough
+	default:
+		return io.NopCloser(r), nil
+	}
+}
+
+// aeadWriter buffers plaintext into fixed-size chunks, sealing each with a
+// distinct counter-based nonce. Every chunk is authenticated with the stream
+// header (magic, version, algorithm, salt, nonce prefix) and a one-byte
+// "final" flag as additional data, so a tampered header or a truncated stream
+// cannot be passed off as valid.
+type aeadWriter struct {
+	w             io.Writer
+	aead          cipher.AEAD
+	noncePrefix   []byte
+	header        []byte
+	headerWritten bool
+	counter       uint32
+	exhausted     bool
+	buf           []byte
+	closed        bool
+}
+
+func (e *aeadWriter) Write(p []byte) (int, error) {
+	if e.closed {
+		return 0, errors.New("write to closed encrypt writer")
+	}
+	e.buf = append(e.buf, p...)
+	for len(e.buf) >= chunkSize {
+		if err := e.seal(e.buf[:chunkSize], false); err != nil {
+			return 0, err
+		}
+		e.buf = e.buf[chunkSize:]
+	}
+	return len(p), nil
+}
+
+func (e *aeadWriter) Close() error {
+	if e.closed {
+		return nil
+	}
+	e.closed = true
+	return e.seal(e.buf, true)
+}
+
+func (e *aeadWriter) seal(plaintext []byte, final bool) error {
+	if e.exhausted {
+		return errors.New("chunk counter overflow: stream too large to encrypt safely")
+	}
+
+	if !e.headerWritten {
+		if _, err := e.w.Write(e.header); err != nil {
+			return errors.Wrap(err, "write header")
+		}
+		e.headerWritten = true
+	}
+
+	counter := e.counter
+	nonce := e.nextNonce()
+	ciphertext := e.aead.Seal(nil, nonce, plaintext, chunkAAD(e.header, counter, final))
+	if uint32(len(ciphertext)) > maxFrameLen {
+		return errors.New("encrypted chunk too large")
+	}
+
+	frameHeader := uint32(len(ciphertext))
+	if final {
+		frameHeader |= finalBit
+	}
+
+	var hdr [frameHeaderLen]byte
+	binary.BigEndian.PutUint32(hdr[:], frameHeader)
+	if _, err := e.w.Write(hdr[:]); err != nil {
+		return errors.Wrap(err, "write frame header")
+	}
+	if _, err := e.w.Write(ciphertext); err != nil {
+		return errors.Wrap(err, "write frame")
+	}
+	return nil
+}
+
+func (e *aeadWriter) nextNonce() []byte {
+	nonce := make([]byte, e.aead.NonceSize())
+	copy(nonce, e.noncePrefix)
+	binary.BigEndian.PutUint32(nonce[len(e.noncePrefix):], e.counter)
+	if e.counter == math.MaxUint32 {
+		e.exhausted = true
+	} else {
+		e.counter++
+	}
+	return nonce
+}
+
+// aeadReader reads framed chunks, verifies and decrypts each, and surfaces the
+// plaintext as a stream
+type aeadReader struct {
+	r           io.Reader
+	aead        cipher.AEAD
+	noncePrefix []byte
+	header      []byte
+	counter     uint32
+	exhausted   bool
+	buf         []byte
+	eof         bool
+}
+
+func (d *aeadReader) Read(p []byte) (int, error) {
+	for len(d.buf) == 0 {
+		if d.eof {
+			return 0, io.EOF
+		}
+		if err := d.readFrame(); err != nil {
+			return 0, err
+		}
+	}
+	n := copy(p, d.buf)
+	d.buf = d.buf[n:]
+	return n, nil
+}
+
+func (d *aeadReader) Close() error { return nil }
+
+func (d *aeadReader) readFrame() error {
+	var hdr [frameHeaderLen]byte
+	if _, err := io.ReadFull(d.r, hdr[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return errors.New("truncated encrypted stream")
+		}
+		return errors.Wrap(err, "read frame header")
+	}
+	frameHeader := binary.BigEndian.Uint32(hdr[:])
+	final := frameHeader&finalBit != 0
+	length := frameHeader &^ finalBit
+
+	// The frame header is not authenticated, so a tampered stream can claim any
+	// length. Reject anything larger than a legitimate sealed chunk before
+	// allocating, otherwise a forged length triggers an unbounded allocation.
+	if length > uint32(chunkSize+d.aead.Overhead()) {
+		return errors.Errorf("encrypted frame length exceeds maximum")
+	}
+
+	ciphertext := make([]byte, length)
+	if _, err := io.ReadFull(d.r, ciphertext); err != nil {
+		return errors.Wrap(err, "read frame")
+	}
+
+	if d.exhausted {
+		return errors.New("chunk counter overflow: stream has too many chunks")
+	}
+	counter := d.counter
+	nonce := d.nextNonce()
+	plaintext, err := d.aead.Open(nil, nonce, ciphertext, chunkAAD(d.header, counter, final))
+	if err != nil {
+		return errors.Wrap(err, "decrypt frame")
+	}
+
+	d.buf = plaintext
+	if final {
+		d.eof = true
+		// The final chunk must be the end of the stream. Anything trailing it
+		// is unauthenticated and indicates tampering or a spliced stream.
+		var probe [1]byte
+		if _, err := io.ReadFull(d.r, probe[:]); !errors.Is(err, io.EOF) {
+			if err == nil {
+				return errors.New("trailing data after final chunk")
+			}
+			return errors.Wrap(err, "check for trailing data")
+		}
+	}
+	return nil
+}
+
+func (d *aeadReader) nextNonce() []byte {
+	nonce := make([]byte, d.aead.NonceSize())
+	copy(nonce, d.noncePrefix)
+	binary.BigEndian.PutUint32(nonce[len(d.noncePrefix):], d.counter)
+	if d.counter == math.MaxUint32 {
+		d.exhausted = true
+	} else {
+		d.counter++
+	}
+	return nonce
+}
+
+// chunkAAD returns the additional authenticated data for a chunk:
+//   - The full stream header so the algorithm, version, salt, and nonce prefix
+//     cannot be tampered with
+//   - The chunk counter so chunks cannot be reordered or spliced in from
+//     another point in the stream
+//   - A one-byte final flag so dropping the last chunk is detectable
+func chunkAAD(header []byte, counter uint32, final bool) []byte {
+	aad := make([]byte, len(header)+counterLen+1)
+	copy(aad, header)
+	binary.BigEndian.PutUint32(aad[len(header):], counter)
+	if final {
+		aad[len(header)+counterLen] = 1
+	}
+	return aad
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }

--- a/pbm/encrypt/encrypt_test.go
+++ b/pbm/encrypt/encrypt_test.go
@@ -1,0 +1,339 @@
+package encrypt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"testing"
+)
+
+const passphrase = "correct horse battery staple"
+
+func allTypes() []EncryptionType {
+	return []EncryptionType{
+		EncryptionTypeNone,
+		EncryptionTypeAES256GCM,
+		EncryptionTypeXChaCha20Poly1305,
+	}
+}
+
+func encryptingTypes() []EncryptionType {
+	return []EncryptionType{
+		EncryptionTypeAES256GCM,
+		EncryptionTypeXChaCha20Poly1305,
+	}
+}
+
+// noncePrefixLen is the length of the random nonce prefix stored in the header
+// for the cipher. It depends on the AEAD nonce size.
+func noncePrefixLen(t *testing.T, enc EncryptionType) int {
+	t.Helper()
+	aead, err := newAEAD(enc, make([]byte, keyLen))
+	if err != nil {
+		t.Fatalf("%s: newAEAD: %v", enc, err)
+	}
+	return aead.NonceSize() - counterLen
+}
+
+// roundTrip encrypts then decrypts data
+func roundTrip(t *testing.T, enc EncryptionType, plaintext []byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w, err := Encrypt(&buf, enc, passphrase)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := w.Write(plaintext); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if enc != EncryptionTypeNone && len(plaintext) >= 64 && bytes.Contains(buf.Bytes(), plaintext) {
+		t.Fatalf("%s: ciphertext contains plaintext", enc)
+	}
+
+	r, err := Decrypt(&buf, enc, passphrase)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("%s: round trip mismatch: got %d bytes, want %d", enc, len(got), len(plaintext))
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	sizes := []int{0, 1, chunkSize - 1, chunkSize, chunkSize + 1, 5 * chunkSize, 5*chunkSize + 123}
+	for _, enc := range allTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			for _, size := range sizes {
+				data := make([]byte, size)
+				if _, err := rand.Read(data); err != nil {
+					t.Fatal(err)
+				}
+				roundTrip(t, enc, data)
+			}
+		})
+	}
+}
+
+// TestHeaderWrittenLazily guards a deadlock. Encrypt must not write
+// the stream header to the writer until the first frame. Storage upload builds
+// the encrypting writer on the write end of an unbuffered io.Pipe and only
+// then starts the reader, so an eager header write blocks forever.
+func TestHeaderWrittenLazily(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, err := Encrypt(&buf, enc, passphrase)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			if buf.Len() != 0 {
+				t.Fatalf("Encrypt wrote %d bytes before any frame, want 0", buf.Len())
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if buf.Len() == 0 {
+				t.Fatal("nothing written after Close")
+			}
+		})
+	}
+}
+
+// TestEncryptThroughPipe reproduces the storage.Upload wiring. The encrypting
+// writer is created on a pipe before its reader goroutine starts. With an eager
+// header write this deadlocks.
+func TestEncryptThroughPipe(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			plaintext := make([]byte, 3*chunkSize+7)
+			if _, err := rand.Read(plaintext); err != nil {
+				t.Fatal(err)
+			}
+
+			r, pw := io.Pipe()
+			w, err := Encrypt(pw, enc, passphrase)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+
+			go func() {
+				_, werr := w.Write(plaintext)
+				cerr := w.Close()
+				pw.CloseWithError(errors.Join(werr, cerr))
+			}()
+
+			dr, err := Decrypt(r, enc, passphrase)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			got, err := io.ReadAll(dr)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if !bytes.Equal(got, plaintext) {
+				t.Fatalf("round trip mismatch: got %d bytes, want %d", len(got), len(plaintext))
+			}
+		})
+	}
+}
+
+func TestWrongPassphraseFails(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, err := Encrypt(&buf, enc, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.Write([]byte("top secret backup payload"))
+			w.Close()
+
+			r, err := Decrypt(&buf, enc, "wrong passphrase")
+			if err != nil {
+				t.Fatalf("Decrypt setup: %v", err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected authentication failure with wrong passphrase")
+			}
+		})
+	}
+}
+
+func TestTruncationDetected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, _ := Encrypt(&buf, enc, passphrase)
+			data := make([]byte, 3*chunkSize)
+			rand.Read(data)
+			w.Write(data)
+			w.Close()
+
+			// Drop the final frame entirely by keeping only the header and first frame.
+			full := buf.Bytes()
+			// header + nonce prefix + partial
+			truncated := full[:fixedHeaderLen+noncePrefixLen(t, enc)+frameHeaderLen+chunkSize/2]
+
+			r, err := Decrypt(bytes.NewReader(truncated), enc, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected error on truncated stream")
+			}
+		})
+	}
+}
+
+func TestEmptyPassphraseRejected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			if _, err := Encrypt(io.Discard, enc, ""); err == nil {
+				t.Fatal("expected error for empty passphrase")
+			}
+		})
+	}
+}
+
+func TestAlgorithmMismatchRejected(t *testing.T) {
+	pairs := []struct{ stream, hint EncryptionType }{
+		{EncryptionTypeAES256GCM, EncryptionTypeXChaCha20Poly1305},
+		{EncryptionTypeXChaCha20Poly1305, EncryptionTypeAES256GCM},
+	}
+	for _, p := range pairs {
+		t.Run(string(p.stream)+"_as_"+string(p.hint), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, err := Encrypt(&buf, p.stream, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.Write([]byte("top secret backup payload"))
+			w.Close()
+
+			if _, err := Decrypt(&buf, p.hint, passphrase); err == nil {
+				t.Fatal("expected mismatch error when decrypt hint disagrees with stream algorithm")
+			}
+		})
+	}
+}
+
+func TestCounterOverflowRejected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			wc, err := Encrypt(&buf, enc, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := wc.(*aeadWriter)
+			w.counter = math.MaxUint32
+
+			if _, err := w.Write(make([]byte, chunkSize)); err != nil {
+				t.Fatalf("sealing the last valid chunk should succeed: %v", err)
+			}
+			if _, err := w.Write(make([]byte, chunkSize)); err == nil {
+				t.Fatal("expected counter overflow error on the chunk past the limit")
+			}
+		})
+	}
+}
+
+func TestTrailingDataDetected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, _ := Encrypt(&buf, enc, passphrase)
+			w.Write([]byte("top secret backup payload"))
+			w.Close()
+
+			extended := append(buf.Bytes(), 0x00)
+
+			r, err := Decrypt(bytes.NewReader(extended), enc, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected failure for data appended after the final chunk")
+			}
+		})
+	}
+}
+
+func TestChunkReorderDetected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			var buf bytes.Buffer
+			w, _ := Encrypt(&buf, enc, passphrase)
+			data := make([]byte, 2*chunkSize+100)
+			rand.Read(data)
+			w.Write(data)
+			w.Close()
+
+			full := buf.Bytes()
+			hdrLen := fixedHeaderLen + noncePrefixLen(t, enc)
+			body := full[hdrLen:]
+
+			frame := func(off int) []byte {
+				length := int(binary.BigEndian.Uint32(body[off:off+frameHeaderLen]) &^ finalBit)
+				return body[off : off+frameHeaderLen+length]
+			}
+			f0 := frame(0)
+			f1 := frame(len(f0))
+
+			reordered := append([]byte(nil), full[:hdrLen]...)
+			reordered = append(reordered, f1...)
+			reordered = append(reordered, f0...)
+			reordered = append(reordered, body[len(f0)+len(f1):]...)
+
+			r, err := Decrypt(bytes.NewReader(reordered), enc, passphrase)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected failure when chunks are reordered")
+			}
+		})
+	}
+}
+
+// magic, version, algorithm, salt, and nonce prefix are all authenticated,
+// so flipping any header byte must be detected rather than silently
+// changing how the stream is decrypted
+func TestHeaderTamperDetected(t *testing.T) {
+	for _, enc := range encryptingTypes() {
+		t.Run(string(enc), func(t *testing.T) {
+			noncePrefixInterior := fixedHeaderLen + noncePrefixLen(t, enc)/2
+			for _, off := range []int{algorithmOffset, saltOffset, fixedHeaderLen, noncePrefixInterior} {
+				var buf bytes.Buffer
+				w, _ := Encrypt(&buf, enc, passphrase)
+				data := make([]byte, chunkSize)
+				rand.Read(data)
+				w.Write(data)
+				w.Close()
+
+				tampered := append([]byte(nil), buf.Bytes()...)
+				tampered[off] ^= 0xff
+
+				r, err := Decrypt(bytes.NewReader(tampered), enc, passphrase)
+				if err != nil {
+					continue // rejected at setup (e.g. unknown algorithm id)
+				}
+				if _, err := io.ReadAll(r); err == nil {
+					t.Fatalf("expected failure for header tampered at offset %d", off)
+				}
+			}
+		})
+	}
+}

--- a/pbm/oplog/chunk.go
+++ b/pbm/oplog/chunk.go
@@ -18,6 +18,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 )
@@ -27,6 +28,7 @@ type OplogChunk struct {
 	RS          string                   `bson:"rs"`
 	FName       string                   `bson:"fname"`
 	Compression compress.CompressionType `bson:"compression"`
+	Encryption  encrypt.EncryptionType   `bson:"encryption,omitempty"`
 	StartTS     bson.Timestamp           `bson:"start_ts"`
 	EndTS       bson.Timestamp           `bson:"end_ts"`
 	Size        int64                    `bson:"size"`

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -24,6 +24,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
@@ -840,6 +841,7 @@ func (r *Restore) snapshotObjects(bcp *backup.BackupMeta) (string, []oplog.Oplog
 			RS:          r.nodeInfo.SetName,
 			FName:       rsMeta.OplogName,
 			Compression: bcp.Compression,
+			Encryption:  bcp.Encryption,
 			StartTS:     bcp.FirstWriteTS,
 			EndTS:       bcp.LastWriteTS,
 		}}
@@ -859,6 +861,7 @@ func (r *Restore) snapshotObjects(bcp *backup.BackupMeta) (string, []oplog.Oplog
 		chunk.RS = rsMeta.Name
 		chunk.FName = rsMeta.OplogName + "/" + file.Name
 		chunk.Size = file.Size
+		chunk.Encryption = bcp.Encryption
 
 		chunk.StartTS, chunk.EndTS, chunk.Compression, err = backup.ParseChunkName(file.Name)
 		if err != nil {
@@ -1064,6 +1067,11 @@ func (r *Restore) RunSnapshot(
 
 	r.log.Debug("restoring up to %d collections in parallel", r.numParallelColls)
 
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return "", errors.Wrap(err, "resolve encryption passphrase")
+	}
+
 	rdr, err := snapshot.DownloadDump(
 		func(ns string) (io.ReadCloser, error) {
 			stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, r.brief.Me, r.log)
@@ -1095,6 +1103,8 @@ func (r *Restore) RunSnapshot(
 			return rdr, nil
 		},
 		bcp.Compression,
+		bcp.Encryption,
+		passphrase,
 		util.MakeSelectedPred(nss),
 		r.numParallelColls)
 	if err != nil {
@@ -1149,7 +1159,18 @@ func (r *Restore) restoreLegacyArchive(
 	}
 	defer sr.Close()
 
-	rdr, err := compress.Decompress(sr, bcp.Compression)
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	er, err := encrypt.Decrypt(sr, bcp.Encryption, passphrase)
+	if err != nil {
+		return errors.Wrapf(err, "decrypt object %s", dump)
+	}
+	defer er.Close()
+
+	rdr, err := compress.Decompress(er, bcp.Compression)
 	if err != nil {
 		return errors.Wrapf(err, "decompress object %s", dump)
 	}
@@ -1558,6 +1579,10 @@ func (r *Restore) applyOplog(ctx context.Context, ranges []oplogRange, options *
 		return errors.Wrap(err, "define mongo version")
 	}
 	stat := phys.RestoreShardStat{}
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
 	partial, err := applyOplog(ctx,
 		r.nodeConn,
 		ranges,
@@ -1567,7 +1592,8 @@ func (r *Restore) applyOplog(ctx context.Context, ranges []oplogRange, options *
 		r.setcommittedTxn,
 		r.getcommittedTxn,
 		&stat.Txn,
-		&mgoV)
+		&mgoV,
+		passphrase)
 	if err != nil {
 		return errors.Wrap(err, "reply oplog")
 	}

--- a/pbm/restore/logical_cfgsvr_full.go
+++ b/pbm/restore/logical_cfgsvr_full.go
@@ -13,6 +13,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
@@ -63,6 +64,16 @@ func (r *Restore) fullRestoreConfigDatabases(
 		return errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
+
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return errors.Wrap(err, "decrypt")
+	}
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
@@ -140,6 +151,16 @@ func (r *Restore) fullRestoreConfigCollections(
 		return "", errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
+
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return "", errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return "", errors.Wrap(err, "decrypt")
+	}
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
@@ -223,6 +244,16 @@ func (r *Restore) fullRestoreConfigChunks(
 		return errors.Wrap(err, "reading file")
 	}
 	defer rdr.Close()
+
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return errors.Wrap(err, "decrypt")
+	}
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -36,6 +36,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/restore/phys"
@@ -73,6 +74,7 @@ const (
 type files struct {
 	BcpName string
 	Cmpr    compress.CompressionType
+	Enc     encrypt.EncryptionType
 	Data    []backup.File
 
 	// dbpath to cut from destination if there is any (see PBM-1058)
@@ -130,6 +132,8 @@ type PhysRestore struct {
 	bufSize         int
 
 	numParallelFiles int
+
+	passphrase string
 }
 
 func NewPhysical(
@@ -1620,6 +1624,7 @@ type copyOp struct {
 	src   string
 	fMeta backup.File
 	cmpr  compress.CompressionType
+	enc   encrypt.EncryptionType
 }
 
 // planCopyFiles walks r.files in restore order (base -> target) and groups
@@ -1658,7 +1663,7 @@ func (r *PhysRestore) planCopyFiles(setName string) []copyFileJob {
 				continue
 			}
 
-			add(dst, &copyOp{src: src, fMeta: f, cmpr: set.Cmpr})
+			add(dst, &copyOp{src: src, fMeta: f, cmpr: set.Cmpr, enc: set.Enc})
 		}
 	}
 
@@ -1726,7 +1731,7 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 				if err := egCtx.Err(); err != nil {
 					return err
 				}
-				if err := r.copyFile(op.src, job.dst, op.fMeta, op.cmpr, cpBuf); err != nil {
+				if err := r.copyFile(op.src, job.dst, op.fMeta, op.cmpr, op.enc, cpBuf); err != nil {
 					return err
 				}
 			}
@@ -1741,7 +1746,7 @@ func (r *PhysRestore) copyFiles() (*storage.DownloadStat, error) {
 }
 
 // copyFile copies file from the storage into local FS.
-func (r *PhysRestore) copyFile(src, dst string, fMeta backup.File, cType compress.CompressionType, cpbuf []byte) error {
+func (r *PhysRestore) copyFile(src, dst string, fMeta backup.File, cType compress.CompressionType, enc encrypt.EncryptionType, cpbuf []byte) error {
 	r.log.Info("copy <%s> to <%s>", src, dst)
 	sr, err := r.bcpStg.SourceReader(src)
 	if err != nil {
@@ -1749,7 +1754,13 @@ func (r *PhysRestore) copyFile(src, dst string, fMeta backup.File, cType compres
 	}
 	defer sr.Close()
 
-	data, err := compress.Decompress(sr, cType)
+	er, err := encrypt.Decrypt(sr, enc, r.passphrase)
+	if err != nil {
+		return errors.Wrapf(err, "decrypt object %s", src)
+	}
+	defer er.Close()
+
+	data, err := compress.Decompress(er, cType)
 	if err != nil {
 		return errors.Wrapf(err, "decompress object %s", src)
 	}
@@ -1969,7 +1980,8 @@ func (r *PhysRestore) replayPITROnStandalone(
 		r.setcommittedTxn,
 		r.getcommittedTxn,
 		&stat.Txn,
-		&mgoV)
+		&mgoV,
+		r.passphrase)
 	if err != nil {
 		return errors.Wrap(err, "replay oplog")
 	}
@@ -2407,6 +2419,10 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 	}
 
 	r.confOpts = cfg.Restore
+	r.passphrase, err = cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
 
 	r.mongod = "mongod" // run from $PATH by default
 	if r.confOpts.MongodLocation != "" {
@@ -2696,6 +2712,7 @@ func (r *PhysRestore) setBcpFiles(ctx context.Context) error {
 		data := files{
 			BcpName: bcp.Name,
 			Cmpr:    bcp.Compression,
+			Enc:     bcp.Encryption,
 			Data:    []backup.File{},
 		}
 		// PBM-1058

--- a/pbm/restore/restore.go
+++ b/pbm/restore/restore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
@@ -335,6 +336,7 @@ func applyOplog(
 	getTxn getcommittedTxnFn,
 	stat *phys.DistTxnStat,
 	mgoV *version.MongoVersion,
+	passphrase string,
 ) (partial []oplog.Txn, err error) {
 	log := log.LogEventFromContext(ctx)
 	log.Info("starting oplog replay")
@@ -381,9 +383,9 @@ func applyOplog(
 			// PBM versions) won’t be compatible - during the restore, PBM will treat such
 			// files as Snappy (judging by its suffix) but in fact, they are s2 files
 			// and restore will fail with snappy: corrupt input. So we try S2 in such a case.
-			lts, err = replayChunk(chnk.FName, oplogRestore, stg, chnk.Compression)
+			lts, err = replayChunk(chnk.FName, oplogRestore, stg, chnk.Compression, chnk.Encryption, passphrase)
 			if err != nil && errors.Is(err, snappy.ErrCorrupt) {
-				lts, err = replayChunk(chnk.FName, oplogRestore, stg, compress.CompressionTypeS2)
+				lts, err = replayChunk(chnk.FName, oplogRestore, stg, compress.CompressionTypeS2, chnk.Encryption, passphrase)
 			}
 			if err != nil {
 				return nil, errors.Wrapf(err, "replay chunk %v.%v", chnk.StartTS.T, chnk.EndTS.T)
@@ -428,6 +430,8 @@ func replayChunk(
 	oplog *oplog.OplogRestore,
 	stg storage.Storage,
 	c compress.CompressionType,
+	enc encrypt.EncryptionType,
+	passphrase string,
 ) (bson.Timestamp, error) {
 	or, err := stg.SourceReader(file)
 	if err != nil {
@@ -436,7 +440,14 @@ func replayChunk(
 	}
 	defer or.Close()
 
-	oplogReader, err := compress.Decompress(or, c)
+	er, err := encrypt.Decrypt(or, enc, passphrase)
+	if err != nil {
+		lts := bson.Timestamp{}
+		return lts, errors.Wrapf(err, "decrypt object %s", file)
+	}
+	defer er.Close()
+
+	oplogReader, err := compress.Decompress(er, c)
 	if err != nil {
 		lts := bson.Timestamp{}
 		return lts, errors.Wrapf(err, "decompress object %s", file)

--- a/pbm/restore/selective.go
+++ b/pbm/restore/selective.go
@@ -12,6 +12,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/archive"
 	"github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
@@ -129,6 +130,16 @@ func (r *Restore) configsvrRestoreDatabases(
 	}
 	defer rdr.Close()
 
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return err
+	}
+
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return err
@@ -214,6 +225,16 @@ func (r *Restore) configsvrRestoreCollections(
 	}
 	defer rdr.Close()
 
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {
 		return nil, err
@@ -279,6 +300,16 @@ func (r *Restore) configsvrRestoreChunks(
 		return err
 	}
 	defer rdr.Close()
+
+	passphrase, err := r.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
+
+	rdr, err = encrypt.Decrypt(rdr, bcp.Encryption, passphrase)
+	if err != nil {
+		return err
+	}
 
 	rdr, err = compress.Decompress(rdr, bcp.Compression)
 	if err != nil {

--- a/pbm/slicer/slicer.go
+++ b/pbm/slicer/slicer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
@@ -162,7 +163,7 @@ func (s *Slicer) Catchup(ctx context.Context) error {
 	}
 
 	if lastBackup.Type == defs.LogicalBackup {
-		err = s.copyReplsetOplog(ctx, rs)
+		err = s.copyReplsetOplog(ctx, rs, lastBackup.Encryption)
 		if err != nil {
 			s.l.Warning("copy oplog from %q backup: %v", lastBackup.Name, err)
 			if s.lastTS.IsZero() {
@@ -228,7 +229,11 @@ func (s *Slicer) OplogOnlyCatchup(ctx context.Context) error {
 	return nil
 }
 
-func (s *Slicer) copyReplsetOplog(ctx context.Context, rs *backup.BackupReplset) error {
+func (s *Slicer) copyReplsetOplog(
+	ctx context.Context,
+	rs *backup.BackupReplset,
+	encryption encrypt.EncryptionType,
+) error {
 	files, err := s.storage.List(rs.OplogName, "")
 	if err != nil {
 		return errors.Wrap(err, "list oplog files")
@@ -258,6 +263,7 @@ func (s *Slicer) copyReplsetOplog(ctx context.Context, rs *backup.BackupReplset)
 			RS:          s.rs,
 			FName:       n,
 			Compression: cmp,
+			Encryption:  encryption,
 			StartTS:     fw,
 			EndTS:       lw,
 			Size:        stat.Size,
@@ -481,8 +487,14 @@ func (s *Slicer) upload(
 ) error {
 	s.oplog.SetTailingSpan(from, to)
 	fname := oplog.FormatChunkFilepath(s.rs, from, to, compression)
+	encryption := s.cfg.EncryptionType()
+	passphrase, err := s.cfg.EncryptionPassphrase()
+	if err != nil {
+		return errors.Wrap(err, "resolve encryption passphrase")
+	}
 	// if use parent ctx, upload will be canceled on the "done" signal
-	size, err := storage.Upload(ctx, s.oplog, s.storage, compression, level, fname)
+	size, err := storage.Upload(ctx, s.oplog, s.storage, compression, level,
+		encryption, passphrase, fname)
 	if err != nil {
 		// PITR chunks have no metadata to indicate any failed state and if something went
 		// wrong during the data read we may end up with an already created file. Although
@@ -500,6 +512,7 @@ func (s *Slicer) upload(
 		RS:          s.rs,
 		FName:       fname,
 		Compression: compression,
+		Encryption:  encryption,
 		StartTS:     from,
 		EndTS:       to,
 		Size:        size,

--- a/pbm/snapshot/dump.go
+++ b/pbm/snapshot/dump.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm/archive"
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 )
 
@@ -18,6 +19,8 @@ func UploadDump(
 	upload UploadFunc,
 	compression compress.CompressionType,
 	compressionLevel *int,
+	encryption encrypt.EncryptionType,
+	passphrase string,
 ) (int64, error) {
 	uploadSize := int64(0)
 
@@ -25,8 +28,10 @@ func UploadDump(
 		pr, pw := io.Pipe()
 
 		compression := compression
+		encryption := encryption
 		if ns == archive.MetaFileV2 {
 			compression = compress.CompressionTypeNone
+			encryption = encrypt.EncryptionTypeNone
 		}
 
 		done := make(chan error)
@@ -44,12 +49,17 @@ func UploadDump(
 			atomic.AddInt64(&uploadSize, rc.n)
 		}()
 
-		w, err := compress.Compress(pw, compression, compressionLevel)
+		encw, err := encrypt.Encrypt(pw, encryption, passphrase)
+		if err != nil {
+			return nil, errors.Wrapf(err, "create encryptor: %q", ns)
+		}
+		w, err := compress.Compress(encw, compression, compressionLevel)
 		dwc := io.WriteCloser(&delegatedWriteCloser{w, funcCloser(func() error {
 			err0 := w.Close()
-			err1 := pw.Close()
-			err2 := <-done
-			return errors.Join(err0, err1, err2)
+			err1 := encw.Close()
+			err2 := pw.Close()
+			err3 := <-done
+			return errors.Join(err0, err1, err2, err3)
 		})})
 		return dwc, errors.Wrapf(err, "create compressor: %q", ns)
 	}
@@ -63,6 +73,8 @@ type DownloadFunc func(filename string) (io.ReadCloser, error)
 func DownloadDump(
 	download DownloadFunc,
 	compression compress.CompressionType,
+	encryption encrypt.EncryptionType,
+	passphrase string,
 	match archive.NSFilterFn,
 	numParallelColls int,
 ) (io.ReadCloser, error) {
@@ -83,6 +95,10 @@ func DownloadDump(
 				return r, nil
 			}
 
+			r, err = encrypt.Decrypt(r, encryption, passphrase)
+			if err != nil {
+				return nil, errors.Wrapf(err, "create decryptor: %q", ns)
+			}
 			r, err = compress.Decompress(r, compression)
 			return r, errors.Wrapf(err, "create decompressor: %q", ns)
 		}

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
 )
@@ -208,10 +209,11 @@ func HasReadAccess(ctx context.Context, stg Storage) error {
 	return nil
 }
 
-// rwError multierror for the read/compress/write-to-store operations set
+// rwError multierror for the read/compress/encrypt/write-to-store operations set
 type rwError struct {
 	read     error
 	compress error
+	encrypt  error
 	write    error
 }
 
@@ -222,6 +224,9 @@ func (rwe rwError) Error() string {
 	}
 	if rwe.compress != nil {
 		r += "compress data: " + rwe.compress.Error() + "."
+	}
+	if rwe.encrypt != nil {
+		r += "encrypt data: " + rwe.encrypt.Error() + "."
 	}
 	if rwe.write != nil {
 		r += "write data: " + rwe.write.Error() + "."
@@ -240,11 +245,14 @@ func (rwe rwError) Unwrap() error {
 	if rwe.compress != nil {
 		return rwe.compress
 	}
+	if rwe.encrypt != nil {
+		return rwe.encrypt
+	}
 	return nil
 }
 
 func (rwe rwError) nil() bool {
-	return rwe.read == nil && rwe.compress == nil && rwe.write == nil
+	return rwe.read == nil && rwe.compress == nil && rwe.encrypt == nil && rwe.write == nil
 }
 
 type Source interface {
@@ -265,9 +273,12 @@ func Upload(
 	dst Storage,
 	compression compress.CompressionType,
 	compressLevel *int,
+	encryption encrypt.EncryptionType,
+	passphrase string,
 	fname string,
 ) (int64, error) {
-	return UploadWithOpts(ctx, src, dst, compression, compressLevel, fname, -1, nil, nil)
+	return UploadWithOpts(ctx, src, dst, compression, compressLevel,
+		encryption, passphrase, fname, -1, nil, nil)
 }
 
 // UploadWithOpts expands Upload with few options: size of stream,
@@ -278,6 +289,8 @@ func UploadWithOpts(
 	dst Storage,
 	compression compress.CompressionType,
 	compressLevel *int,
+	encryption encrypt.EncryptionType,
+	passphrase string,
 	fname string,
 	sizeb int64,
 	saveBuf []byte,
@@ -285,7 +298,12 @@ func UploadWithOpts(
 ) (int64, error) {
 	r, pw := io.Pipe()
 
-	w, err := compress.Compress(pw, compression, compressLevel)
+	encw, err := encrypt.Encrypt(pw, encryption, passphrase)
+	if err != nil {
+		return 0, err
+	}
+
+	w, err := compress.Compress(encw, compression, compressLevel)
 	if err != nil {
 		return 0, err
 	}
@@ -295,6 +313,7 @@ func UploadWithOpts(
 	go func() {
 		n, rwErr.read = src.WriteTo(w)
 		rwErr.compress = w.Close()
+		rwErr.encrypt = encw.Close()
 		pw.Close()
 	}()
 

--- a/pbm/storage/storage_test.go
+++ b/pbm/storage/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/percona/percona-backup-mongodb/pbm/compress"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 )
@@ -150,8 +151,8 @@ func BenchmarkStorageUpload(b *testing.B) {
 		fileName := fmt.Sprintf("%s/%s-%d", runDir, *fName, rand.Uint64())
 
 		ts := time.Now()
-		sz, err := storage.UploadWithOpts(context.Background(), src, stg, cType, nil, fileName,
-			-1, saveBuf, fsSaveBuf)
+		sz, err := storage.UploadWithOpts(context.Background(), src, stg, cType, nil,
+			encrypt.EncryptionTypeNone, "", fileName, -1, saveBuf, fsSaveBuf)
 		if err != nil {
 			b.Fatalf("storage upload: %v", err)
 		}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/ctrl"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/encrypt"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/lock"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
@@ -72,6 +73,14 @@ const (
 	CompressionTypeZstandard = compress.CompressionTypeZstandard
 )
 
+type EncryptionType = encrypt.EncryptionType
+
+const (
+	EncryptionTypeNone              = encrypt.EncryptionTypeNone
+	EncryptionTypeAES256GCM         = encrypt.EncryptionTypeAES256GCM
+	EncryptionTypeXChaCha20Poly1305 = encrypt.EncryptionTypeXChaCha20Poly1305
+)
+
 type (
 	Config          = config.Config
 	BackupMetadata  = backup.BackupMeta
@@ -83,18 +92,21 @@ type (
 type LogicalBackupOptions struct {
 	CompressionType  CompressionType
 	CompressionLevel CompressionLevel
+	EncryptionType   EncryptionType
 	Namespaces       []string
 }
 
 type PhysicalBackupOptions struct {
 	CompressionType  CompressionType
 	CompressionLevel CompressionLevel
+	EncryptionType   EncryptionType
 }
 
 type IncrementalBackupOptions struct {
 	NewBase          bool
 	CompressionType  CompressionType
 	CompressionLevel CompressionLevel
+	EncryptionType   EncryptionType
 }
 
 type GetBackupByNameOptions struct {


### PR DESCRIPTION
Encrypt backup data on the client before it reaches storage so plaintext never leaves the node. A new encrypt package provides a streaming AEAD format (AES-256-GCM and XChaCha20-Poly1305) with an Argon2id-derived key, wired through the backup, oplog, and restore paths. Configured via the encryption fields in the backup configuration and the --encryption flag on `pbm backup`.  The passphrase is redacted from config output. Default is none.

Backup metadata and the physical-backup filelist are not yet encrypted and are left for follow-up commits.