### PR TITLE
PBM-1776 GCS parallel upload (with storage close)

### DIFF
--- a/cmd/pbm-agent/agent.go
+++ b/cmd/pbm-agent/agent.go
@@ -460,6 +460,7 @@ func (a *Agent) storStatus(
 	if err != nil {
 		return topo.SubsysStatus{Err: fmt.Sprintf("unable to get storage: %v", err)}
 	}
+	defer storage.Close(stg, log)
 
 	ok, err := storage.IsInitialized(ctx, stg)
 	if err != nil {

--- a/cmd/pbm-agent/delete.go
+++ b/cmd/pbm-agent/delete.go
@@ -98,6 +98,7 @@ func (a *Agent) Delete(ctx context.Context, d *ctrl.DeleteBackupCmd, opid ctrl.O
 			l.Error("get storage: %v", err)
 			return
 		}
+		defer storage.Close(stg, l)
 		l.Info("deleting backups older than %v %s", t, util.LogProfileArg(d.Profile))
 		err = backup.DeleteBackupBefore(ctx, a.leadConn, stg, d.Profile, bcpType, t)
 		if err != nil {
@@ -271,6 +272,7 @@ func (a *Agent) Cleanup(ctx context.Context, d *ctrl.CleanupCmd, opid ctrl.OPID,
 		l.Error("get storage: " + err.Error())
 		return
 	}
+	defer storage.Close(stg, l)
 
 	cr, err := backup.MakeCleanupInfo(ctx, a.leadConn, d.OlderThan, d.Profile)
 	if err != nil {
@@ -308,6 +310,7 @@ func (a *Agent) deletePITRImpl(ctx context.Context, ts bson.Timestamp) error {
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	eg := &errgroup.Group{}
 	eg.SetLimit(runtime.NumCPU())

--- a/cmd/pbm-agent/pitr.go
+++ b/cmd/pbm-agent/pitr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/oplog"
 	"github.com/percona/percona-backup-mongodb/pbm/prio"
 	"github.com/percona/percona-backup-mongodb/pbm/slicer"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/topo"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 )
@@ -366,6 +367,7 @@ func (a *Agent) pitr(ctx context.Context) error {
 		err = s.Catchup(ctx)
 	}
 	if err != nil {
+		storage.Close(stg, l)
 		if err := lck.Release(); err != nil {
 			l.Error("release lock: %v", err)
 		}
@@ -375,6 +377,7 @@ func (a *Agent) pitr(ctx context.Context) error {
 
 	go func() {
 		stopSlicingCtx, stopSlicing := context.WithCancel(ctx)
+		defer storage.Close(stg, l)
 		defer stopSlicing()
 		stopC := make(chan struct{})
 

--- a/cmd/pbm-agent/profile.go
+++ b/cmd/pbm-agent/profile.go
@@ -91,6 +91,7 @@ func (a *Agent) handleAddConfigProfile(
 		err = errors.Wrap(err, "storage from config")
 		return
 	}
+	defer storage.Close(stg, l)
 
 	err = storage.HasReadAccess(ctx, stg)
 	if err != nil {

--- a/cmd/pbm-speed-test/main.go
+++ b/cmd/pbm-speed-test/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/connect"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/blackhole"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"github.com/percona/percona-backup-mongodb/pbm/version"
@@ -209,6 +210,7 @@ func testStorage(mURL string, compression compress.CompressionType, level *int, 
 	if err != nil {
 		stdlog.Fatalln("Error: get storage:", err)
 	}
+	defer storage.Close(stg, nil)
 	done := make(chan struct{})
 	go printw(done)
 	r, err := doTest(sess, stg, compression, level, sizeGb, collection)

--- a/cmd/pbm/backup.go
+++ b/cmd/pbm/backup.go
@@ -464,12 +464,15 @@ func describeBackup(
 
 	var stg storage.Storage
 	if b.coll || bcp.Size == 0 {
+		l := log.LogEventFromContext(ctx)
+
 		// to read backed up collection names
 		// or calculate size of files for legacy backups
-		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, node, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, node, l)
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}
+		defer storage.Close(stg, l)
 
 		err = storage.HasReadAccess(ctx, stg)
 		if err != nil && !errors.Is(err, storage.ErrUninitialized) {

--- a/cmd/pbm/oplog.go
+++ b/cmd/pbm/oplog.go
@@ -11,6 +11,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 	"github.com/percona/percona-backup-mongodb/pbm/errors"
 	"github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/util"
 	"github.com/percona/percona-backup-mongodb/sdk"
 )
@@ -79,6 +80,7 @@ func replayOplog(
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	name := time.Now().UTC().Format(time.RFC3339Nano)
 	cmd := ctrl.Cmd{

--- a/cmd/pbm/restore.go
+++ b/cmd/pbm/restore.go
@@ -188,6 +188,7 @@ func runRestore(
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	m, err := doRestore(
 		ctx,
@@ -578,6 +579,7 @@ func runFinishRestore(o descrRestoreOpts, node string) (fmt.Stringer, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, nil)
 
 	path := fmt.Sprintf("%s/%s/cluster", defs.PhysRestoresDir, o.restore)
 	msg := outMsg{"Command sent. Check `pbm describe-restore ...` for the result."}
@@ -779,8 +781,9 @@ func describeRestore(
 		if err != nil {
 			return nil, errors.Wrap(err, "get storage")
 		}
-		meta, err = restore.GetPhysRestoreMeta(o.restore, stg, log.New(nil, "cli", "").
-			NewEvent("", "", "", bson.Timestamp{}))
+		l := log.New(nil, "cli", "").NewEvent("", "", "", bson.Timestamp{})
+		defer storage.Close(stg, l)
+		meta, err = restore.GetPhysRestoreMeta(o.restore, stg, l)
 		if err != nil && meta == nil {
 			return nil, errors.Wrap(err, "get restore meta")
 		}

--- a/cmd/pbm/status.go
+++ b/cmd/pbm/status.go
@@ -603,11 +603,12 @@ func getStorageStat(
 
 	bcpsMatchCluster(bcps, ver.VersionString, fcv, shards, rsMap)
 
-	stg, err := util.GetStorage(ctx, conn, inf.Me,
-		log.FromContext(ctx).NewEvent("", "", "", bson.Timestamp{}))
+	l := log.FromContext(ctx).NewEvent("", "", "", bson.Timestamp{})
+	stg, err := util.GetStorage(ctx, conn, inf.Me, l)
 	if err != nil {
 		return s, errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	now, err := topo.GetClusterTime(ctx, conn)
 	if err != nil {

--- a/e2e-tests/cmd/ensure-oplog/main.go
+++ b/e2e-tests/cmd/ensure-oplog/main.go
@@ -272,10 +272,12 @@ func ensureReplsetOplog(ctx context.Context, uri string, from, till bson.Timesta
 		return errors.Wrap(err, "get config")
 	}
 
-	stg, err := util.StorageFromConfig(&cfg.Storage, "", log.FromContext(ctx).NewDefaultEvent())
+	l := log.FromContext(ctx).NewDefaultEvent()
+	stg, err := util.StorageFromConfig(&cfg.Storage, "", l)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	compression := defs.DefaultCompression
 	compressionLevel := (*int)(nil)

--- a/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
+++ b/e2e-tests/pkg/tests/sharded/test_backup_cancellation.go
@@ -76,6 +76,7 @@ func listAllFiles(confFilepath string) ([]storage.FileInfo, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "storage from config")
 	}
+	defer storage.Close(stg, nil)
 
 	files, err := stg.List("", "")
 	if err != nil {

--- a/packaging/conf/pbm-conf-reference.yml
+++ b/packaging/conf/pbm-conf-reference.yml
@@ -135,8 +135,25 @@
 ## When undefined, backups are saved at the root of the bucket.
 #      prefix:
 
+## Google SDK client type. Supported values: json, grpc.
+## When undefined, json is used.
+#      clientType: json
+
 ## The size of data chunks in bytes to be uploaded to the storage bucket in a single request.
+## Applies to standard Google SDK uploads only. It is not used when parallelUpload is enabled.
 #      chunkSize: 10MB
+
+## Experimental Google SDK parallel upload configuration.
+## This is used only with clientType: grpc. It creates temporary GCS objects and composes
+## them into the final object. The credentials must be allowed to delete temporary objects
+## for cleanup. Failed or interrupted uploads can leave temporary objects behind, so a
+## bucket lifecycle cleanup rule is recommended.
+#      parallelUpload:
+#        enabled: false
+## Size of each temporary part in bytes. When undefined or 0, the Google SDK default is used.
+#        partSize: 16MB
+## Number of parallel upload workers. When undefined or 0, the Google SDK default is used.
+#        maxConcurrency: 4
 
 ## GCS access credentials. You can use either HMAC or Service Account keys.
 ## HMAC Example:
@@ -156,6 +173,7 @@
 #        backoffInitial: 1s
 #        backoffMax: 30s
 #        backoffMultiplier: 2
+## Applies to standard Google SDK uploads only. It is not used when parallelUpload is enabled.
 #        chunkRetryDeadline: 32s
 #
 ## The maximum object size that will be stored on the storage

--- a/packaging/conf/pbm-conf-reference.yml
+++ b/packaging/conf/pbm-conf-reference.yml
@@ -140,20 +140,16 @@
 #      clientType: json
 
 ## The size of data chunks in bytes to be uploaded to the storage bucket in a single request.
-## Applies to standard Google SDK uploads only. It is not used when parallelUpload is enabled.
+## For parallel uploads, it is used as the temporary part size. When undefined,
+## PBM uses 10MB for standard uploads and 16MB for parallel uploads.
 #      chunkSize: 10MB
 
-## Experimental Google SDK parallel upload configuration.
-## This is used only with clientType: grpc. It creates temporary GCS objects and composes
-## them into the final object. The credentials must be allowed to delete temporary objects
-## for cleanup. Failed or interrupted uploads can leave temporary objects behind, so a
-## bucket lifecycle cleanup rule is recommended.
-#      parallelUpload:
-#        enabled: false
-## Size of each temporary part in bytes. When undefined or 0, the Google SDK default is used.
-#        partSize: 16MB
-## Number of parallel upload workers. When undefined or 0, the Google SDK default is used.
-#        maxConcurrency: 4
+## Experimental Google SDK parallel upload concurrency. Parallel upload is used only
+## with clientType: grpc and parallelUploadConcurrency greater than 1. It creates
+## temporary GCS objects and composes them into the final object. The credentials must
+## be allowed to delete temporary objects for cleanup. Failed or interrupted uploads can
+## leave temporary objects behind, so a bucket lifecycle cleanup rule is recommended.
+#      parallelUploadConcurrency: 4
 
 ## GCS access credentials. You can use either HMAC or Service Account keys.
 ## HMAC Example:
@@ -173,7 +169,7 @@
 #        backoffInitial: 1s
 #        backoffMax: 30s
 #        backoffMultiplier: 2
-## Applies to standard Google SDK uploads only. It is not used when parallelUpload is enabled.
+## Applies to standard Google SDK uploads only. It is not used for parallel uploads.
 #        chunkRetryDeadline: 32s
 #
 ## The maximum object size that will be stored on the storage

--- a/pbm/backup/backup.go
+++ b/pbm/backup/backup.go
@@ -220,6 +220,7 @@ func (b *Backup) Run(ctx context.Context, bcp *ctrl.BackupCmd, opid ctrl.OPID, l
 	if err != nil {
 		return errors.Wrap(err, "unable to get PBM storage configuration settings")
 	}
+	defer storage.Close(stg, l)
 
 	bcpm, err := NewDBManager(b.leadConn).GetBackupByName(ctx, bcp.Name)
 	if err != nil {

--- a/pbm/backup/delete.go
+++ b/pbm/backup/delete.go
@@ -86,6 +86,7 @@ func deleteBackupImpl(
 	}
 
 	l := log.LogEventFromContext(ctx)
+	defer storage.Close(stg, l)
 	l.Info("deleting backup %q %s", bcp.Name, util.LogProfileArg(bcp.Store.Name))
 	return DeleteBackupData(ctx, conn, stg, bcp.Name)
 }
@@ -112,6 +113,7 @@ func deleteIncremetalChainImpl(ctx context.Context, conn connect.Client, bcp *Ba
 	}
 
 	l := log.LogEventFromContext(ctx)
+	defer storage.Close(stg, l)
 	for i := len(all) - 1; i >= 0; i-- {
 		l.Info("deleting backup %q %s", all[i].Name, util.LogProfileArg(bcp.Store.Name))
 		err = DeleteBackupData(ctx, conn, stg, all[i].Name)

--- a/pbm/backup/logical.go
+++ b/pbm/backup/logical.go
@@ -202,6 +202,7 @@ func (b *Backup) doLogical(
 			if err != nil {
 				return errors.Wrap(err, "get storage")
 			}
+			defer storage.Close(stg, l)
 			filepath := path.Join(bcp.Name, rsMeta.Name, ns+ext)
 			return stg.Save(filepath, r, storage.Size(sizeHints[ns]))
 		},

--- a/pbm/config/config_test.go
+++ b/pbm/config/config_test.go
@@ -406,6 +406,7 @@ func TestConfig(t *testing.T) {
 						ClientEmail: "ce1",
 						PrivateKey:  "pk1",
 					},
+					ClientType:   gcs.ClientTypeJSON,
 					ChunkSize:    100,
 					MaxObjSizeGB: floatPtr(1.1),
 					Retryer: &gcs.Retryer{
@@ -510,6 +511,75 @@ func TestConfig(t *testing.T) {
 					wantCfg.Storage.GCS, gotCfg.Storage.GCS, cmp.Diff(*wantCfg.Storage.GCS, *gotCfg.Storage.GCS))
 			}
 		})
+	})
+
+	t.Run("gcs parallel upload config", func(t *testing.T) {
+		emptyCfg := &Config{
+			Storage: StorageConf{Type: storage.GCS, GCS: &gcs.Config{}},
+		}
+		err := SetConfig(ctx, connClient, emptyCfg)
+		if err != nil {
+			t.Fatalf("setup: initial SetConfig failed: %v", err)
+		}
+
+		testCases := []struct {
+			desc  string
+			param string
+			val   string
+		}{
+			{
+				desc:  "clientType",
+				param: "storage.gcs.clientType",
+				val:   string(gcs.ClientTypeGRPC),
+			},
+			{
+				desc:  "parallelUpload.enabled",
+				param: "storage.gcs.parallelUpload.enabled",
+				val:   "true",
+			},
+			{
+				desc:  "parallelUpload.partSize",
+				param: "storage.gcs.parallelUpload.partSize",
+				val:   "123",
+			},
+			{
+				desc:  "parallelUpload.maxConcurrency",
+				param: "storage.gcs.parallelUpload.maxConcurrency",
+				val:   "4",
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.desc, func(t *testing.T) {
+				err := SetConfigVar(ctx, connClient, tt.param, tt.val)
+				if err != nil {
+					t.Fatalf("SetConfigVar failed for %s with value %s: %v",
+						tt.param, tt.val, err)
+				}
+			})
+		}
+
+		gotCfg, err := GetConfig(ctx, connClient)
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+
+		gotGCS := gotCfg.Storage.GCS
+		if gotGCS.ClientType != gcs.ClientTypeGRPC {
+			t.Fatalf("clientType: got=%q, want=%q", gotGCS.ClientType, gcs.ClientTypeGRPC)
+		}
+		if gotGCS.ParallelUpload == nil {
+			t.Fatal("expected parallelUpload config")
+		}
+		if !gotGCS.ParallelUpload.Enabled {
+			t.Fatal("expected parallelUpload.enabled=true")
+		}
+		if gotGCS.ParallelUpload.PartSize != 123 {
+			t.Fatalf("parallelUpload.partSize: got=%d, want=123", gotGCS.ParallelUpload.PartSize)
+		}
+		if gotGCS.ParallelUpload.MaxConcurrency != 4 {
+			t.Fatalf("parallelUpload.maxConcurrency: got=%d, want=4", gotGCS.ParallelUpload.MaxConcurrency)
+		}
 	})
 
 	t.Run("restore config", func(t *testing.T) {

--- a/pbm/config/config_test.go
+++ b/pbm/config/config_test.go
@@ -406,9 +406,10 @@ func TestConfig(t *testing.T) {
 						ClientEmail: "ce1",
 						PrivateKey:  "pk1",
 					},
-					ClientType:   gcs.ClientTypeJSON,
-					ChunkSize:    100,
-					MaxObjSizeGB: floatPtr(1.1),
+					ClientType:                gcs.ClientTypeJSON,
+					ChunkSize:                 100,
+					ParallelUploadConcurrency: 4,
+					MaxObjSizeGB:              floatPtr(1.1),
 					Retryer: &gcs.Retryer{
 						BackoffInitial:     11 * time.Minute,
 						BackoffMax:         111 * time.Minute,
@@ -449,6 +450,11 @@ func TestConfig(t *testing.T) {
 				desc:  "chunkSize",
 				param: "storage.gcs.chunkSize",
 				val:   fmt.Sprintf("%d", wantCfg.Storage.GCS.ChunkSize),
+			},
+			{
+				desc:  "parallelUploadConcurrency",
+				param: "storage.gcs.parallelUploadConcurrency",
+				val:   fmt.Sprintf("%d", wantCfg.Storage.GCS.ParallelUploadConcurrency),
 			},
 			{
 				desc:  "maxObjSizeGB",
@@ -533,18 +539,8 @@ func TestConfig(t *testing.T) {
 				val:   string(gcs.ClientTypeGRPC),
 			},
 			{
-				desc:  "parallelUpload.enabled",
-				param: "storage.gcs.parallelUpload.enabled",
-				val:   "true",
-			},
-			{
-				desc:  "parallelUpload.partSize",
-				param: "storage.gcs.parallelUpload.partSize",
-				val:   "123",
-			},
-			{
-				desc:  "parallelUpload.maxConcurrency",
-				param: "storage.gcs.parallelUpload.maxConcurrency",
+				desc:  "parallelUploadConcurrency",
+				param: "storage.gcs.parallelUploadConcurrency",
 				val:   "4",
 			},
 		}
@@ -568,17 +564,8 @@ func TestConfig(t *testing.T) {
 		if gotGCS.ClientType != gcs.ClientTypeGRPC {
 			t.Fatalf("clientType: got=%q, want=%q", gotGCS.ClientType, gcs.ClientTypeGRPC)
 		}
-		if gotGCS.ParallelUpload == nil {
-			t.Fatal("expected parallelUpload config")
-		}
-		if !gotGCS.ParallelUpload.Enabled {
-			t.Fatal("expected parallelUpload.enabled=true")
-		}
-		if gotGCS.ParallelUpload.PartSize != 123 {
-			t.Fatalf("parallelUpload.partSize: got=%d, want=123", gotGCS.ParallelUpload.PartSize)
-		}
-		if gotGCS.ParallelUpload.MaxConcurrency != 4 {
-			t.Fatalf("parallelUpload.maxConcurrency: got=%d, want=4", gotGCS.ParallelUpload.MaxConcurrency)
+		if gotGCS.ParallelUploadConcurrency != 4 {
+			t.Fatalf("parallelUploadConcurrency: got=%d, want=4", gotGCS.ParallelUploadConcurrency)
 		}
 	})
 

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -134,6 +134,12 @@ func (r *Restore) Close() {
 	if r.stopHB != nil {
 		close(r.stopHB)
 	}
+
+	storage.Close(r.bcpStg, r.log)
+	r.bcpStg = nil
+
+	storage.Close(r.oplogStg, r.log)
+	r.oplogStg = nil
 }
 
 func (r *Restore) exit(ctx context.Context, err error) {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -752,11 +752,13 @@ func LookupBackupMeta(
 		return nil, errors.Wrap(err, "get backup metadata from db")
 	}
 
+	l := log.LogEventFromContext(ctx)
 	var stg storage.Storage
-	stg, err = util.GetStorage(ctx, conn, node, log.LogEventFromContext(ctx))
+	stg, err = util.GetStorage(ctx, conn, node, l)
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
+	defer storage.Close(stg, l)
 
 	bcp, err = GetMetaFromStore(stg, backupName)
 	if err != nil {

--- a/pbm/restore/logical.go
+++ b/pbm/restore/logical.go
@@ -87,6 +87,22 @@ type oplogRange struct {
 	storage storage.Storage
 }
 
+type storageReadCloser struct {
+	r   io.ReadCloser
+	stg storage.Storage
+	l   log.LogEvent
+}
+
+func (rc storageReadCloser) Read(p []byte) (int, error) {
+	return rc.r.Read(p)
+}
+
+func (rc storageReadCloser) Close() error {
+	err := rc.r.Close()
+	storage.Close(rc.stg, rc.l)
+	return err
+}
+
 // configDatabasesDoc represents document in config.databases collection
 type configDatabasesDoc struct {
 	ID      string `bson:"_id"`
@@ -1083,11 +1099,14 @@ func (r *Restore) RunSnapshot(
 			// we have to use mapping passed by --replset-mapping option
 			rdr, err := stg.SourceReader(path.Join(bcp.Name, mapRS(r.brief.SetName), ns))
 			if err != nil {
+				storage.Close(stg, r.log)
 				return nil, err
 			}
 
 			if ns == archive.MetaFile {
 				data, err := io.ReadAll(rdr)
+				_ = rdr.Close()
+				storage.Close(stg, r.log)
 				if err != nil {
 					return nil, err
 				}
@@ -1097,10 +1116,10 @@ func (r *Restore) RunSnapshot(
 					return nil, errors.Wrap(err, "load indexes")
 				}
 
-				rdr = io.NopCloser(bytes.NewReader(data))
+				return io.NopCloser(bytes.NewReader(data)), nil
 			}
 
-			return rdr, nil
+			return storageReadCloser{r: rdr, stg: stg, l: r.log}, nil
 		},
 		bcp.Compression,
 		util.MakeSelectedPred(nss),

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -92,15 +92,16 @@ type PhysRestore struct {
 	startTS int64
 	secOpts *topo.MongodOptsSec
 
-	name      string
-	opid      string
-	nodeInfo  *topo.NodeInfo
-	stg       storage.Storage
-	bcpStg    storage.Storage
-	bcp       *backup.BackupMeta
-	files     []files
-	bcpSizeRS int64 // total uncompressed size of the backup for RS (including all increments)
-	restoreTS bson.Timestamp
+	name       string
+	opid       string
+	nodeInfo   *topo.NodeInfo
+	stg        storage.Storage
+	bcpStg     storage.Storage
+	bcp        *backup.BackupMeta
+	files      []files
+	bcpSizeRS  int64 // total uncompressed size of the backup for RS (including all increments)
+	restoreTS  bson.Timestamp
+	newStorage func() (storage.Storage, error)
 
 	confOpts *config.RestoreConf
 
@@ -120,7 +121,6 @@ type PhysRestore struct {
 
 	stopHB        chan struct{}
 	stopCleanupHB chan struct{}
-	hbWG          sync.WaitGroup
 
 	log     log.LogEvent
 	logBuff *logBuff
@@ -213,9 +213,7 @@ func NewPhysical(
 	}, nil
 }
 
-func (r *PhysRestore) closeStoragesAfterHeartbeats() {
-	r.hbWG.Wait()
-
+func (r *PhysRestore) closeStorages() {
 	storage.Close(r.bcpStg, r.log)
 	r.bcpStg = nil
 
@@ -289,7 +287,7 @@ func (r *PhysRestore) close(noerr bool, progress nodeStatus) (err error) {
 		if r.stopCleanupHB != nil {
 			close(r.stopCleanupHB)
 		}
-		r.closeStoragesAfterHeartbeats()
+		r.closeStorages()
 	}()
 
 	// resolve and exec cleanup
@@ -1209,6 +1207,7 @@ func (r *PhysRestore) Snapshot(
 	defer func() {
 		if cmd.Exit && err == nil {
 			// nothing to cleanup in case of successful ext restore with exit
+			r.closeStorages()
 			return
 		}
 		if err != nil && !errors.Is(err, ErrNoDataForShard) {
@@ -2414,7 +2413,12 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 		return errors.Wrap(err, "get pbm config")
 	}
 
-	r.stg, err = util.StorageFromConfig(&cfg.Storage, r.nodeInfo.Me, l)
+	storageConf := cfg.Storage
+	r.newStorage = func() (storage.Storage, error) {
+		return util.StorageFromConfig(&storageConf, r.nodeInfo.Me, l)
+	}
+
+	r.stg, err = r.newStorage()
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
@@ -2468,18 +2472,23 @@ func (r *PhysRestore) init(ctx context.Context, name string, opid ctrl.OPID, l l
 
 // startHB starts heartbeats in separate go routine.
 func (r *PhysRestore) startHB(l log.LogEvent) {
-	err := r.hb()
+	stg, err := r.newStorage()
+	if err != nil {
+		l.Error("get heartbeat storage: %v", err)
+		return
+	}
+
+	err = r.hb(stg)
 	if err != nil {
 		l.Error("send init heartbeat: %v", err)
 	}
 
 	r.stopHB = make(chan struct{})
-	r.hbWG.Add(1)
 	go func() {
 		tk := time.NewTicker(time.Second * hbFrameSec)
 		defer func() {
-			r.hbWG.Done()
 			tk.Stop()
+			storage.Close(stg, l)
 			r.stopHB = nil
 			l.Debug("heartbeats stopped")
 		}()
@@ -2487,7 +2496,7 @@ func (r *PhysRestore) startHB(l log.LogEvent) {
 		for {
 			select {
 			case <-tk.C:
-				err := r.hb()
+				err := r.hb(stg)
 				if err != nil {
 					l.Warning("send heartbeat: %v", err)
 				}
@@ -2498,20 +2507,20 @@ func (r *PhysRestore) startHB(l log.LogEvent) {
 	}()
 }
 
-func (r *PhysRestore) hb() error {
+func (r *PhysRestore) hb(stg storage.Storage) error {
 	now := []byte(strconv.FormatInt(time.Now().Unix(), 10))
 
-	err := storage.RetryableWrite(r.stg, r.syncPathNode+"."+syncHbSuffix, now)
+	err := storage.RetryableWrite(stg, r.syncPathNode+"."+syncHbSuffix, now)
 	if err != nil {
 		return errors.Wrap(err, "write node hb")
 	}
 
-	err = storage.RetryableWrite(r.stg, r.syncPathRS+"."+syncHbSuffix, now)
+	err = storage.RetryableWrite(stg, r.syncPathRS+"."+syncHbSuffix, now)
 	if err != nil {
 		return errors.Wrap(err, "write rs hb")
 	}
 
-	err = storage.RetryableWrite(r.stg, r.syncPathCluster+"."+syncHbSuffix, now)
+	err = storage.RetryableWrite(stg, r.syncPathCluster+"."+syncHbSuffix, now)
 	if err != nil {
 		return errors.Wrap(err, "write cluster hb")
 	}
@@ -2519,10 +2528,10 @@ func (r *PhysRestore) hb() error {
 	return nil
 }
 
-func (r *PhysRestore) hbCleanup() error {
+func (r *PhysRestore) hbCleanup(stg storage.Storage) error {
 	now := []byte(strconv.FormatInt(time.Now().Unix(), 10))
 
-	err := storage.RetryableWrite(r.stg, r.syncPathCluster+"."+syncHbCleanupSuffix, now)
+	err := storage.RetryableWrite(stg, r.syncPathCluster+"."+syncHbCleanupSuffix, now)
 	if err != nil {
 		return errors.Wrap(err, "write cleanup hb")
 	}
@@ -2533,18 +2542,23 @@ func (r *PhysRestore) hbCleanup() error {
 // startCleanupHb generates cleanup hb for the purpose of detecting physical restore
 // cleanup activity.
 func (r *PhysRestore) startCleanupHb() {
-	err := r.hbCleanup()
+	stg, err := r.newStorage()
+	if err != nil {
+		r.log.Warning("get cleanup heartbeat storage: %v", err)
+		return
+	}
+
+	err = r.hbCleanup(stg)
 	if err != nil {
 		r.log.Warning("send init cleanup heartbeat: %v", err)
 	}
 
 	r.stopCleanupHB = make(chan struct{})
-	r.hbWG.Add(1)
 	go func() {
 		tk := time.NewTicker(hbCleanupFrame)
 		defer func() {
-			r.hbWG.Done()
 			tk.Stop()
+			storage.Close(stg, r.log)
 			r.stopCleanupHB = nil
 			r.log.Debug("cleanup heartbeats stopped")
 		}()
@@ -2552,7 +2566,7 @@ func (r *PhysRestore) startCleanupHb() {
 		for {
 			select {
 			case <-tk.C:
-				err := r.hbCleanup()
+				err := r.hbCleanup(stg)
 				if err != nil {
 					r.log.Warning("send cleanup heartbeat: %v", err)
 				}
@@ -3186,12 +3200,13 @@ func PhysRestoreFinish(l log.LogEvent, cmd *ExtFinishCmd) error {
 		return errors.Wrap(err, "creating restore object from storage dump")
 	}
 
+	defer r.closeStorages()
+
 	r.startHB(l)
 	defer func() {
 		if r.stopHB != nil {
 			close(r.stopHB)
 		}
-		r.closeStoragesAfterHeartbeats()
 	}()
 
 	excfg, err := r.prepareExtRestore(l)
@@ -3295,6 +3310,9 @@ func physRestoreFromExtDump(
 	physRestore := PhysRestore{
 		stg: stg,
 		log: l,
+		newStorage: func() (storage.Storage, error) {
+			return GetRestoreMetaStg(cmd.CfgPath, cmd.Node)
+		},
 
 		dbpath:             extDump.DBpath,
 		tmpPort:            extDump.TmpPort,

--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -120,6 +120,7 @@ type PhysRestore struct {
 
 	stopHB        chan struct{}
 	stopCleanupHB chan struct{}
+	hbWG          sync.WaitGroup
 
 	log     log.LogEvent
 	logBuff *logBuff
@@ -212,6 +213,16 @@ func NewPhysical(
 	}, nil
 }
 
+func (r *PhysRestore) closeStoragesAfterHeartbeats() {
+	r.hbWG.Wait()
+
+	storage.Close(r.bcpStg, r.log)
+	r.bcpStg = nil
+
+	storage.Close(r.stg, r.log)
+	r.stg = nil
+}
+
 // peeks a random free port in a range [minPort, maxPort]
 func peekTmpPort(current int) (int, error) {
 	const (
@@ -278,6 +289,7 @@ func (r *PhysRestore) close(noerr bool, progress nodeStatus) (err error) {
 		if r.stopCleanupHB != nil {
 			close(r.stopCleanupHB)
 		}
+		r.closeStoragesAfterHeartbeats()
 	}()
 
 	// resolve and exec cleanup
@@ -2462,9 +2474,11 @@ func (r *PhysRestore) startHB(l log.LogEvent) {
 	}
 
 	r.stopHB = make(chan struct{})
+	r.hbWG.Add(1)
 	go func() {
 		tk := time.NewTicker(time.Second * hbFrameSec)
 		defer func() {
+			r.hbWG.Done()
 			tk.Stop()
 			r.stopHB = nil
 			l.Debug("heartbeats stopped")
@@ -2525,9 +2539,11 @@ func (r *PhysRestore) startCleanupHb() {
 	}
 
 	r.stopCleanupHB = make(chan struct{})
+	r.hbWG.Add(1)
 	go func() {
 		tk := time.NewTicker(hbCleanupFrame)
 		defer func() {
+			r.hbWG.Done()
 			tk.Stop()
 			r.stopCleanupHB = nil
 			r.log.Debug("cleanup heartbeats stopped")
@@ -3175,6 +3191,7 @@ func PhysRestoreFinish(l log.LogEvent, cmd *ExtFinishCmd) error {
 		if r.stopHB != nil {
 			close(r.stopHB)
 		}
+		r.closeStoragesAfterHeartbeats()
 	}()
 
 	excfg, err := r.prepareExtRestore(l)
@@ -3254,6 +3271,12 @@ func physRestoreFromExtDump(
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "get storage")
 	}
+	closeStorage := true
+	defer func() {
+		if closeStorage {
+			storage.Close(stg, l)
+		}
+	}()
 
 	extDumpF := fmt.Sprintf("%s/%s/rs.%s/node.%s.%s",
 		defs.PhysRestoresDir, cmd.RestoreName, cmd.RS, cmd.Node, extDumpSuffix)
@@ -3308,6 +3331,7 @@ func physRestoreFromExtDump(
 		physRestore.secOpts = mongodCfg.Security
 	}
 
+	closeStorage = false
 	return &physRestore, restoreMeta, nil
 }
 

--- a/pbm/resync/rsync.go
+++ b/pbm/resync/rsync.go
@@ -39,6 +39,7 @@ func Resync(
 	if err != nil {
 		return errors.Wrap(err, "unable to get backup store")
 	}
+	defer storage.Close(stg, l)
 
 	err = storage.HasReadAccess(ctx, stg)
 	if err != nil {
@@ -116,6 +117,7 @@ func SyncBackupList(
 	if err != nil {
 		return errors.Wrap(err, "storage from config")
 	}
+	defer storage.Close(stg, l)
 
 	err = ClearBackupList(ctx, conn, profile)
 	if err != nil {

--- a/pbm/storage/gcs/config.go
+++ b/pbm/storage/gcs/config.go
@@ -9,10 +9,19 @@ import (
 )
 
 //nolint:lll
+type ClientType string
+
+const (
+	ClientTypeJSON ClientType = "json"
+	ClientTypeGRPC ClientType = "grpc"
+)
+
+//nolint:lll
 type Config struct {
 	Bucket      string      `bson:"bucket" json:"bucket" yaml:"bucket"`
 	Prefix      string      `bson:"prefix" json:"prefix" yaml:"prefix"`
 	Credentials Credentials `bson:"credentials" json:"-" yaml:"credentials"`
+	ClientType  ClientType  `bson:"clientType,omitempty" json:"clientType,omitempty" yaml:"clientType,omitempty"`
 
 	// The maximum number of bytes that the Writer will attempt to send in a single request.
 	// https://pkg.go.dev/cloud.google.com/go/storage#Writer
@@ -26,10 +35,10 @@ type Config struct {
 
 // ParallelUpload configures the experimental Google Cloud Storage parallel upload feature.
 //
-// Parallel uploads are supported only by the Google SDK gRPC client. HMAC credentials
-// continue to use the MinIO client and are not affected by this setting.
+// Parallel uploads are supported only by the Google SDK gRPC client.
+// HMAC credentials continue to use the MinIO client and are not affected by this setting.
 type ParallelUpload struct {
-	// Enabled switches the Google SDK client to gRPC and enables Writer parallel uploads.
+	// Enabled enables Writer parallel uploads when clientType is grpc.
 	Enabled bool `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
 	// PartSize is the size of each temporary part in bytes.
@@ -114,6 +123,9 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.Prefix != other.Prefix {
 		return false
 	}
+	if cfg.ClientType != other.ClientType {
+		return false
+	}
 	if cfg.ChunkSize != other.ChunkSize {
 		return false
 	}
@@ -152,6 +164,13 @@ func (cfg *Config) IsSameStorage(other *Config) bool {
 func (cfg *Config) Cast() error {
 	if cfg == nil {
 		return errors.New("missing GCS configuration with GCS storage type")
+	}
+
+	if cfg.ClientType == "" {
+		cfg.ClientType = ClientTypeJSON
+	}
+	if cfg.ClientType != ClientTypeJSON && cfg.ClientType != ClientTypeGRPC {
+		return errors.Errorf("invalid clientType %q", cfg.ClientType)
 	}
 
 	if cfg.ChunkSize == 0 {
@@ -204,5 +223,5 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 }
 
 func (cfg *Config) parallelUploadEnabled() bool {
-	return cfg.ParallelUpload != nil && cfg.ParallelUpload.Enabled
+	return cfg.ClientType == ClientTypeGRPC && cfg.ParallelUpload != nil && cfg.ParallelUpload.Enabled
 }

--- a/pbm/storage/gcs/config.go
+++ b/pbm/storage/gcs/config.go
@@ -25,29 +25,11 @@ type Config struct {
 
 	// The maximum number of bytes that the Writer will attempt to send in a single request.
 	// https://pkg.go.dev/cloud.google.com/go/storage#Writer
-	ChunkSize    int      `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
-	MaxObjSizeGB *float64 `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
-
-	ParallelUpload *ParallelUpload `bson:"parallelUpload,omitempty" json:"parallelUpload,omitempty" yaml:"parallelUpload,omitempty"`
+	ChunkSize                 int      `bson:"chunkSize,omitempty" json:"chunkSize,omitempty" yaml:"chunkSize,omitempty"`
+	ParallelUploadConcurrency int      `bson:"parallelUploadConcurrency,omitempty" json:"parallelUploadConcurrency,omitempty" yaml:"parallelUploadConcurrency,omitempty"`
+	MaxObjSizeGB              *float64 `bson:"maxObjSizeGB,omitempty" json:"maxObjSizeGB,omitempty" yaml:"maxObjSizeGB,omitempty"`
 
 	Retryer *Retryer `bson:"retryer,omitempty" json:"retryer,omitempty" yaml:"retryer,omitempty"`
-}
-
-// ParallelUpload configures the experimental Google Cloud Storage parallel upload feature.
-//
-// Parallel uploads are supported only by the Google SDK gRPC client.
-// HMAC credentials continue to use the MinIO client and are not affected by this setting.
-type ParallelUpload struct {
-	// Enabled enables Writer parallel uploads when clientType is grpc.
-	Enabled bool `bson:"enabled,omitempty" json:"enabled,omitempty" yaml:"enabled,omitempty"`
-
-	// PartSize is the size of each temporary part in bytes.
-	// If unset, PBM uses the computed ChunkSize for the uploaded object.
-	PartSize int `bson:"partSize,omitempty" json:"partSize,omitempty" yaml:"partSize,omitempty"`
-
-	// MaxConcurrency is the number of goroutines used to upload parts in parallel.
-	// If unset, the Google SDK chooses a value based on the number of CPUs.
-	MaxConcurrency int `bson:"maxConcurrency,omitempty" json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty"`
 }
 
 //nolint:lll
@@ -100,10 +82,6 @@ func (cfg *Config) Clone() *Config {
 		v := *cfg.MaxObjSizeGB
 		rv.MaxObjSizeGB = &v
 	}
-	if cfg.ParallelUpload != nil {
-		v := *cfg.ParallelUpload
-		rv.ParallelUpload = &v
-	}
 	if cfg.Retryer != nil {
 		v := *cfg.Retryer
 		rv.Retryer = &v
@@ -129,10 +107,10 @@ func (cfg *Config) Equal(other *Config) bool {
 	if cfg.ChunkSize != other.ChunkSize {
 		return false
 	}
-	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
+	if cfg.ParallelUploadConcurrency != other.ParallelUploadConcurrency {
 		return false
 	}
-	if !reflect.DeepEqual(cfg.ParallelUpload, other.ParallelUpload) {
+	if !reflect.DeepEqual(cfg.MaxObjSizeGB, other.MaxObjSizeGB) {
 		return false
 	}
 	if !reflect.DeepEqual(cfg.Credentials, other.Credentials) {
@@ -173,17 +151,11 @@ func (cfg *Config) Cast() error {
 		return errors.Errorf("invalid clientType %q", cfg.ClientType)
 	}
 
-	if cfg.ChunkSize == 0 {
-		cfg.ChunkSize = defaultChunkSize
+	if cfg.ChunkSize == 0 && cfg.parallelUploadEnabled() {
+		cfg.ChunkSize = defaultParallelUploadChunkSize
 	}
-
-	if cfg.ParallelUpload != nil {
-		if cfg.ParallelUpload.PartSize < 0 {
-			return errors.New("parallelUpload.partSize cannot be negative")
-		}
-		if cfg.ParallelUpload.MaxConcurrency < 0 {
-			return errors.New("parallelUpload.maxConcurrency cannot be negative")
-		}
+	if cfg.ChunkSize == 0 && !cfg.parallelUploadEnabled() {
+		cfg.ChunkSize = defaultChunkSize
 	}
 
 	if cfg.Retryer == nil {
@@ -223,5 +195,5 @@ func (cfg *Config) GetMaxObjSizeGB() float64 {
 }
 
 func (cfg *Config) parallelUploadEnabled() bool {
-	return cfg.ClientType == ClientTypeGRPC && cfg.ParallelUpload != nil && cfg.ParallelUpload.Enabled
+	return cfg.ClientType == ClientTypeGRPC && cfg.ParallelUploadConcurrency > 1
 }

--- a/pbm/storage/gcs/config_test.go
+++ b/pbm/storage/gcs/config_test.go
@@ -22,7 +22,8 @@ func TestCast(t *testing.T) {
 		t.Fatalf("got error during Cast: %v", err)
 	}
 	want := &Config{
-		ChunkSize: defaultChunkSize,
+		ClientType: ClientTypeJSON,
+		ChunkSize:  defaultChunkSize,
 		Retryer: &Retryer{
 			MaxAttempts:        defaultMaxAttempts,
 			BackoffInitial:     defaultBackoffInitial,
@@ -52,6 +53,11 @@ func TestCast(t *testing.T) {
 				cfg:  &Config{ParallelUpload: &ParallelUpload{MaxConcurrency: -1}},
 				err:  "parallelUpload.maxConcurrency cannot be negative",
 			},
+			{
+				name: "invalid client type",
+				cfg:  &Config{ClientType: ClientType("xml")},
+				err:  `invalid clientType "xml"`,
+			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				err := tt.cfg.Cast()
@@ -71,6 +77,7 @@ func TestConfig(t *testing.T) {
 			ClientEmail: "email@example.com",
 			PrivateKey:  "-----BEGIN PRIVATE KEY-----\nKey\n-----END PRIVATE KEY-----\n",
 		},
+		ClientType: ClientTypeGRPC,
 		ParallelUpload: &ParallelUpload{
 			Enabled:        true,
 			PartSize:       16 * 1024 * 1024,
@@ -116,6 +123,12 @@ func TestConfig(t *testing.T) {
 		clone.Credentials.ClientEmail = "updated@example.com"
 		if opts.Equal(clone) {
 			t.Error("expected not to be equal when updating credentials")
+		}
+
+		clone = opts.Clone()
+		clone.ClientType = ClientTypeJSON
+		if opts.Equal(clone) {
+			t.Error("expected not to be equal when updating client type")
 		}
 
 		clone = opts.Clone()

--- a/pbm/storage/gcs/config_test.go
+++ b/pbm/storage/gcs/config_test.go
@@ -37,22 +37,12 @@ func TestCast(t *testing.T) {
 		t.Fatalf("wrong config after Cast, diff=%s", cmp.Diff(*c, *want))
 	}
 
-	t.Run("parallel upload validation", func(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
 		for _, tt := range []struct {
 			name string
 			cfg  *Config
 			err  string
 		}{
-			{
-				name: "negative part size",
-				cfg:  &Config{ParallelUpload: &ParallelUpload{PartSize: -1}},
-				err:  "parallelUpload.partSize cannot be negative",
-			},
-			{
-				name: "negative max concurrency",
-				cfg:  &Config{ParallelUpload: &ParallelUpload{MaxConcurrency: -1}},
-				err:  "parallelUpload.maxConcurrency cannot be negative",
-			},
 			{
 				name: "invalid client type",
 				cfg:  &Config{ClientType: ClientType("xml")},
@@ -67,6 +57,35 @@ func TestCast(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("negative parallel upload concurrency is disabled", func(t *testing.T) {
+		c := &Config{
+			ClientType:                ClientTypeGRPC,
+			ParallelUploadConcurrency: -1,
+		}
+		err := c.Cast()
+		if err != nil {
+			t.Fatalf("got error during Cast: %v", err)
+		}
+		if c.ChunkSize != defaultChunkSize {
+			t.Fatalf("wrong chunk size: got %d, want %d", c.ChunkSize, defaultChunkSize)
+		}
+	})
+
+	t.Run("parallel upload default chunk size", func(t *testing.T) {
+		c := &Config{
+			ClientType:                ClientTypeGRPC,
+			ParallelUploadConcurrency: 2,
+		}
+		err := c.Cast()
+		if err != nil {
+			t.Fatalf("got error during Cast: %v", err)
+		}
+		if c.ChunkSize != defaultParallelUploadChunkSize {
+			t.Fatalf("wrong parallel upload chunk size: got %d, want %d",
+				c.ChunkSize, defaultParallelUploadChunkSize)
+		}
+	})
 }
 
 func TestConfig(t *testing.T) {
@@ -77,12 +96,8 @@ func TestConfig(t *testing.T) {
 			ClientEmail: "email@example.com",
 			PrivateKey:  "-----BEGIN PRIVATE KEY-----\nKey\n-----END PRIVATE KEY-----\n",
 		},
-		ClientType: ClientTypeGRPC,
-		ParallelUpload: &ParallelUpload{
-			Enabled:        true,
-			PartSize:       16 * 1024 * 1024,
-			MaxConcurrency: 4,
-		},
+		ClientType:                ClientTypeGRPC,
+		ParallelUploadConcurrency: 4,
 	}
 
 	t.Run("Clone", func(t *testing.T) {
@@ -95,11 +110,11 @@ func TestConfig(t *testing.T) {
 			t.Error("expected clone to be equal")
 		}
 
-		opts.ParallelUpload.MaxConcurrency = 8
+		opts.ParallelUploadConcurrency = 8
 		if opts.Equal(clone) {
 			t.Error("expected clone to be unchanged when updating original")
 		}
-		opts.ParallelUpload.MaxConcurrency = 4
+		opts.ParallelUploadConcurrency = 4
 
 		opts.Bucket = "updatedName"
 		if opts.Equal(clone) {
@@ -132,9 +147,9 @@ func TestConfig(t *testing.T) {
 		}
 
 		clone = opts.Clone()
-		clone.ParallelUpload.Enabled = false
+		clone.ParallelUploadConcurrency = 8
 		if opts.Equal(clone) {
-			t.Error("expected not to be equal when updating parallel upload")
+			t.Error("expected not to be equal when updating parallel upload concurrency")
 		}
 	})
 

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -14,8 +14,9 @@ import (
 const (
 	gcsEndpointURL = "storage.googleapis.com"
 
-	defaultChunkSize    = 10 * 1024 * 1024 // 10MiB
-	defaultMaxObjSizeGB = 5018             // 4.9 TB
+	defaultChunkSize               = 10 * 1024 * 1024 // 10MiB
+	defaultParallelUploadChunkSize = 16 * 1024 * 1024 // 16MiB, matches Google SDK PCU default
+	defaultMaxObjSizeGB            = 5018             // 4.9 TB
 
 	defaultMaxAttempts        = 5
 	defaultBackoffInitial     = time.Second

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -91,6 +91,10 @@ func NewWithDownloader(
 	l log.LogEvent,
 	cc, bufSizeMb, spanSizeMb int,
 ) (storage.Storage, error) {
+	if err := opts.Cast(); err != nil {
+		return nil, errors.Wrap(err, "set defaults")
+	}
+
 	if l == nil {
 		l = log.DiscardEvent
 	}

--- a/pbm/storage/gcs/gcs.go
+++ b/pbm/storage/gcs/gcs.go
@@ -165,3 +165,16 @@ func (g *GCS) Delete(name string) error {
 func (g *GCS) Copy(src, dst string) error {
 	return g.client.copy(src, dst)
 }
+
+func (g *GCS) Close() error {
+	if g == nil || g.client == nil {
+		return nil
+	}
+
+	c, ok := g.client.(storage.Closable)
+	if !ok {
+		return nil
+	}
+
+	return c.Close()
+}

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -80,17 +80,18 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 		return nil, errors.Wrap(err, "new GCS client")
 	}
 
-	bh := cli.Bucket(cfg.Bucket).
-		Retryer(
-			storagegcs.WithBackoff(gax.Backoff{
-				Initial:    cfg.Retryer.BackoffInitial,
-				Max:        cfg.Retryer.BackoffMax,
-				Multiplier: cfg.Retryer.BackoffMultiplier,
-			}),
-			storagegcs.WithMaxAttempts(cfg.Retryer.MaxAttempts),
-			storagegcs.WithPolicy(storagegcs.RetryAlways),
-			storagegcs.WithErrorFunc(shouldRetryExtended),
-		)
+	cli.SetRetry(
+		storagegcs.WithBackoff(gax.Backoff{
+			Initial:    cfg.Retryer.BackoffInitial,
+			Max:        cfg.Retryer.BackoffMax,
+			Multiplier: cfg.Retryer.BackoffMultiplier,
+		}),
+		storagegcs.WithMaxAttempts(cfg.Retryer.MaxAttempts),
+		storagegcs.WithPolicy(storagegcs.RetryAlways),
+		storagegcs.WithErrorFunc(shouldRetryExtended),
+	)
+
+	bh := cli.Bucket(cfg.Bucket)
 
 	return &googleClient{
 		bucketHandle: bh,

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -146,37 +146,56 @@ func (g googleClient) save(name string, data io.Reader, options ...storage.Optio
 		}
 	}
 
-	const align int64 = 256 << 10 // 256 KiB (both min size and alignment)
-
-	partSize := storage.ComputePartSize(
-		opts.Size,
-		defaultChunkSize,
-		align,
-		10_000,
-		int64(g.cfg.ChunkSize),
-	)
-
-	if rem := partSize % align; rem != 0 {
-		partSize += align - rem
-	}
-
-	if g.log != nil && opts.UseLogger {
-		g.log.Debug(`uploading %q [size hint: %v (%v); part size: %v (%v)]`,
-			name,
-			opts.Size, storage.PrettySize(opts.Size),
-			partSize, storage.PrettySize(partSize))
-	}
-
 	ctx := context.Background()
 	w := g.bucketHandle.Object(path.Join(g.cfg.Prefix, name)).NewWriter(ctx)
-	w.ChunkSize = int(partSize)
-	w.ChunkRetryDeadline = g.cfg.Retryer.ChunkRetryDeadline
 	if g.cfg.parallelUploadEnabled() {
+		pu := g.cfg.ParallelUpload
+		if g.log != nil && opts.UseLogger {
+			partSize := "SDK default"
+			if pu.PartSize > 0 {
+				partSize = fmt.Sprintf("%v (%v)", pu.PartSize, storage.PrettySize(int64(pu.PartSize)))
+			}
+
+			concurrency := "SDK default"
+			if pu.MaxConcurrency > 0 {
+				concurrency = fmt.Sprintf("%d", pu.MaxConcurrency)
+			}
+
+			g.log.Debug(`uploading %q [size hint: %v (%v); parallel upload part size: %s; concurrency: %s]`,
+				name,
+				opts.Size, storage.PrettySize(opts.Size),
+				partSize, concurrency)
+		}
+
 		w.EnableParallelUpload = true
 		w.ParallelUploadConfig = storagegcs.ParallelUploadConfig{
-			PartSize:       g.cfg.ParallelUpload.PartSize,
-			MaxConcurrency: g.cfg.ParallelUpload.MaxConcurrency,
+			PartSize:       pu.PartSize,
+			MaxConcurrency: pu.MaxConcurrency,
 		}
+	} else {
+		const align int64 = 256 << 10 // 256 KiB (both min size and alignment)
+
+		partSize := storage.ComputePartSize(
+			opts.Size,
+			defaultChunkSize,
+			align,
+			10_000,
+			int64(g.cfg.ChunkSize),
+		)
+
+		if rem := partSize % align; rem != 0 {
+			partSize += align - rem
+		}
+
+		if g.log != nil && opts.UseLogger {
+			g.log.Debug(`uploading %q [size hint: %v (%v); part size: %v (%v)]`,
+				name,
+				opts.Size, storage.PrettySize(opts.Size),
+				partSize, storage.PrettySize(partSize))
+		}
+
+		w.ChunkSize = int(partSize)
+		w.ChunkRetryDeadline = g.cfg.Retryer.ChunkRetryDeadline
 	}
 	if g.log != nil && opts.UseLogger {
 		w.ProgressFunc = func(written int64) {

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -53,7 +53,7 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 		if merr != nil {
 			return nil, errors.Wrap(merr, "marshal GCS credentials")
 		}
-		if cfg.parallelUploadEnabled() {
+		if cfg.ClientType == ClientTypeGRPC {
 			cli, err = storagegcs.NewGRPCClient(ctx, option.WithCredentialsJSON(creds))
 		} else {
 			cli, err = storagegcs.NewClient(ctx, option.WithCredentialsJSON(creds))
@@ -69,7 +69,7 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 		if adcErr != nil {
 			return nil, fmt.Errorf("validate default credential type: %w", adcErr)
 		}
-		if cfg.parallelUploadEnabled() {
+		if cfg.ClientType == ClientTypeGRPC {
 			cli, err = storagegcs.NewGRPCClient(ctx)
 		} else {
 			cli, err = storagegcs.NewClient(ctx)

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -55,7 +55,9 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 			return nil, errors.Wrap(merr, "marshal GCS credentials")
 		}
 		if cfg.ClientType == ClientTypeGRPC {
-			cli, err = storagegcs.NewGRPCClient(ctx, option.WithCredentialsJSON(creds))
+			cli, err = storagegcs.NewGRPCClient(ctx,
+				option.WithCredentialsJSON(creds),
+				storagegcs.WithDisabledClientMetrics())
 		} else {
 			cli, err = storagegcs.NewClient(ctx, option.WithCredentialsJSON(creds))
 		}
@@ -71,7 +73,7 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 			return nil, fmt.Errorf("validate default credential type: %w", adcErr)
 		}
 		if cfg.ClientType == ClientTypeGRPC {
-			cli, err = storagegcs.NewGRPCClient(ctx)
+			cli, err = storagegcs.NewGRPCClient(ctx, storagegcs.WithDisabledClientMetrics())
 		} else {
 			cli, err = storagegcs.NewClient(ctx)
 		}
@@ -159,28 +161,18 @@ func (g googleClient) save(name string, data io.Reader, options ...storage.Optio
 	ctx := context.Background()
 	w := g.bucketHandle.Object(path.Join(g.cfg.Prefix, name)).NewWriter(ctx)
 	if g.cfg.parallelUploadEnabled() {
-		pu := g.cfg.ParallelUpload
 		if g.log != nil && opts.UseLogger {
-			partSize := "SDK default"
-			if pu.PartSize > 0 {
-				partSize = fmt.Sprintf("%v (%v)", pu.PartSize, storage.PrettySize(int64(pu.PartSize)))
-			}
-
-			concurrency := "SDK default"
-			if pu.MaxConcurrency > 0 {
-				concurrency = fmt.Sprintf("%d", pu.MaxConcurrency)
-			}
-
-			g.log.Debug(`uploading %q [size hint: %v (%v); parallel upload part size: %s; concurrency: %s]`,
+			g.log.Debug(`uploading %q [size hint: %v (%v); parallel upload part size: %v (%v); concurrency: %d]`,
 				name,
 				opts.Size, storage.PrettySize(opts.Size),
-				partSize, concurrency)
+				g.cfg.ChunkSize, storage.PrettySize(int64(g.cfg.ChunkSize)),
+				g.cfg.ParallelUploadConcurrency)
 		}
 
 		w.EnableParallelUpload = true
 		w.ParallelUploadConfig = storagegcs.ParallelUploadConfig{
-			PartSize:       pu.PartSize,
-			MaxConcurrency: pu.MaxConcurrency,
+			PartSize:       g.cfg.ChunkSize,
+			MaxConcurrency: g.cfg.ParallelUploadConcurrency,
 		}
 	} else {
 		const align int64 = 256 << 10 // 256 KiB (both min size and alignment)

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -109,6 +109,12 @@ func (g googleClient) Close() error {
 		return nil
 	}
 
+	if g.cfg.parallelUploadEnabled() {
+		// Google SDK parallel upload starts temporary object cleanup asynchronously
+		// after Writer.Close returns. Give it a short window before closing the client.
+		time.Sleep(2 * time.Second)
+	}
+
 	return g.client.Close()
 }
 

--- a/pbm/storage/gcs/google_client.go
+++ b/pbm/storage/gcs/google_client.go
@@ -21,6 +21,7 @@ import (
 )
 
 type googleClient struct {
+	client       *storagegcs.Client
 	bucketHandle *storagegcs.BucketHandle
 	cfg          *Config
 	log          log.LogEvent
@@ -94,10 +95,19 @@ func newGoogleClient(cfg *Config, l log.LogEvent) (*googleClient, error) {
 	bh := cli.Bucket(cfg.Bucket)
 
 	return &googleClient{
+		client:       cli,
 		bucketHandle: bh,
 		cfg:          cfg,
 		log:          l,
 	}, nil
+}
+
+func (g googleClient) Close() error {
+	if g.client == nil {
+		return nil
+	}
+
+	return g.client.Close()
 }
 
 // validateDefaultCredentialType validates that credentials are of type "external_account" used for Workload Identity

--- a/pbm/storage/split_merge_mw.go
+++ b/pbm/storage/split_merge_mw.go
@@ -253,6 +253,15 @@ func (sm *SplitMergeMiddleware) DownloadStat() DownloadStat {
 	return sm.s.DownloadStat()
 }
 
+func (sm *SplitMergeMiddleware) Close() error {
+	c, ok := sm.s.(Closable)
+	if !ok {
+		return nil
+	}
+
+	return c.Close()
+}
+
 // fileWithParts fetches a list of FileInfo for the base file and all its PBM parts.
 // The base part has always 0 index, and all other parts have the array index the
 // same as pbm part index.

--- a/pbm/storage/storage.go
+++ b/pbm/storage/storage.go
@@ -66,6 +66,26 @@ type Storage interface {
 	DownloadStat() DownloadStat
 }
 
+type Closable interface {
+	Close() error
+}
+
+func Close(stg Storage, l log.LogEvent) {
+	if stg == nil {
+		return
+	}
+
+	c, ok := stg.(Closable)
+	if !ok {
+		return
+	}
+
+	err := c.Close()
+	if err != nil && l != nil {
+		l.Warning("close %s storage: %v", stg.Type(), err)
+	}
+}
+
 // ParseType parses string and returns storage type
 func ParseType(s string) Type {
 	switch s {

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -178,12 +178,16 @@ func (c *Client) getBackupHelper(
 func (c *Client) fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata) error {
 	var err error
 	var stg storage.Storage
+	l := log.LogEventFromContext(ctx)
+	defer func() {
+		storage.Close(stg, l)
+	}()
 
 	eg, _ := errgroup.WithContext(ctx)
 	eg.SetLimit(runtime.NumCPU())
 
 	if version.HasFilelistFile(bcp.PBMVersion) {
-		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
+		stg, err = util.StorageFromConfig(&bcp.Store.StorageConf, c.node, l)
 		if err != nil {
 			return errors.Wrap(err, "get storage")
 		}

--- a/sdk/impl.go
+++ b/sdk/impl.go
@@ -242,12 +242,14 @@ func (c *Client) fillFilelistForBackup(ctx context.Context, bcp *BackupMetadata)
 }
 
 func (c *Client) getStorageForRead(ctx context.Context, bcp *backup.BackupMeta) (storage.Storage, error) {
-	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, c.node, log.LogEventFromContext(ctx))
+	l := log.LogEventFromContext(ctx)
+	stg, err := util.StorageFromConfig(&bcp.Store.StorageConf, c.node, l)
 	if err != nil {
 		return nil, errors.Wrap(err, "get storage")
 	}
 	err = storage.HasReadAccess(ctx, stg)
 	if err != nil && !errors.Is(err, storage.ErrUninitialized) {
+		storage.Close(stg, l)
 		return nil, errors.Wrap(err, "check storage access")
 	}
 


### PR DESCRIPTION
```yaml
storage:
  type: gcs
  gcs:
    bucket: pbm-jakub
    prefix: pbm
    maxObjSizeGB: 1
    credentials:
      clientEmail: "pbm-jakub@dev-sandbox-348314.iam.gserviceaccount.com"
      privateKey: "..."
      clientType: grpc # json | grpc 
      parallelUploadConcurrency: 4 # number of concurrent parts, enabled requires > 1
 ```
 
 Status will remain experimental due to ongoing work in GCS. 
 At least these need to be released:
 - https://github.com/googleapis/google-cloud-go/pull/14704
 - https://github.com/googleapis/google-cloud-go/pull/19930