### PR TITLE
PBM-1771: Support MongoDB 8.3 time-series archive namespaces

### DIFF
--- a/pbm/archive/archive.go
+++ b/pbm/archive/archive.go
@@ -56,6 +56,10 @@ func Compose(w io.Writer, newReader NewReader, nsFilter NSFilterFn, concurrency 
 	if err != nil {
 		return errors.Wrap(err, "metadata")
 	}
+	sourceVersion, err := db.StrToVersion(meta.Header.ServerVersion)
+	if err != nil {
+		return errors.Wrap(err, "parse source server version")
+	}
 
 	if concurrency > 0 {
 		// mongorestore uses this field as a number of
@@ -78,7 +82,8 @@ func Compose(w io.Writer, newReader NewReader, nsFilter NSFilterFn, concurrency 
 
 	err = writeAllNamespaces(w, newReader,
 		int(meta.Header.ConcurrentCollections),
-		meta.Namespaces)
+		meta.Namespaces,
+		sourceVersion)
 	return errors.Wrap(err, "write namespaces")
 }
 
@@ -93,7 +98,13 @@ func writePrelude(w io.Writer, m *archiveMeta) error {
 	return errors.Wrap(err, "write")
 }
 
-func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namespace) error {
+func writeAllNamespaces(
+	w io.Writer,
+	newReader NewReader,
+	lim int,
+	nss []*Namespace,
+	sourceVersion db.Version,
+) error {
 	mu := sync.Mutex{}
 	eg := errgroup.Group{}
 	eg.SetLimit(lim)
@@ -106,7 +117,7 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 				mu.Lock()
 				defer mu.Unlock()
 
-				return errors.Wrap(closeChunk(w, ns), "close empty chunk")
+				return errors.Wrap(closeChunk(w, ns, sourceVersion), "close empty chunk")
 			}
 
 			nss := NSify(ns.Database, ns.Collection)
@@ -120,7 +131,7 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 				mu.Lock()
 				defer mu.Unlock()
 
-				return errors.Wrap(writeChunk(w, ns, b), "write chunk")
+				return errors.Wrap(writeChunk(w, ns, b, sourceVersion), "write chunk")
 			})
 			if err != nil {
 				return errors.Wrap(err, "split")
@@ -129,7 +140,7 @@ func writeAllNamespaces(w io.Writer, newReader NewReader, lim int, nss []*Namesp
 			mu.Lock()
 			defer mu.Unlock()
 
-			return errors.Wrap(closeChunk(w, ns), "close chunk")
+			return errors.Wrap(closeChunk(w, ns, sourceVersion), "close chunk")
 		})
 	}
 
@@ -193,13 +204,18 @@ func ReadBSONBuffer(r io.Reader, buf []byte) ([]byte, error) {
 	return buf[:size], nil
 }
 
