### PR TITLE
PBM-1779: TTL + unique index can break physical PITR restore

### DIFF
--- a/pbm/restore/physical.go
+++ b/pbm/restore/physical.go
@@ -2458,6 +2458,9 @@ func tryConn(port int, logpath string) (*mongo.Client, error) {
 }
 
 func (r *PhysRestore) startMongo(opts ...string) error {
+	// PBM-1779: disable TTL Monitor during restore (all mongod restarts)
+	opts = append(opts, []string{"--setParameter", "ttlMonitorEnabled=false"}...)
+
 	if r.tmpConf != nil {
 		opts = append(opts, []string{"-f", r.tmpConf.Name()}...)
 	}


### PR DESCRIPTION
PR for https://perconadev.atlassian.net/browse/PBM-1779

During a physical restore, PBM starts a temporary standalone `mongod` several times. The [bug](https://perconadev.atlassian.net/browse/PBM-1779) describes a possible error that can happen when PITR replay entries and _TTL Monitor_ delete activities, run at the same time.

The new PBM’s strategy is to disable _TTL monitor_ for the whole duration of the physical restore for the following main reasons:
* A combination of TTL index configurations and workload captured with PITR chunks, can cause errors during the PITR restore phase, as described in the bug.
* _TTL Monitor_ deletion activities are captured within PITR chunks and applied during physical restore with PITR, so it’s preferable not to have duplicate deletion activities on the same documents caused by enabled _TTL Monitor_.
* Physical restore is applied independently on every node in the cluster, and enabled _TTL Monitor_ can introduce deltas between replica set members, as well as inconsistent data between shards. 
* _TTL Monitor_ will be enabled by default on the first start after restore, and it’ll process all leftovers through regular behavior, which is a clean and straightforward solution.

PR’s implementation disables _TTL Monitor_ by running `mongod` with the option: `--setParameter ttlMonitorEnabled=false` during physical restore.