-func writeChunk(w io.Writer, ns *Namespace, data []byte) error {
+func archiveDataCollection(ns *Namespace, sourceVersion db.Version) string {
+	if ns.Type == "timeseries" && !sourceVersion.SupportsRawData() {
+		return "system.buckets." + ns.Collection
+	}
+
+	return ns.Collection
+}
+
+func writeChunk(w io.Writer, ns *Namespace, data []byte, sourceVersion db.Version) error {
 	nsHeader := archive.NamespaceHeader{
 		Database:   ns.Database,
-		Collection: ns.Collection,
-	}
-	if ns.Type == "timeseries" {
-		nsHeader.Collection = "system.buckets." + nsHeader.Collection
+		Collection: archiveDataCollection(ns, sourceVersion),
 	}
 
 	header, err := bson.Marshal(nsHeader)
@@ -219,15 +235,12 @@ func writeChunk(w io.Writer, ns *Namespace, data []byte) error {
 	return errors.Wrap(err, "terminator")
 }
 
-func closeChunk(w io.Writer, ns *Namespace) error {
+func closeChunk(w io.Writer, ns *Namespace, sourceVersion db.Version) error {
 	nsHeader := archive.NamespaceHeader{
 		Database:   ns.Database,
-		Collection: ns.Collection,
+		Collection: archiveDataCollection(ns, sourceVersion),
 		EOF:        true,
 		CRC:        uint64(ns.CRC), //nolint:gosec
-	}
-	if ns.Type == "timeseries" {
-		nsHeader.Collection = "system.buckets." + nsHeader.Collection
 	}
 
 	header, err := bson.Marshal(nsHeader)

--- a/pbm/archive/archive_test.go
+++ b/pbm/archive/archive_test.go
@@ -1,0 +1,156 @@
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	mtarchive "github.com/mongodb/mongo-tools/common/archive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestComposeNamespaceHeaders(t *testing.T) {
+	doc, err := bson.Marshal(bson.D{
+		{"_id", 1},
+		{"data", bson.Binary{Subtype: bson.TypeBinaryColumn, Data: []byte("compressed column")}},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		serverVersion  string
+		collectionType string
+		body           []byte
+		wantCollection string
+	}{
+		{
+			name:           "MongoDB 8.0 time series",
+			serverVersion:  "8.0.0",
+			collectionType: "timeseries",
+			body:           doc,
+			wantCollection: "system.buckets.ts",
+		},
+		{
+			name:           "MongoDB 8.2 time series",
+			serverVersion:  "8.2.0",
+			collectionType: "timeseries",
+			body:           doc,
+			wantCollection: "system.buckets.ts",
+		},
+		{
+			name:           "MongoDB 8.3 time series",
+			serverVersion:  "8.3.0",
+			collectionType: "timeseries",
+			body:           doc,
+			wantCollection: "ts",
+		},
+		{
+			name:           "MongoDB 8.3 empty time series",
+			serverVersion:  "8.3.0",
+			collectionType: "timeseries",
+			wantCollection: "ts",
+		},
+		{
+			name:           "regular collection",
+			serverVersion:  "8.3.0",
+			collectionType: "collection",
+			body:           doc,
+			wantCollection: "ts",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meta := &archiveMeta{
+				Header: &mtarchive.Header{
+					ConcurrentCollections: 1,
+					FormatVersion:         "0.1",
+					ServerVersion:         test.serverVersion,
+					ToolVersion:           "test",
+				},
+				Namespaces: []*Namespace{{
+					CollectionMetadata: &mtarchive.CollectionMetadata{
+						Database:   "test",
+						Collection: "ts",
+						Size:       len(test.body),
+						Type:       test.collectionType,
+					},
+					CRC:  42,
+					Size: int64(len(test.body)),
+				}},
+			}
+
+			metadata, err := bson.MarshalExtJSON(meta, true, true)
+			require.NoError(t, err)
+
+			files := map[string][]byte{MetaFile: metadata}
+			if len(test.body) != 0 {
+				files["test.ts"] = test.body
+			}
+			newReader := func(name string) (io.ReadCloser, error) {
+				data, ok := files[name]
+				if !ok {
+					return nil, fmt.Errorf("file %q not found", name)
+				}
+				return io.NopCloser(bytes.NewReader(data)), nil
+			}
+
+			var buf bytes.Buffer
+			require.NoError(t, Compose(&buf, newReader, DefaultNSFilter, 1))
+
+			reader := bytes.NewReader(buf.Bytes())
+			prelude := &mtarchive.Prelude{}
+			require.NoError(t, prelude.Read(reader))
+			assert.Equal(t, test.serverVersion, prelude.Header.ServerVersion)
+
+			collector := &namespaceCollector{}
+			parser := mtarchive.Parser{In: reader}
+			require.NoError(t, parser.ReadAllBlocks(collector))
+
+			wantHeaders := 2
+			if len(test.body) == 0 {
+				wantHeaders = 1
+			}
+			require.Len(t, collector.headers, wantHeaders)
+			for i, header := range collector.headers {
+				assert.Equal(t, "test", header.Database, "header %d database", i)
+				assert.Equal(t, test.wantCollection, header.Collection, "header %d collection", i)
+				wantEOF := i == wantHeaders-1
+				assert.Equal(t, wantEOF, header.EOF, "header %d EOF", i)
+			}
+
+			if len(test.body) == 0 {
+				assert.Empty(t, collector.bodies)
+				return
+			}
+			require.Len(t, collector.bodies, 1)
+			assert.Equal(t, test.body, collector.bodies[0])
+		})
+	}
+}
+
+type namespaceCollector struct {
+	headers []mtarchive.NamespaceHeader
+	bodies  [][]byte
+}
+
+func (c *namespaceCollector) HeaderBSON(data []byte) error {
+	header := mtarchive.NamespaceHeader{}
+	if err := bson.Unmarshal(data, &header); err != nil {
+		return err
+	}
+	c.headers = append(c.headers, header)
+	return nil
+}
+
+func (c *namespaceCollector) BodyBSON(data []byte) error {
+	c.bodies = append(c.bodies, bytes.Clone(data))
+	return nil
+}
+
+func (*namespaceCollector) End() error {
+	return nil
+}


### PR DESCRIPTION
Ticket: https://perconadev.atlassian.net/browse/PBM-1771

MongoDB 8.3 introduced the rawData API for time-series collections, which accesses raw bucket data through the logical collection namespace instead of system.buckets.<collection>.

The fix parses the source MongoDB version from the backup metadata and uses the existing mongo-tools SupportsRawData() check when composing archive headers:

- Pre-8.3 TS collections use system.buckets.<collection>.
- 8.3+ TS collections use the logical collection name.
- Other collection types remain unchanged.
